### PR TITLE
feat: add responsive interactive font finder

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,11 @@
 <div align="center">
 
 ```text
-文字  moji
+   ∧＿∧
+  （ ´∀｀）  文字  moji
+  （       ）
+   |  |  |
+  （_＿）＿）
 ```
 
 <h1>moji</h1>
@@ -38,11 +42,14 @@ bun add --global @microck/moji
 search for a family:
 
 ```bash
+moji
+# or jump straight to results
 moji "Inter"
 ```
 
-when stdin and stdout are terminals, `moji` opens the interactive result list.
-redirect or pipe the command to get a stable table instead.
+bare `moji` opens the home TUI so you can type a query. pass a query to jump
+straight to the live result list. redirect or pipe a queried command to get a
+stable table instead.
 
 ```bash
 moji "Inter" --format otf,ttf
@@ -78,6 +85,7 @@ and an instance URL are configured.
 
 | command | purpose |
 | --- | --- |
+| `moji` | open the home TUI and type a font query |
 | `moji <query>` | search interactively or print a table when piped |
 | `moji get <query>` | rank results and download the best match |
 | `moji config` | create the default config when needed and open `$EDITOR` |

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -33,6 +33,12 @@ for Linux, macOS, and Windows on x64 and arm64.
 Run a search in a terminal to open the live interface:
 
 ```sh
+moji
+```
+
+Type a family and press `enter`, or jump directly to results:
+
+```sh
 moji "Inter"
 ```
 

--- a/docs/content/docs/reference/cli.mdx
+++ b/docs/content/docs/reference/cli.mdx
@@ -6,6 +6,7 @@ description: Commands, flags, output modes, and defaults.
 ## Command grammar
 
 ```text
+moji
 moji <query> [flags]
 moji get <query> [flags]
 moji config [show]
@@ -13,6 +14,12 @@ moji cache clear
 moji --version
 moji --help
 ```
+
+### `moji`
+
+When stdin and stdout are terminals, open the home TUI and wait for a font
+query. In a non-interactive process, print an actionable usage error instead of
+waiting for input.
 
 ### `moji <query>`
 
@@ -43,7 +50,7 @@ Delete cached provider responses and recreate the cache directory.
 | --- | --- | --- | --- |
 | `--format <list>` | `-f` | config default | Comma-separated `otf`, `ttf`, `woff`, or `woff2` |
 | `--weight <name>` | `-w` | any | Keep only a normalized font weight |
-| `--max <count>` | `-n` | 10 search / 1 get | Maximum visible results or downloads |
+| `--max <count>` | `-n` | all in TUI / 10 output / 1 get | Maximum results or downloads |
 | `--provider <list>` | | all enabled | Comma-separated `github`, `getfonts`, or configured `websearch` |
 | `--json` | | off | Print machine-readable JSON |
 | `--dry-run` | | off | Preview a `get` selection without downloading |
@@ -63,9 +70,13 @@ argument or `--flag=value`.
 
 | Key | Action |
 | --- | --- |
+| typed text | Enter a query on the home screen |
+| `enter` | Start the home-screen search or open result details |
 | `up` / `k` | Select previous result |
 | `down` / `j` | Select next result |
-| `enter` | Open result details |
+| `page up` / `page down` | Move by one visible page |
+| `home` / `g` | Select the first result |
+| `end` / `G` | Select the last result |
 | `D` | Download selected result |
 | `/` | Filter loaded results |
 | `f` | Cycle all, OTF, TTF, and WOFF2 |

--- a/docs/content/docs/tutorial.mdx
+++ b/docs/content/docs/tutorial.mdx
@@ -39,7 +39,14 @@ The command prints `0.1.0`.
 
 ## 2. Search interactively
 
-Search for the Inter family:
+Open the home screen:
+
+```sh
+moji
+```
+
+Type `Inter` and press `enter`. You can also jump directly to the same live
+results:
 
 ```sh
 moji "Inter"

--- a/docs/src/app/(home)/page.tsx
+++ b/docs/src/app/(home)/page.tsx
@@ -25,6 +25,11 @@ export default function HomePage() {
             <span className="h-3 w-3 rounded-full bg-amber-400" />
             <span className="h-3 w-3 rounded-full bg-green-400" />
           </div>
+          <pre aria-label="Mona, Moji's mascot" className="mb-5 text-orange-400">{`   ∧＿∧
+  （ ´∀｀）  文字  moji
+  （       ）
+   |  |  |
+  （_＿）＿）`}</pre>
           <p className="text-zinc-500">$ npm install --global @microck/moji</p>
           <p className="mt-4 text-zinc-500">$ moji get &quot;Inter bold&quot; --dry-run</p>
           <p className="mt-4 text-orange-400">Would download:</p>

--- a/docs/src/lib/layout.shared.tsx
+++ b/docs/src/lib/layout.shared.tsx
@@ -2,5 +2,14 @@ import type { BaseLayoutProps } from 'fumadocs-ui/layouts/shared';
 import { appName } from './shared';
 
 export function baseOptions(): BaseLayoutProps {
-  return { nav: { title: appName } };
+  return {
+    nav: {
+      title: (
+        <span className="inline-flex items-center gap-2">
+          <span aria-label="Mona, Moji's mascot" className="font-mono text-orange-500">（ ´∀｀）</span>
+          {appName}
+        </span>
+      ),
+    },
+  };
 }

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -35,11 +35,21 @@ func TestMojiBinaryEndToEnd(t *testing.T) {
 
 	font := append([]byte("OTTO"), make([]byte, 64)...)
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if strings.HasPrefix(request.URL.Path, "/font-") {
+			response.Write(font)
+			return
+		}
 		switch request.URL.Path {
 		case "/api/search":
-			fmt.Fprintf(response, "{\"items\":[{\"name\":\"MojiFixture-Regular.otf\",\"html_url\":%q,\"repository\":{\"full_name\":\"fixture/fonts\"}}]}", "http://"+request.Host+"/font.otf")
-		case "/font.otf":
-			response.Write(font)
+			items := make([]string, 12)
+			for index := range items {
+				name := fmt.Sprintf("MojiFixture-%02d-Regular.otf", index)
+				if index == 0 {
+					name = "MojiFixture-Regular.otf"
+				}
+				items[index] = fmt.Sprintf("{\"name\":%q,\"html_url\":%q,\"repository\":{\"full_name\":\"fixture/fonts\"}}", name, fmt.Sprintf("http://%s/font-%02d.otf", request.Host, index))
+			}
+			fmt.Fprintf(response, "{\"items\":[%s]}", strings.Join(items, ","))
 		default:
 			http.NotFound(response, request)
 		}
@@ -63,42 +73,17 @@ func TestMojiBinaryEndToEnd(t *testing.T) {
 	if !bytes.Contains(searchOutput, []byte("MojiFixture-Regular.otf")) {
 		t.Fatalf("unexpected search output: %s", searchOutput)
 	}
+	if count := bytes.Count(searchOutput, []byte(`"filename"`)); count != 10 {
+		t.Fatalf("non-interactive default returned %d results, want 10: %s", count, searchOutput)
+	}
 
-	interactiveContext, cancelInteractive := context.WithTimeout(context.Background(), 10*time.Second)
-	defer cancelInteractive()
-	interactive := exec.CommandContext(interactiveContext, binary, "MojiFixture", "--no-cache")
-	interactive.Env = append(environment, "TERM=xterm-256color")
-	terminal, err := pty.Start(interactive)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if err := terminal.SetReadDeadline(time.Now().Add(10 * time.Second)); err != nil {
-		t.Fatal(err)
-	}
-	interactiveOutput := make([]byte, 0, 4096)
-	readBuffer := make([]byte, 4096)
-	for !bytes.Contains(interactiveOutput, []byte("MojiFixture-Regular.otf")) {
-		read, readErr := terminal.Read(readBuffer)
-		interactiveOutput = append(interactiveOutput, readBuffer[:read]...)
-		if readErr != nil {
-			t.Fatalf("TUI did not become ready: %v\n%s", readErr, interactiveOutput)
-		}
-	}
-	if _, err := terminal.Write([]byte("q")); err != nil {
-		t.Fatal(err)
-	}
-	remainder, readErr := io.ReadAll(terminal)
-	interactiveOutput = append(interactiveOutput, remainder...)
-	terminal.Close()
-	waitErr := interactive.Wait()
-	if readErr != nil && !strings.Contains(readErr.Error(), "input/output error") {
-		t.Fatalf("read TUI: %v", readErr)
-	}
-	if waitErr != nil {
-		t.Fatalf("TUI exit: %v\n%s", waitErr, interactiveOutput)
-	}
-	if !bytes.Contains(interactiveOutput, []byte("Found 1 results")) || !bytes.Contains(interactiveOutput, []byte("MojiFixture-Regular.otf")) {
+	interactiveOutput := runTUI(t, binary, []string{"MojiFixture", "--no-cache"}, environment, nil, "MojiFixture-Regular.otf")
+	if !bytes.Contains(interactiveOutput, []byte("Found 12 results")) || !bytes.Contains(interactiveOutput, []byte("MojiFixture-Regular.otf")) {
 		t.Fatalf("TUI did not render fixture result: %q", interactiveOutput)
+	}
+	homeOutput := runTUI(t, binary, nil, environment, []byte("MojiFixture\r"), "MojiFixture-Regular.otf")
+	if !bytes.Contains(homeOutput, []byte("Type a font name")) || !bytes.Contains(homeOutput, []byte("Found 12 results")) {
+		t.Fatalf("home TUI did not transition to results: %q", homeOutput)
 	}
 
 	get := exec.Command(binary, "get", "MojiFixture regular", "--allow-insecure", "--no-cache")
@@ -120,4 +105,52 @@ func TestMojiBinaryEndToEnd(t *testing.T) {
 	if output, err := cacheClear.CombinedOutput(); err != nil || !bytes.Contains(output, []byte("Cleared cache:")) {
 		t.Fatalf("cache clear: %v\n%s", err, output)
 	}
+}
+
+func runTUI(t *testing.T, binary string, args []string, environment []string, input []byte, readyText string) []byte {
+	t.Helper()
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+	command := exec.CommandContext(ctx, binary, args...)
+	command.Env = append(environment, "TERM=xterm-256color")
+	terminal, err := pty.Start(command)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer terminal.Close()
+	output := make([]byte, 0, 4096)
+	buffer := make([]byte, 4096)
+	readUntil := func(text string) {
+		// Give each sequential phase its own budget. A slow home render should not
+		// consume the time reserved for the provider round-trip and results view.
+		if err := terminal.SetReadDeadline(time.Now().Add(20 * time.Second)); err != nil {
+			t.Fatal(err)
+		}
+		for !bytes.Contains(output, []byte(text)) {
+			read, readErr := terminal.Read(buffer)
+			output = append(output, buffer[:read]...)
+			if readErr != nil {
+				t.Fatalf("TUI did not become ready: %v\n%s", readErr, output)
+			}
+		}
+	}
+	if len(input) > 0 {
+		readUntil("Type a font name")
+		if _, err := terminal.Write(input); err != nil {
+			t.Fatal(err)
+		}
+	}
+	readUntil(readyText)
+	if _, err := terminal.Write([]byte("q")); err != nil {
+		t.Fatal(err)
+	}
+	remainder, readErr := io.ReadAll(terminal)
+	output = append(output, remainder...)
+	if readErr != nil && !strings.Contains(readErr.Error(), "input/output error") {
+		t.Fatalf("read TUI: %v", readErr)
+	}
+	if err := command.Wait(); err != nil {
+		t.Fatalf("TUI exit: %v\n%s", err, output)
+	}
+	return output
 }

--- a/go.mod
+++ b/go.mod
@@ -1,18 +1,19 @@
 module github.com/microck/moji
 
-go 1.24.0
+go 1.25.0
 
 require (
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
+	github.com/charmbracelet/x/ansi v0.10.1
 	github.com/creack/pty v1.1.24
+	golang.org/x/term v0.45.0
 	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
-	github.com/charmbracelet/x/ansi v0.10.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
@@ -25,6 +26,6 @@ require (
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/sys v0.36.0 // indirect
+	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.3.8 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -39,8 +39,10 @@ golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561 h1:MDc5xs78ZrZr3HMQugiXOAkSZ
 golang.org/x/exp v0.0.0-20220909182711-5c715a9e8561/go.mod h1:cyybsKvd6eL0RnXn6p/Grxp8F5bW7iYuBgsNCOHpMYE=
 golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.36.0 h1:KVRy2GtZBrk1cBYA7MKu5bEZFxQk4NIDV6RLVcC8o0k=
-golang.org/x/sys v0.36.0/go.mod h1:OgkHotnGiDImocRcuBABYBEXf8A9a87e/uXjp9XT3ks=
+golang.org/x/sys v0.47.0 h1:o7XGOvZQCADBQQ4Y7VNq2dRWQR7JmOUW8Kxx4ZsNgWs=
+golang.org/x/sys v0.47.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+golang.org/x/term v0.45.0 h1:NwWyBmoJCbfTHpxrWoZ9C6/VxOf7ic219I8xZZFdrf0=
+golang.org/x/term v0.45.0/go.mod h1:9aqxs0blBcrm/n0L9QW0aRVD+ktan8ssZromtqJC43w=
 golang.org/x/text v0.3.8 h1:nAL+RVCQ9uMn3vJZbV+MRnydTJFPf8qqY42YiA6MrqY=
 golang.org/x/text v0.3.8/go.mod h1:E6s5w1FMmriuDzIBO73fBruAKo1PCIq6d2Q6DHfQ8WQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/microck/moji/internal/config"
 	"github.com/microck/moji/internal/rank"
+	"golang.org/x/term"
 )
 
 var Version = "0.1.0"
@@ -30,13 +31,16 @@ type options struct {
 
 func (application App) Run(ctx context.Context, args []string) int {
 	application.setDefaults()
-	if len(args) == 0 || containsHelp(args) {
+	if containsHelp(args) {
 		fmt.Fprint(application.Stdout, helpText)
 		return 0
 	}
-	if args[0] == "--version" {
+	if len(args) > 0 && args[0] == "--version" {
 		fmt.Fprintln(application.Stdout, Version)
 		return 0
+	}
+	if len(args) == 0 && (!isTerminal(application.Stdin) || !isTerminal(application.Stdout)) {
+		return application.fail(errors.New("font query is required in non-interactive mode; example: moji \"Inter\""), 2)
 	}
 	configPath, err := config.Path()
 	if err != nil {
@@ -45,6 +49,9 @@ func (application App) Run(ctx context.Context, args []string) int {
 	current, err := config.Load(configPath)
 	if err != nil {
 		return application.fail(err, 1)
+	}
+	if len(args) == 0 {
+		return application.runHome(ctx, current, current.DefaultFormats, options{downloadDir: current.DownloadDir})
 	}
 	if args[0] == "config" {
 		return application.runConfig(current, configPath, args[1:])
@@ -101,14 +108,15 @@ func (application App) Run(ctx context.Context, args []string) int {
 	if parsed.downloadDir == "" {
 		parsed.downloadDir = current.DownloadDir
 	}
+	interactive := !getMode && !parsed.json && isTerminal(application.Stdin) && isTerminal(application.Stdout)
 	if parsed.max == 0 {
 		if getMode {
 			parsed.max = intent.Max
-		} else {
+		} else if !interactive {
 			parsed.max = 10
 		}
 	}
-	if !getMode && !parsed.json && isTerminal(application.Stdin) && isTerminal(application.Stdout) {
+	if interactive {
 		return application.runInteractive(ctx, current, query, formats, parsed)
 	}
 	results, failures, err := application.search(ctx, current, query, formats, parsed)
@@ -154,8 +162,7 @@ func isTerminal(stream any) bool {
 	if !ok {
 		return false
 	}
-	info, err := file.Stat()
-	return err == nil && info.Mode()&os.ModeCharDevice != 0
+	return term.IsTerminal(int(file.Fd()))
 }
 
 func colorEnabled() bool {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -72,6 +72,15 @@ func TestRunRejectsUnsupportedProviderAndBadUsage(t *testing.T) {
 	}
 }
 
+func TestHelpUsesPlainProductDescription(t *testing.T) {
+	t.Parallel()
+	var stdout bytes.Buffer
+	code := (App{Stdout: &stdout, Stderr: &bytes.Buffer{}}).Run(context.Background(), []string{"--help"})
+	if code != 0 || !strings.Contains(stdout.String(), "a terminal font finder") || strings.Contains(stdout.String(), "cozy") {
+		t.Fatalf("code=%d help=%q", code, stdout.String())
+	}
+}
+
 func TestConfigShowRedactsToken(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, "config.yaml")
@@ -95,6 +104,41 @@ func TestMissingQueryExplainsHowToRecover(t *testing.T) {
 	code := (App{Stdout: &bytes.Buffer{}, Stderr: &stderr}).Run(context.Background(), []string{"get"})
 	if code != 2 || !strings.Contains(stderr.String(), "example: moji \"Inter\"") {
 		t.Fatalf("code=%d error=%q", code, stderr.String())
+	}
+}
+
+func TestBareCommandRequiresInteractiveTerminal(t *testing.T) {
+	t.Setenv("MOJI_CONFIG", filepath.Join(t.TempDir(), "missing.yaml"))
+	var stdout, stderr bytes.Buffer
+	code := (App{Stdout: &stdout, Stderr: &stderr}).Run(context.Background(), nil)
+	if code != 2 || !strings.Contains(stderr.String(), "font query is required") || stdout.Len() != 0 {
+		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+}
+
+func TestIsTerminalRejectsNonTTYCharacterDevice(t *testing.T) {
+	device, err := os.OpenFile(os.DevNull, os.O_RDWR, 0)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer device.Close()
+
+	if isTerminal(device) {
+		t.Fatal("/dev/null must not be treated as an interactive terminal")
+	}
+}
+
+func TestBareNonInteractiveUsageDoesNotDependOnValidConfig(t *testing.T) {
+	root := t.TempDir()
+	path := filepath.Join(root, "config.yaml")
+	if err := os.WriteFile(path, []byte("not: [valid"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("MOJI_CONFIG", path)
+	var stderr bytes.Buffer
+	code := (App{Stdout: &bytes.Buffer{}, Stderr: &stderr}).Run(context.Background(), nil)
+	if code != 2 || !strings.Contains(stderr.String(), "font query is required") || strings.Contains(stderr.String(), "parse config") {
+		t.Fatalf("code=%d stderr=%q", code, stderr.String())
 	}
 }
 

--- a/internal/app/output.go
+++ b/internal/app/output.go
@@ -80,9 +80,10 @@ func redact(message string) string {
 	return message
 }
 
-var helpText = `文字  moji - a cozy terminal font finder
+var helpText = `文字  moji - a terminal font finder
 
 Usage:
+  moji                                 Open the interactive font finder
   moji <query> [flags]                 Search and print ranked results
   moji get <query> [flags]             Download the best matching font
   moji config [show]                   Edit or display configuration
@@ -90,6 +91,7 @@ Usage:
   moji --version
 
 Examples:
+  moji
   moji "Inter"
   moji "Inter" --format otf,ttf --json
   moji get "Inter bold" --dry-run

--- a/internal/app/search.go
+++ b/internal/app/search.go
@@ -87,15 +87,30 @@ func (application App) runInteractive(ctx context.Context, current config.Config
 	if err != nil {
 		return application.fail(err, 1)
 	}
-	downloader := download.Downloader{Client: application.Client, AllowInsecure: parsed.allowInsecure}
-	model := tui.NewLiveModel(events, func(result provider.Result) (string, error) {
-		file, err := downloader.Download(ctx, result, expandHome(parsed.downloadDir))
-		return file.Path, err
-	}, colorEnabled(), strings.ToLower(parsed.weight), current.Ranking, parsed.max)
+	model := tui.NewLiveModel(events, application.interactiveDownloader(ctx, parsed), colorEnabled(), strings.ToLower(parsed.weight), current.Ranking, parsed.max)
 	if err := tui.Run(application.Stdin, application.Stdout, model); err != nil {
 		return application.fail(fmt.Errorf("interactive interface: %w", err), 1)
 	}
 	return 0
+}
+
+func (application App) runHome(ctx context.Context, current config.Config, formats []string, parsed options) int {
+	model := tui.NewHomeModel(func(query string) (<-chan provider.Event, error) {
+		events, _, err := application.searchEvents(ctx, current, query, formats, parsed)
+		return events, err
+	}, application.interactiveDownloader(ctx, parsed), colorEnabled(), "", current.Ranking, parsed.max)
+	if err := tui.Run(application.Stdin, application.Stdout, model); err != nil {
+		return application.fail(fmt.Errorf("interactive interface: %w", err), 1)
+	}
+	return 0
+}
+
+func (application App) interactiveDownloader(ctx context.Context, parsed options) tui.DownloadFunc {
+	downloader := download.Downloader{Client: application.Client, AllowInsecure: parsed.allowInsecure}
+	return func(result provider.Result) (string, error) {
+		file, err := downloader.Download(ctx, result, expandHome(parsed.downloadDir))
+		return file.Path, err
+	}
 }
 
 func selectProviders(available map[string]provider.Provider, current config.Config, requested string) ([]provider.Provider, error) {

--- a/internal/tui/home.go
+++ b/internal/tui/home.go
@@ -1,0 +1,155 @@
+package tui
+
+import (
+	"strings"
+	"unicode"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/microck/moji/internal/provider"
+	"github.com/microck/moji/internal/rank"
+)
+
+type SearchFunc func(query string) (<-chan provider.Event, error)
+
+var fullMona = []string{
+	"（　・∀・）",
+}
+
+var mojiWordmark = []string{
+	"█▀▄▀█ █▀█   █ █",
+	"█ ▀ █ █▄█ █▄█ █",
+}
+
+func NewHomeModel(search SearchFunc, downloader DownloadFunc, color bool, wantedWeight string, ranking rank.Weights, maximum int) Model {
+	model := NewModel(nil, downloader, color)
+	model.home = true
+	model.search = search
+	model.wantedWeight = wantedWeight
+	model.ranking = ranking
+	model.maximum = maximum
+	return model
+}
+
+func (model Model) updateHome(message tea.Msg) (tea.Model, tea.Cmd) {
+	key, ok := message.(tea.KeyMsg)
+	if !ok {
+		return model, nil
+	}
+	switch key.String() {
+	case "ctrl+c", "esc":
+		return model, tea.Quit
+	case "enter":
+		query := strings.TrimSpace(model.query)
+		if query == "" {
+			model.status = "Type a font name before searching."
+			return model, nil
+		}
+		if model.search == nil {
+			model.status = "Search is unavailable. Exit and try again."
+			return model, nil
+		}
+		events, err := model.search(query)
+		if err != nil {
+			model.status = "Search couldn't start: " + err.Error()
+			return model, nil
+		}
+		model.home = false
+		model.loading = true
+		model.events = events
+		model.status = ""
+		model.all = nil
+		model.visible = nil
+		model.cursor = 0
+		model.providerStatus = make(map[string]string)
+		return model, model.waitForEvent()
+	case "backspace":
+		runes := []rune(model.query)
+		if len(runes) > 0 {
+			model.query = string(runes[:len(runes)-1])
+		}
+	default:
+		if len(key.Runes) > 0 {
+			// Terminals deliver bracketed paste as one key event, including any
+			// copied line breaks. Collapse whitespace so the one-line input cannot
+			// spill through its border.
+			model.query += strings.Map(func(character rune) rune {
+				if unicode.IsSpace(character) {
+					return ' '
+				}
+				if unicode.IsControl(character) {
+					return -1
+				}
+				return character
+			}, string(key.Runes))
+			model.status = ""
+		}
+	}
+	return model, nil
+}
+
+func (model Model) viewHome() string {
+	contentWidth := model.contentWidth()
+	inputWidth := min(64, contentWidth)
+	body := make([]string, 0, 16)
+	if model.termHeight() >= 14 {
+		body = append(body, model.renderMonaBlock(fullMona)...)
+		body = append(body, "")
+	}
+	if model.termHeight() >= 10 {
+		body = append(body,
+			model.accent.Bold(true).Render(mojiWordmark[0]),
+			model.brand.Render(mojiWordmark[1]),
+			"",
+		)
+	} else {
+		body = append(body, model.brand.Render("文字  moji"))
+	}
+	input := "> " + model.query + "_"
+	body = append(body, model.accent.Render("┌"+strings.Repeat("─", max(0, inputWidth-2))+"┐"))
+	if inputWidth >= 2 {
+		body = append(body, model.accent.Render("│")+padRight(truncate(input, inputWidth-2), inputWidth-2)+model.accent.Render("│"))
+	} else {
+		body = append(body, truncate(input, inputWidth))
+	}
+	body = append(body, model.accent.Render("└"+strings.Repeat("─", max(0, inputWidth-2))+"┘"))
+	if model.termHeight() >= 12 {
+		body = append(body, model.faint.Render("Type a font name, then press Enter."))
+	}
+	if model.status != "" {
+		body = append(body, model.accent.Render(truncate(model.status, contentWidth)))
+	}
+
+	// The home screen is an entry point, not a data view. Keep its small action
+	// block centered while preserving the same pinned footer used elsewhere.
+	mainHeight := max(1, model.termHeight()-2)
+	if len(body) > mainHeight {
+		body = body[len(body)-mainHeight:]
+	}
+	top := max(0, (mainHeight-len(body))/2)
+	lines := make([]string, 0, model.termHeight())
+	lines = append(lines, make([]string, top)...)
+	for _, line := range body {
+		lines = append(lines, model.centerLine(line, contentWidth))
+	}
+	for len(lines) < mainHeight {
+		lines = append(lines, "")
+	}
+	rule := model.centerLine(model.faint.Render(strings.Repeat("─", contentWidth)), contentWidth)
+	help := model.centerLine(model.faint.Render("enter: search  esc: quit"), contentWidth)
+	return strings.Join(append(lines, rule, help), "\n")
+}
+
+func (model Model) renderMonaBlock(lines []string) []string {
+	width := 0
+	for _, line := range lines {
+		width = max(width, lipgloss.Width(line))
+	}
+	rendered := make([]string, len(lines))
+	for index, line := range lines {
+		// Pad before centering so every row shares one coordinate system. Centering
+		// individual rows would erase the indentation that forms Mona's body.
+		rendered[index] = model.faint.Render(padRight(line, width))
+	}
+	return rendered
+}

--- a/internal/tui/results.go
+++ b/internal/tui/results.go
@@ -5,9 +5,11 @@ import (
 	"io"
 	"sort"
 	"strings"
+	"unicode/utf8"
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
+	"github.com/charmbracelet/x/ansi"
 	"github.com/microck/moji/internal/provider"
 	"github.com/microck/moji/internal/rank"
 )
@@ -15,6 +17,9 @@ import (
 type DownloadFunc func(provider.Result) (string, error)
 
 type Model struct {
+	home           bool
+	query          string
+	search         SearchFunc
 	all            []provider.Result
 	visible        []provider.Result
 	cursor         int
@@ -23,6 +28,7 @@ type Model struct {
 	format         string
 	sortMode       int
 	preview        bool
+	detailOffset   int
 	status         string
 	providerStatus map[string]string
 	events         <-chan provider.Event
@@ -34,6 +40,8 @@ type Model struct {
 	brand          lipgloss.Style
 	accent         lipgloss.Style
 	faint          lipgloss.Style
+	width          int
+	height         int
 }
 
 type downloadMessage struct {
@@ -73,6 +81,20 @@ func NewLiveModel(events <-chan provider.Event, downloader DownloadFunc, color b
 func (model Model) Init() tea.Cmd { return model.waitForEvent() }
 
 func (model Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
+	if size, ok := message.(tea.WindowSizeMsg); ok {
+		// Some PTY implementations initially report 0x0. Keep the documented
+		// fallback size until the terminal provides usable dimensions.
+		if size.Width > 0 {
+			model.width = size.Width
+		}
+		if size.Height > 0 {
+			model.height = size.Height
+		}
+		return model, nil
+	}
+	if model.home {
+		return model.updateHome(message)
+	}
 	switch message := message.(type) {
 	case eventMessage:
 		if !message.open {
@@ -116,12 +138,24 @@ func (model Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return model, nil
 		}
+		if model.preview {
+			switch message.String() {
+			case "up", "k":
+				model.detailOffset = max(0, model.detailOffset-1)
+				return model, nil
+			case "down", "j":
+				maximum := max(0, len(model.detailLines(model.visible[model.cursor]))-model.bodyHeight())
+				model.detailOffset = min(maximum, model.detailOffset+1)
+				return model, nil
+			}
+		}
 		switch message.String() {
 		case "ctrl+c", "q":
 			return model, tea.Quit
 		case "esc":
 			if model.preview {
 				model.preview = false
+				model.detailOffset = 0
 				return model, nil
 			}
 			return model, tea.Quit
@@ -133,9 +167,18 @@ func (model Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			if model.cursor+1 < len(model.visible) {
 				model.cursor++
 			}
+		case "pgup":
+			model.cursor = max(0, model.cursor-model.resultPageSize())
+		case "pgdown":
+			model.cursor = min(max(0, len(model.visible)-1), model.cursor+model.resultPageSize())
+		case "g", "home":
+			model.cursor = 0
+		case "G", "end":
+			model.cursor = max(0, len(model.visible)-1)
 		case "enter":
 			if len(model.visible) > 0 {
 				model.preview = true
+				model.detailOffset = 0
 			}
 		case "/":
 			model.filtering = true
@@ -167,57 +210,295 @@ func (model Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (model Model) View() string {
-	var view strings.Builder
-	view.WriteString(model.brand.Render("文字  moji"))
-	view.WriteString("\n\n")
+	if model.home {
+		return model.viewHome()
+	}
 	if model.preview && len(model.visible) > 0 {
 		result := model.visible[model.cursor]
-		fmt.Fprintf(&view, "%s\n\nFormat: %s\nWeight: %s\nSource: %s\nLicense: %s\nURL: %s\n\n",
-			model.accent.Render(result.Filename), strings.ToUpper(result.Format), displayWeight(result.Weight),
-			result.Source, result.License, result.URL)
-		view.WriteString(model.faint.Render("D: download  esc: back  q: quit"))
-		return view.String()
+		lines := model.detailLines(result)
+		maximum := max(0, len(lines)-model.bodyHeight())
+		offset := min(model.detailOffset, maximum)
+		end := min(len(lines), offset+model.bodyHeight())
+		context := "font details"
+		if len(lines) > model.bodyHeight() {
+			context += fmt.Sprintf("  lines %d-%d/%d", offset+1, end, len(lines))
+		}
+		if model.contentWidth() < 48 {
+			context = "details"
+			if len(lines) > model.bodyHeight() {
+				context += fmt.Sprintf(" %d-%d/%d", offset+1, end, len(lines))
+			}
+		}
+		return model.chrome(context, strings.Join(lines[offset:end], "\n"), model.detailHelp())
 	}
+	return model.chrome(model.resultsContext(), model.resultsBody(), model.resultsHelp())
+}
+
+func (model Model) resultsContext() string {
 	verb := "Found"
 	if model.loading {
 		verb = "Finding"
 	}
-	fmt.Fprintf(&view, "%s %d results  [format: %s]  [sort: %s]\n", verb, len(model.visible), model.format, model.sortName())
+	if model.contentWidth() < 48 {
+		if model.loading {
+			return fmt.Sprintf("finding %d", len(model.visible))
+		}
+		return fmt.Sprintf("%d results", len(model.visible))
+	}
+	return fmt.Sprintf("%s %d results  format:%s  sort:%s", verb, len(model.visible), model.format, model.sortName())
+}
+
+func (model Model) resultsBody() string {
+	lines := make([]string, 0, model.bodyHeight())
 	if len(model.providerStatus) > 0 {
 		names := make([]string, 0, len(model.providerStatus))
 		for name := range model.providerStatus {
 			names = append(names, name)
 		}
 		sort.Strings(names)
+		statuses := make([]string, 0, len(names))
 		for _, name := range names {
-			fmt.Fprintf(&view, "  %s: %s\n", name, model.providerStatus[name])
+			statuses = append(statuses, name+": "+model.providerStatus[name])
 		}
+		lines = append(lines, model.faint.Render(truncate(strings.Join(statuses, "  "), model.contentWidth())))
 	}
 	if model.filtering || model.filter != "" {
 		cursor := ""
 		if model.filtering {
 			cursor = "_"
 		}
-		fmt.Fprintf(&view, "Filter: %s%s\n", model.filter, cursor)
+		lines = append(lines, truncate("Filter: "+model.filter+cursor, model.contentWidth()))
 	}
-	view.WriteString("\n")
-	for index, result := range model.visible {
-		prefix := "  "
-		line := fmt.Sprintf("%s  %-6s %-10s %-32s", result.Filename, strings.ToUpper(result.Format), displayWeight(result.Weight), result.Source)
-		if index == model.cursor {
-			prefix = "> "
-			line = model.accent.Render(line)
-		}
-		view.WriteString(prefix + line + "\n")
+	remaining := model.bodyHeight() - len(lines)
+	if model.status != "" {
+		remaining--
 	}
 	if len(model.visible) == 0 {
-		view.WriteString("  No matching results.\n")
+		lines = append(lines, "", "  No matching results.")
+	} else if remaining > 0 {
+		lines = append(lines, model.resultWindow(remaining)...)
 	}
 	if model.status != "" {
-		view.WriteString("\n" + model.status + "\n")
+		lines = append(lines, model.accent.Render(truncate(model.status, model.contentWidth())))
 	}
-	view.WriteString("\n" + model.faint.Render("up/down: browse  enter: details  D: download  /: filter  f: format  tab: sort  q: quit"))
-	return view.String()
+	return strings.Join(lines, "\n")
+}
+
+func (model Model) renderBrand() string {
+	return model.faint.Render("(´∀｀)") + "  " + model.brand.Render("文字  moji")
+}
+
+const maxContentWidth = 112
+
+func (model Model) termWidth() int {
+	if model.width <= 0 {
+		return 100
+	}
+	return model.width
+}
+
+func (model Model) termHeight() int {
+	if model.height <= 0 {
+		return 30
+	}
+	return model.height
+}
+
+func (model Model) contentWidth() int {
+	width := model.termWidth()
+	if width >= 32 {
+		width -= 4
+	}
+	return min(maxContentWidth, max(1, width))
+}
+
+func (model Model) bodyHeight() int { return max(1, model.termHeight()-4) }
+
+func (model Model) center(block string) string {
+	padding := max(0, (model.termWidth()-model.contentWidth())/2)
+	if padding == 0 {
+		return block
+	}
+	prefix := strings.Repeat(" ", padding)
+	lines := strings.Split(block, "\n")
+	for index := range lines {
+		lines[index] = prefix + lines[index]
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (model Model) centerLine(line string, boundaryWidth int) string {
+	line = truncate(line, boundaryWidth)
+	left := max(0, (model.termWidth()-lipgloss.Width(line))/2)
+	return strings.Repeat(" ", left) + line
+}
+
+func (model Model) chrome(context, body, help string) string {
+	width := model.contentWidth()
+	header := truncate(model.renderBrand()+model.faint.Render("  "+context), width)
+	rule := model.faint.Render(strings.Repeat("─", width))
+	bodyLines := strings.Split(body, "\n")
+	if body == "" {
+		bodyLines = nil
+	}
+	if len(bodyLines) > model.bodyHeight() {
+		bodyLines = bodyLines[:model.bodyHeight()]
+	}
+	for len(bodyLines) < model.bodyHeight() {
+		bodyLines = append(bodyLines, "")
+	}
+	for index := range bodyLines {
+		bodyLines[index] = truncate(bodyLines[index], width)
+	}
+	parts := []string{padRight(header, width), rule, strings.Join(bodyLines, "\n"), rule, truncate(help, width)}
+	return model.center(strings.Join(parts, "\n"))
+}
+
+func (model Model) resultWindow(height int) []string {
+	rowsPerResult := 1
+	if model.contentWidth() < 72 {
+		rowsPerResult = 2
+	}
+	capacity := max(1, height/rowsPerResult)
+	start := min(max(0, model.cursor-capacity+1), max(0, len(model.visible)-capacity))
+	end := min(len(model.visible), start+capacity)
+	lines := make([]string, 0, height)
+	for index := start; index < end; index++ {
+		lines = append(lines, model.resultRow(model.visible[index], index == model.cursor)...)
+	}
+	return lines
+}
+
+func (model Model) resultPageSize() int {
+	height := model.bodyHeight()
+	if model.status != "" {
+		height--
+	}
+	if len(model.providerStatus) > 0 {
+		height--
+	}
+	if model.filtering || model.filter != "" {
+		height--
+	}
+	if model.contentWidth() < 72 {
+		height /= 2
+	}
+	return max(1, height)
+}
+
+func (model Model) resultRow(result provider.Result, selected bool) []string {
+	width := model.contentWidth()
+	prefix := "  "
+	if selected {
+		prefix = "> "
+	}
+	decorate := func(line string) string {
+		line = truncate(line, width)
+		if selected {
+			return model.accent.Render(line)
+		}
+		return line
+	}
+	if width >= 72 {
+		formatWidth, weightWidth := 6, 11
+		sourceWidth := min(28, max(12, width/4))
+		nameWidth := max(8, width-2-formatWidth-weightWidth-sourceWidth-6)
+		line := prefix + padRight(truncate(result.Filename, nameWidth), nameWidth) + "  " +
+			padRight(strings.ToUpper(result.Format), formatWidth) + " " +
+			padRight(truncate(displayWeight(result.Weight), weightWidth), weightWidth) + " " +
+			truncate(result.Source, sourceWidth)
+		return []string{decorate(line)}
+	}
+	name := prefix + truncate(result.Filename, max(1, width-2))
+	metadata := "  " + strings.ToUpper(result.Format) + "  " + displayWeight(result.Weight)
+	if width >= 42 && result.Source != "" {
+		metadata += "  " + result.Source
+	}
+	return []string{decorate(name), decorate(model.faint.Render(truncate(metadata, width)))}
+}
+
+func (model Model) detailLines(result provider.Result) []string {
+	width := model.contentWidth()
+	nameLines := wrapCells(result.Filename, width)
+	lines := make([]string, len(nameLines))
+	for index := range nameLines {
+		lines[index] = model.accent.Render(nameLines[index])
+	}
+	fields := [][2]string{{"Format", strings.ToUpper(result.Format)}, {"Weight", displayWeight(result.Weight)}, {"Source", result.Source}, {"License", result.License}, {"URL", result.URL}}
+	for _, field := range fields {
+		lines = append(lines, wrapCells(field[0]+": "+field[1], width)...)
+	}
+	return lines
+}
+
+func (model Model) resultsHelp() string {
+	switch {
+	case model.contentWidth() < 34:
+		return model.faint.Render("j/k move  enter open  q")
+	case model.contentWidth() < 48:
+		return model.faint.Render("j/k move  enter open  q quit")
+	case model.contentWidth() < 90:
+		return model.faint.Render("up/down browse  enter details  / filter  q quit")
+	default:
+		return model.faint.Render("up/down: browse  pgup/dn: page  enter: details  D: download  /: filter  f: format  tab: sort  q: quit")
+	}
+}
+
+func (model Model) detailHelp() string {
+	if model.contentWidth() < 34 {
+		return model.faint.Render("j/k scroll  esc back")
+	}
+	if model.contentWidth() < 48 {
+		return model.faint.Render("j/k scroll  D download  esc back")
+	}
+	return model.faint.Render("up/down: scroll  D: download  esc: back  q: quit")
+}
+
+func truncate(value string, width int) string {
+	if width <= 0 {
+		return ""
+	}
+	if lipgloss.Width(value) <= width {
+		return value
+	}
+	if width <= 3 {
+		return ansi.Truncate(value, width, "")
+	}
+	return ansi.Truncate(value, width, "...")
+}
+
+func padRight(value string, width int) string {
+	return value + strings.Repeat(" ", max(0, width-lipgloss.Width(value)))
+}
+
+func wrapCells(value string, width int) []string {
+	if width <= 0 {
+		return nil
+	}
+	var lines []string
+	for value != "" {
+		if lipgloss.Width(value) <= width {
+			lines = append(lines, value)
+			break
+		}
+		cut := min(width, len(value))
+		for cut > 0 && cut < len(value) && !utf8.RuneStart(value[cut]) {
+			cut--
+		}
+		for cut > 0 && lipgloss.Width(value[:cut]) > width {
+			_, size := utf8.DecodeLastRuneInString(value[:cut])
+			cut -= size
+		}
+		if cut == 0 {
+			_, cut = utf8.DecodeRuneInString(value)
+		}
+		lines = append(lines, value[:cut])
+		value = value[cut:]
+	}
+	if len(lines) == 0 {
+		return []string{""}
+	}
+	return lines
 }
 
 func (model Model) waitForEvent() tea.Cmd {
@@ -278,6 +559,10 @@ func (model *Model) refresh() {
 	}
 	if model.cursor >= len(model.visible) {
 		model.cursor = max(0, len(model.visible)-1)
+	}
+	if len(model.visible) == 0 {
+		model.preview = false
+		model.detailOffset = 0
 	}
 }
 

--- a/internal/tui/results_test.go
+++ b/internal/tui/results_test.go
@@ -1,13 +1,34 @@
 package tui
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
 	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
 	"github.com/microck/moji/internal/provider"
 	"github.com/microck/moji/internal/rank"
 )
+
+func sizedModel(t *testing.T, model Model, width, height int) Model {
+	t.Helper()
+	updated, _ := model.Update(tea.WindowSizeMsg{Width: width, Height: height})
+	return updated.(Model)
+}
+
+func assertViewFits(t *testing.T, view string, width, height int) {
+	t.Helper()
+	lines := strings.Split(strings.TrimSuffix(view, "\n"), "\n")
+	if len(lines) > height {
+		t.Fatalf("view is %d lines tall in a %d-line terminal:\n%s", len(lines), height, view)
+	}
+	for index, line := range lines {
+		if got := lipgloss.Width(line); got > width {
+			t.Fatalf("line %d is %d cells wide in a %d-column terminal:\n%s", index+1, got, width, view)
+		}
+	}
+}
 
 func TestModelNavigationFilteringPreviewAndFormatCycle(t *testing.T) {
 	t.Parallel()
@@ -35,6 +56,237 @@ func TestModelNavigationFilteringPreviewAndFormatCycle(t *testing.T) {
 	}
 }
 
+func TestModelViewIncludesMonaMascot(t *testing.T) {
+	t.Parallel()
+
+	view := NewModel(nil, nil, false).View()
+	if !strings.Contains(view, "(´∀｀)  文字  moji") {
+		t.Fatalf("Mona mascot missing from view:\n%s", view)
+	}
+}
+
+func TestHomeUsesFullMonaAndBlockWordmark(t *testing.T) {
+	t.Parallel()
+	for _, size := range []struct{ width, height int }{{100, 30}, {40, 16}} {
+		model := sizedModel(t, NewHomeModel(nil, nil, false, "", rank.DefaultWeights(), 10), size.width, size.height)
+		view := model.View()
+		assertViewFits(t, view, size.width, size.height)
+		for _, wanted := range []string{"（　・∀・）", "█▀▄▀█ █▀█   █ █", "█ ▀ █ █▄█ █▄█ █"} {
+			if !strings.Contains(view, wanted) {
+				t.Fatalf("%dx%d home branding is missing %q:\n%s", size.width, size.height, wanted, view)
+			}
+		}
+		if strings.Contains(view, "Mona finds the right font") {
+			t.Fatalf("redundant mascot tagline remains:\n%s", view)
+		}
+	}
+}
+
+func TestViewsFitSupportedTerminalSizes(t *testing.T) {
+	t.Parallel()
+	results := make([]provider.Result, 12)
+	for index := range results {
+		results[index] = provider.Result{
+			Filename: "SourceSans3VF-UltraLightItalic-With-A-Very-Long-Name.woff2",
+			Format:   "woff2", Weight: "extra-light", Source: "getfonts.cc/a-provider-with-a-long-name",
+			URL: "https://example.test/fonts/SourceSans3VF-UltraLightItalic-With-A-Very-Long-Name.woff2?download=1",
+		}
+	}
+
+	for _, size := range []struct{ width, height int }{{120, 30}, {80, 24}, {60, 18}, {40, 12}, {24, 8}} {
+		size := size
+		t.Run(fmt.Sprintf("%dx%d", size.width, size.height), func(t *testing.T) {
+			model := sizedModel(t, NewModel(results, nil, false), size.width, size.height)
+			assertViewFits(t, model.View(), size.width, size.height)
+
+			model.preview = true
+			assertViewFits(t, model.View(), size.width, size.height)
+
+			home := sizedModel(t, NewHomeModel(nil, nil, false, "", rank.DefaultWeights(), 10), size.width, size.height)
+			assertViewFits(t, home.View(), size.width, size.height)
+		})
+	}
+}
+
+func TestZeroSizedPTYUsesFallbackDimensions(t *testing.T) {
+	t.Parallel()
+	model := sizedModel(t, NewModel([]provider.Result{{Filename: "Fallback.otf", Format: "otf"}}, nil, false), 0, 0)
+	view := model.View()
+	if !strings.Contains(view, "Fallback.otf") || strings.Count(view, "\n") < 5 {
+		t.Fatalf("zero-sized PTY collapsed the interface:\n%s", view)
+	}
+}
+
+func TestResultsKeepChromeVisibleAndScrollSelectionIntoView(t *testing.T) {
+	t.Parallel()
+	results := make([]provider.Result, 20)
+	for index := range results {
+		results[index] = provider.Result{Filename: fmt.Sprintf("Font-%02d.otf", index), Format: "otf", Source: "fixture"}
+	}
+	model := sizedModel(t, NewModel(results, nil, false), 80, 12)
+	for range 15 {
+		updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyDown})
+		model = updated.(Model)
+	}
+	view := model.View()
+	assertViewFits(t, view, 80, 12)
+	for _, wanted := range []string{"文字  moji", "Found 20 results", "Font-15.otf", "up/down"} {
+		if !strings.Contains(view, wanted) {
+			t.Fatalf("%q is not visible after scrolling:\n%s", wanted, view)
+		}
+	}
+}
+
+func TestResultsSupportPageAndBoundaryNavigation(t *testing.T) {
+	t.Parallel()
+	results := make([]provider.Result, 30)
+	for index := range results {
+		results[index] = provider.Result{Filename: fmt.Sprintf("Font-%02d.otf", index), Format: "otf", Score: float64(30 - index)}
+	}
+	model := sizedModel(t, NewModel(results, nil, false), 80, 12)
+
+	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyPgDown})
+	model = updated.(Model)
+	if model.cursor <= 1 {
+		t.Fatalf("page down only moved to result %d", model.cursor)
+	}
+
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyEnd})
+	model = updated.(Model)
+	if model.cursor != len(results)-1 || !strings.Contains(model.View(), "Font-29.otf") {
+		t.Fatalf("end did not select the last result: cursor=%d\n%s", model.cursor, model.View())
+	}
+
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyHome})
+	model = updated.(Model)
+	if model.cursor != 0 {
+		t.Fatalf("home selected result %d", model.cursor)
+	}
+}
+
+func TestResponsiveHelpFitsWithoutLosingCommandsMidLabel(t *testing.T) {
+	t.Parallel()
+	for _, width := range []int{24, 40, 60, 80, 120} {
+		model := sizedModel(t, NewModel(nil, nil, false), width, 12)
+		if got := lipgloss.Width(model.resultsHelp()); got > model.contentWidth() {
+			t.Fatalf("results help is %d cells in %d available cells", got, model.contentWidth())
+		}
+		if got := lipgloss.Width(model.detailHelp()); got > model.contentWidth() {
+			t.Fatalf("detail help is %d cells in %d available cells", got, model.contentWidth())
+		}
+	}
+}
+
+func TestLongDetailValuesWrapInsteadOfClipping(t *testing.T) {
+	t.Parallel()
+	model := NewModel([]provider.Result{{
+		Filename: "SourceSans3VF-UltraLightItalic.woff2", Format: "woff2", Weight: "ultralight",
+		Source: "fixture", License: "OFL-1.1", URL: "https://example.test/a/very/long/path/to/a/font/file.woff2?download=1",
+	}}, nil, false)
+	model.preview = true
+	model = sizedModel(t, model, 40, 14)
+	view := model.View()
+	assertViewFits(t, view, 40, 14)
+	compact := strings.ReplaceAll(strings.ReplaceAll(view, "\n", ""), " ", "")
+	if !strings.Contains(compact, "download=1") {
+		t.Fatalf("wrapped URL lost its tail:\n%s", view)
+	}
+}
+
+func TestLongDetailsScrollWithoutChangingSelectedResult(t *testing.T) {
+	t.Parallel()
+	model := NewModel([]provider.Result{
+		{Filename: "First.otf", Format: "otf", URL: "https://example.test/" + strings.Repeat("long-path/", 12) + "first.otf"},
+		{Filename: "Second.otf", Format: "otf", URL: "https://example.test/second.otf"},
+	}, nil, false)
+	model.preview = true
+	model = sizedModel(t, model, 40, 10)
+	initial := model.View()
+	for range 10 {
+		updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyDown})
+		model = updated.(Model)
+	}
+	view := model.View()
+	assertViewFits(t, view, 40, 10)
+	if model.cursor != 0 {
+		t.Fatalf("detail scrolling changed the selected result to %d", model.cursor)
+	}
+	if view == initial || !strings.Contains(view, "first.otf") {
+		t.Fatalf("detail viewport did not reveal the URL tail:\n%s", view)
+	}
+}
+
+func TestRefreshClosesDetailsWhenSelectedResultDisappears(t *testing.T) {
+	t.Parallel()
+	model := NewModel([]provider.Result{{Filename: "Only.ttf", Format: "ttf"}}, nil, false)
+	model.preview = true
+
+	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
+	model = updated.(Model)
+	if model.preview || len(model.visible) != 0 {
+		t.Fatalf("preview=%v visible=%d, want closed preview with no results", model.preview, len(model.visible))
+	}
+
+	// Scrolling after the refresh must remain safe when the filtered list is empty.
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyDown})
+	model = updated.(Model)
+	if model.cursor != 0 {
+		t.Fatalf("empty result cursor moved to %d", model.cursor)
+	}
+}
+
+func TestHomeModelStartsLiveSearchFromTypedQuery(t *testing.T) {
+	t.Parallel()
+
+	events := make(chan provider.Event, 2)
+	events <- provider.Event{Provider: "fixture", Type: provider.EventResult, Result: provider.Result{Filename: "Inter-Regular.otf", Format: "otf"}}
+	events <- provider.Event{Provider: "fixture", Type: provider.EventStatus, Status: provider.StateDone, Count: 1}
+	close(events)
+	var searched string
+	model := NewHomeModel(func(query string) (<-chan provider.Event, error) {
+		searched = query
+		return events, nil
+	}, nil, false, "", rank.DefaultWeights(), 10)
+	if !strings.Contains(model.View(), "Type a font name") {
+		t.Fatalf("home prompt missing:\n%s", model.View())
+	}
+
+	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'q'}})
+	model = updated.(Model)
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("uicksand")})
+	model = updated.(Model)
+	updated, command := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	if searched != "quicksand" || model.home || !model.loading || command == nil {
+		t.Fatalf("searched=%q home=%v loading=%v command=%v", searched, model.home, model.loading, command != nil)
+	}
+	for command != nil {
+		updated, command = model.Update(command())
+		model = updated.(Model)
+	}
+	if !strings.Contains(model.View(), "Inter-Regular.otf") {
+		t.Fatalf("search result missing:\n%s", model.View())
+	}
+}
+
+func TestHomeModelKeepsPastedQueryOnOneLine(t *testing.T) {
+	model := sizedModel(t, NewHomeModel(nil, nil, false, "", rank.DefaultWeights(), 10), 40, 12)
+
+	updated, _ := model.Update(tea.KeyMsg{
+		Type:  tea.KeyRunes,
+		Runes: []rune("Noto\nSans\tJP"),
+		Paste: true,
+	})
+	model = updated.(Model)
+
+	if model.query != "Noto Sans JP" {
+		t.Fatalf("query = %q, want a single-line pasted query", model.query)
+	}
+	if got := len(strings.Split(model.View(), "\n")); got != 12 {
+		t.Fatalf("rendered lines = %d, want terminal height 12", got)
+	}
+}
+
 func TestModelDownloadCommandReportsStatus(t *testing.T) {
 	t.Parallel()
 	model := NewModel([]provider.Result{{Filename: "Example.otf", Format: "otf"}}, func(result provider.Result) (string, error) {
@@ -49,6 +301,24 @@ func TestModelDownloadCommandReportsStatus(t *testing.T) {
 	model = updated.(Model)
 	if !strings.Contains(model.status, "Downloaded: /tmp/Example.otf") {
 		t.Fatal(model.status)
+	}
+}
+
+func TestResultsReserveAVisibleRowForStatus(t *testing.T) {
+	results := make([]provider.Result, 20)
+	for index := range results {
+		results[index] = provider.Result{Filename: fmt.Sprintf("Font-%02d.otf", index), Format: "otf"}
+	}
+	model := sizedModel(t, NewModel(results, nil, false), 80, 12)
+	model.cursor = 15
+	model.status = "Downloaded: /tmp/Font-15.otf"
+
+	view := model.View()
+	if !strings.Contains(view, "> Font-15.otf") {
+		t.Fatalf("selected result disappeared behind status:\n%s", view)
+	}
+	if !strings.Contains(view, model.status) {
+		t.Fatalf("status missing from view:\n%s", view)
 	}
 }
 
@@ -67,5 +337,26 @@ func TestLiveModelStreamsProviderEvents(t *testing.T) {
 	}
 	if model.loading || len(model.visible) != 1 || !strings.Contains(model.View(), "fixture: done (1 results)") {
 		t.Fatalf("live model did not settle: %s", model.View())
+	}
+}
+
+func TestLiveModelHonorsExplicitMaximum(t *testing.T) {
+	t.Parallel()
+	events := make(chan provider.Event, 13)
+	for index := range 12 {
+		events <- provider.Event{Provider: "fixture", Type: provider.EventResult, Result: provider.Result{
+			Filename: fmt.Sprintf("Font-%02d.otf", index), Format: "otf", URL: fmt.Sprintf("https://example.test/%02d", index),
+		}}
+	}
+	events <- provider.Event{Provider: "fixture", Type: provider.EventStatus, Status: provider.StateDone, Count: 12}
+	close(events)
+	model := NewLiveModel(events, nil, false, "", rank.DefaultWeights(), 5)
+	for command := model.Init(); command != nil; {
+		updated, next := model.Update(command())
+		model = updated.(Model)
+		command = next
+	}
+	if len(model.visible) != 5 {
+		t.Fatalf("explicit maximum yielded %d results, want 5", len(model.visible))
 	}
 }


### PR DESCRIPTION
**What changed**

- Open the interactive font finder when `moji` runs without arguments.
- Add a branded home screen with keyboard-driven search.
- Stream all provider results into a responsive scrolling viewport.
- Add filtering, sorting, format selection, details, downloads, paging, and boundary navigation.
- Keep non-interactive output capped at 10 while allowing all TUI results by default.
- Add Mona branding across the TUI and documentation.
- Add terminal-size, PTY, navigation, streaming, and end-to-end regression coverage.

**Why**

Moji previously required a query before opening its TUI and discarded results after the default limit of 10. The new flow behaves like a complete terminal application while retaining script-friendly output.

**Validation**

- `CGO_ENABLED=1 go test -race ./...`
- `go vet ./...`
- `npm run verify`
- Interactive PTY checks from `120x30` through `24x8`
- Live result, resize, paging, filtering, and detail-scroll checks

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a bare-command interactive font finder flow. The main changes are:

- Home TUI opens when `moji` runs without arguments in a terminal.
- Live TUI results now support responsive rendering, paging, filtering, sorting, detail scrolling, and boundary navigation.
- Non-interactive search output stays capped at 10 results while interactive results can stream all matches by default.
- Mona branding is added across the TUI and documentation.
- Tests cover terminal sizing, PTY behavior, home-to-results search, navigation, streaming, and output limits.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

No confirmed functional or security issues were found in the changed paths. The main TUI and CLI behavior is covered by focused unit and end-to-end tests.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The race-enabled end-to-end test for the app/TUI/e2e ran and completed with EXIT\_CODE: 0, including the TestMojiBinaryEndToEnd and the responsive TestViewsFitSupportedTerminalSizes subtests.
- Terminal size validation under race conditions was isolated and confirmed across 120x30, 80x24, 60x18, 40x12, and 24x8 with all sizes passing.
- Static analysis with go vet was executed for the CLI, internal, and e2e packages and completed with EXIT\_CODE: 0.

<a href="https://app.greptile.com/trex/runs/14065627/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| internal/app/app.go | Routes bare interactive invocations to the home TUI while preserving non-interactive usage errors and explicit output limits. |
| internal/app/search.go | Factors interactive downloader setup and adds home-screen search startup wiring. |
| internal/tui/home.go | Introduces the home-screen TUI for typed queries, responsive rendering, and search transition state. |
| internal/tui/results.go | Adds responsive chrome, result paging, detail scrolling, boundary navigation, and safer preview reset behavior. |
| internal/tui/results_test.go | Adds unit coverage for responsive layout, home search, paging, detail scrolling, preview reset, and live-result limits. |
| e2e/cli_test.go | Extends end-to-end coverage for capped non-interactive output and unlimited/home TUI results. |
| docs/content/docs/reference/cli.mdx | Adds CLI grammar, TUI keybindings, and max-result default documentation for the interactive flow. |
| go.mod | Bumps the Go directive and promotes terminal/ANSI dependencies needed for improved TTY handling and rendering. |


<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant App as internal/app.Run
participant Home as tui.HomeModel
participant Search as app.searchEvents
participant Providers as Aggregator/Providers
participant Results as tui.LiveModel

User->>App: moji (no args, TTY)
App->>Home: runHome(config, defaults)
User->>Home: type query + Enter
Home->>Search: SearchFunc(query)
Search->>Providers: aggregate.Search(query, formats)
Providers-->>Search: provider.Event stream
Search-->>Home: event channel
Home->>Results: switch from home to live results
Results-->>User: responsive scrolling results/details
User->>Results: filter/sort/page/download keys
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant App as internal/app.Run
participant Home as tui.HomeModel
participant Search as app.searchEvents
participant Providers as Aggregator/Providers
participant Results as tui.LiveModel

User->>App: moji (no args, TTY)
App->>Home: runHome(config, defaults)
User->>Home: type query + Enter
Home->>Search: SearchFunc(query)
Search->>Providers: aggregate.Search(query, formats)
Providers-->>Search: provider.Event stream
Search-->>Home: event channel
Home->>Results: switch from home to live results
Results-->>User: responsive scrolling results/details
User->>Results: filter/sort/page/download keys
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (4)</h3></summary>

1. `internal/tui/results.go`, line 128-131 ([link](https://github.com/microck/moji/blob/e26de31a64a951e550d137e9d88aee38f090751f/internal/tui/results.go#L128-L131)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Delete runes safely**
   The filter prompt appends typed input as runes but deletes with `model.filter[:len(model.filter)-1]`, which removes only one byte. When a multi-byte font family or filter character is typed and backspace is pressed, `model.filter` is left with invalid UTF-8, so the displayed filter and matching text become corrupted.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/tui/results.go
   Line: 128-131

   Comment:
   **Delete runes safely**
   The filter prompt appends typed input as runes but deletes with `model.filter[:len(model.filter)-1]`, which removes only one byte. When a multi-byte font family or filter character is typed and backspace is pressed, `model.filter` is left with invalid UTF-8, so the displayed filter and matching text become corrupted.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22microck%2Fmoji%22%20on%20the%20existing%20branch%20%22feat%2Finteractive-tui%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Finteractive-tui%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Ftui%2Fresults.go%0ALine%3A%20128-131%0A%0AComment%3A%0A**Delete%20runes%20safely**%0AThe%20filter%20prompt%20appends%20typed%20input%20as%20runes%20but%20deletes%20with%20%60model.filter%5B%3Alen%28model.filter%29-1%5D%60%2C%20which%20removes%20only%20one%20byte.%20When%20a%20multi-byte%20font%20family%20or%20filter%20character%20is%20typed%20and%20backspace%20is%20pressed%2C%20%60model.filter%60%20is%20left%20with%20invalid%20UTF-8%2C%20so%20the%20displayed%20filter%20and%20matching%20text%20become%20corrupted.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=microck%2Fmoji&pr=2&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

2. `internal/tui/results.go`, line 185-187 ([link](https://github.com/microck/moji/blob/e26de31a64a951e550d137e9d88aee38f090751f/internal/tui/results.go#L185-L187)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Include supported WOFF**
   The TUI format cycle skips `woff`, even though `config.ParseFormats` accepts `woff` and the CLI/docs advertise it as a supported format. When results contain WOFF fonts, pressing `f` never filters to that supported format, so interactive filtering behaves differently from the rest of the app.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/tui/results.go
   Line: 185-187

   Comment:
   **Include supported WOFF**
   The TUI format cycle skips `woff`, even though `config.ParseFormats` accepts `woff` and the CLI/docs advertise it as a supported format. When results contain WOFF fonts, pressing `f` never filters to that supported format, so interactive filtering behaves differently from the rest of the app.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22microck%2Fmoji%22%20on%20the%20existing%20branch%20%22feat%2Finteractive-tui%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Finteractive-tui%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Ftui%2Fresults.go%0ALine%3A%20185-187%0A%0AComment%3A%0A**Include%20supported%20WOFF**%0AThe%20TUI%20format%20cycle%20skips%20%60woff%60%2C%20even%20though%20%60config.ParseFormats%60%20accepts%20%60woff%60%20and%20the%20CLI%2Fdocs%20advertise%20it%20as%20a%20supported%20format.%20When%20results%20contain%20WOFF%20fonts%2C%20pressing%20%60f%60%20never%20filters%20to%20that%20supported%20format%2C%20so%20interactive%20filtering%20behaves%20differently%20from%20the%20rest%20of%20the%20app.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=microck%2Fmoji&pr=2&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

3. `internal/tui/results.go`, line 128-132 ([link](https://github.com/microck/moji/blob/8a8d3a3561e805a99b4c6720467d143b1ce06589/internal/tui/results.go#L128-L132)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Delete whole runes**
   Filter input appends `message.Runes`, but backspace removes one byte with `model.filter[:len(model.filter)-1]`. For a multibyte filter such as `文字`, one backspace leaves invalid UTF-8 and corrupts the visible filter and matching text; mirror the home-screen `[]rune` deletion here.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/tui/results.go
   Line: 128-132

   Comment:
   **Delete whole runes**
   Filter input appends `message.Runes`, but backspace removes one byte with `model.filter[:len(model.filter)-1]`. For a multibyte filter such as `文字`, one backspace leaves invalid UTF-8 and corrupts the visible filter and matching text; mirror the home-screen `[]rune` deletion here.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22microck%2Fmoji%22%20on%20the%20existing%20branch%20%22feat%2Finteractive-tui%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Finteractive-tui%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Ftui%2Fresults.go%0ALine%3A%20128-132%0A%0AComment%3A%0A**Delete%20whole%20runes**%0AFilter%20input%20appends%20%60message.Runes%60%2C%20but%20backspace%20removes%20one%20byte%20with%20%60model.filter%5B%3Alen%28model.filter%29-1%5D%60.%20For%20a%20multibyte%20filter%20such%20as%20%60%E6%96%87%E5%AD%97%60%2C%20one%20backspace%20leaves%20invalid%20UTF-8%20and%20corrupts%20the%20visible%20filter%20and%20matching%20text%3B%20mirror%20the%20home-screen%20%60%5B%5Drune%60%20deletion%20here.%0A%0A%60%60%60suggestion%0A%09%09%09case%20%22backspace%22%3A%0A%09%09%09%09runes%20%3A%3D%20%5B%5Drune%28model.filter%29%0A%09%09%09%09if%20len%28runes%29%20%3E%200%20%7B%0A%09%09%09%09%09model.filter%20%3D%20string%28runes%5B%3Alen%28runes%29-1%5D%29%0A%09%09%09%09%09model.refresh%28%29%0A%09%09%09%09%7D%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=microck%2Fmoji&pr=2&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

4. `internal/tui/results.go`, line 185-187 ([link](https://github.com/microck/moji/blob/8a8d3a3561e805a99b4c6720467d143b1ce06589/internal/tui/results.go#L185-L187)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Include WOFF filtering**
   The CLI accepts `woff` in `--format`, but the TUI cycle skips it and only visits `all`, `otf`, `ttf`, and `woff2`. Users can see WOFF results under `all` but cannot isolate them with the new format selection; add `woff` to this cycle so the interactive filter covers every supported format.

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: internal/tui/results.go
   Line: 185-187

   Comment:
   **Include WOFF filtering**
   The CLI accepts `woff` in `--format`, but the TUI cycle skips it and only visits `all`, `otf`, `ttf`, and `woff2`. Users can see WOFF results under `all` but cannot isolate them with the new format selection; add `woff` to this cycle so the interactive filter covers every supported format.

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22microck%2Fmoji%22%20on%20the%20existing%20branch%20%22feat%2Finteractive-tui%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22feat%2Finteractive-tui%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20internal%2Ftui%2Fresults.go%0ALine%3A%20185-187%0A%0AComment%3A%0A**Include%20WOFF%20filtering**%0AThe%20CLI%20accepts%20%60woff%60%20in%20%60--format%60%2C%20but%20the%20TUI%20cycle%20skips%20it%20and%20only%20visits%20%60all%60%2C%20%60otf%60%2C%20%60ttf%60%2C%20and%20%60woff2%60.%20Users%20can%20see%20WOFF%20results%20under%20%60all%60%20but%20cannot%20isolate%20them%20with%20the%20new%20format%20selection%3B%20add%20%60woff%60%20to%20this%20cycle%20so%20the%20interactive%20filter%20covers%20every%20supported%20format.%0A%0A%60%60%60suggestion%0A%09%09case%20%22f%22%3A%0A%09%09%09formats%20%3A%3D%20%5B%5Dstring%7B%22all%22%2C%20%22otf%22%2C%20%22ttf%22%2C%20%22woff%22%2C%20%22woff2%22%7D%0A%09%09%09for%20index%2C%20format%20%3A%3D%20range%20formats%20%7B%0A%60%60%60%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=microck%2Fmoji&pr=2&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["feat(tui): add responsive interactive fo..."](https://github.com/microck/moji/commit/71350703349c158b0cfff386e5839e05df2d476a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43456002)</sub>

<!-- /greptile_comment -->