### PR TITLE
fix: use short global install flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ and arm64. installing Go is not required.
 install with the package manager you already use:
 
 ```bash
-npm install --global @microck/moji
-pnpm add --global @microck/moji
-bun add --global @microck/moji
+npm install -g @microck/moji
+pnpm add -g @microck/moji
+bun add -g @microck/moji
 ```
 
 search for a family:

--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -20,9 +20,9 @@ downloads through a validation pipeline.
 Choose the package manager you already use:
 
 ```sh
-npm install --global @microck/moji
-pnpm add --global @microck/moji
-bun add --global @microck/moji
+npm install -g @microck/moji
+pnpm add -g @microck/moji
+bun add -g @microck/moji
 ```
 
 All three commands install the same npm-registry package. It includes binaries

--- a/docs/content/docs/tutorial.mdx
+++ b/docs/content/docs/tutorial.mdx
@@ -14,19 +14,19 @@ Use one package manager.
 ### npm
 
 ```sh
-npm install --global @microck/moji
+npm install -g @microck/moji
 ```
 
 ### pnpm
 
 ```sh
-pnpm add --global @microck/moji
+pnpm add -g @microck/moji
 ```
 
 ### Bun
 
 ```sh
-bun add --global @microck/moji
+bun add -g @microck/moji
 ```
 
 Confirm that the launcher can find its bundled binary:

--- a/docs/src/app/(home)/page.tsx
+++ b/docs/src/app/(home)/page.tsx
@@ -30,7 +30,7 @@ export default function HomePage() {
   （       ）
    |  |  |
   （_＿）＿）`}</pre>
-          <p className="text-zinc-500">$ npm install --global @microck/moji</p>
+          <p className="text-zinc-500">$ npm install -g @microck/moji</p>
           <p className="mt-4 text-zinc-500">$ moji get &quot;Inter bold&quot; --dry-run</p>
           <p className="mt-4 text-orange-400">Would download:</p>
           <p className="mt-2">1&nbsp;&nbsp; OTF&nbsp;&nbsp; bold&nbsp;&nbsp; getfonts.cc/...</p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@microck/moji",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@microck/moji",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "license": "MIT",
       "workspaces": [
         "docs"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microck/moji",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "description": "A cozy terminal font finder with safe downloads and script-friendly output.",
   "type": "module",
   "bin": { "moji": "bin/moji.js" },


### PR DESCRIPTION
**Summary**

- Replace `--global` with `-g` in npm, pnpm, and Bun installation examples.
- Bump the npm package from `0.1.0` to `0.1.1`.
- Keep the documentation site and packaged README consistent.

**Verification**

- `npm run verify`
- `npm pack --dry-run`
- Confirmed the package contains all six platform binaries.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the package install guidance and bumps the published package version.

- Replaces `--global` with `-g` in README and docs install examples.
- Updates the homepage terminal mockup to show the shorter npm global flag.
- Bumps `@microck/moji` from `0.1.0` to `0.1.1` in package metadata.

<h3>Confidence Score: 4/5</h3>

Mostly safe to merge after fixing the tutorial version mismatch.

The install flag and package metadata changes are small and consistent, but the tutorial documents an incorrect expected `moji --version` output.

`docs/content/docs/tutorial.mdx`

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Reproduced the tutorial version output mismatch by running a narrow Node repro that builds the current-platform CLI and checks its --version against the tutorial line 38.
- Validated the root package verification and dry-run packaging completed with EXIT\_CODE: 0, and confirmed six platform binaries were prepared, with the binary-count log reporting 6 found.
- Artifacts documenting the mismatch and packaging results were collected and inspected to enable reviewer verification.

<a href="https://app.greptile.com/trex/runs/14088713/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>


<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| README.md | Updates quick-start global install examples from long `--global` flags to short `-g` flags. |
| docs/content/docs/index.mdx | Updates documentation install examples to use short global install flags. |
| docs/content/docs/tutorial.mdx | Updates tutorial install commands, but leaves the expected `moji --version` output at the previous package version. |
| docs/src/app/(home)/page.tsx | Updates the homepage terminal mockup to show `npm install -g @microck/moji`. |
| package.json | Bumps the npm package version from `0.1.0` to `0.1.1`. |
| package-lock.json | Bumps the root package lockfile version from `0.1.0` to `0.1.1`. |


<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `docs/content/docs/tutorial.mdx`, line 38 ([link](https://github.com/microck/moji/blob/7b8a84d0d615bc0a78f35a3b66f2b3f7f18dae93/docs/content/docs/tutorial.mdx#L38)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Update displayed version**
   The tutorial still tells users that `moji --version` prints `0.1.0`, but this PR bumps the package metadata to `0.1.1` in `package.json` and `package-lock.json`. After installing the new package, the verification step documents the wrong expected output.

   <details><summary><strong>Artifacts</strong></summary><br />

   **[Repro: script that builds the CLI, runs --version, and compares it with tutorial line 38](https://app.greptile.com/trex/artifacts/c5b2b16c-d5eb-4899-aaa3-a2a5a5237d78)**

   - Contains supporting evidence from the run (text/javascript; charset=utf-8).

   **[Repro: command output showing CLI version 0.1.1 and tutorial expected version 0.1.0](https://app.greptile.com/trex/artifacts/b336268e-afd5-4928-97da-ed98001daf80)**

   - Keeps the command output available without making the summary code-heavy.

   <a href="https://app.greptile.com/trex/runs/14088713/artifacts?artifact=c5b2b16c-d5eb-4899-aaa3-a2a5a5237d78"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"><img alt="View artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewArtifacts.svg?v=4"></picture></a>
   </details>

   <sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: docs/content/docs/tutorial.mdx
   Line: 38

   Comment:
   **Update displayed version**
   The tutorial still tells users that `moji --version` prints `0.1.0`, but this PR bumps the package metadata to `0.1.1` in `package.json` and `package-lock.json`. After installing the new package, the verification step documents the wrong expected output.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

   <a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22microck%2Fmoji%22%20on%20the%20existing%20branch%20%22fix%2Finstall-command%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Finstall-command%22.%0A%0AThis%20is%20a%20comment%20left%20during%20a%20code%20review.%0APath%3A%20docs%2Fcontent%2Fdocs%2Ftutorial.mdx%0ALine%3A%2038%0A%0AComment%3A%0A**Update%20displayed%20version**%0AThe%20tutorial%20still%20tells%20users%20that%20%60moji%20--version%60%20prints%20%600.1.0%60%2C%20but%20this%20PR%20bumps%20the%20package%20metadata%20to%20%600.1.1%60%20in%20%60package.json%60%20and%20%60package-lock.json%60.%20After%20installing%20the%20new%20package%2C%20the%20verification%20step%20documents%20the%20wrong%20expected%20output.%0A%0AHow%20can%20I%20resolve%20this%3F%20If%20you%20propose%20a%20fix%2C%20please%20make%20it%20concise.&repo=microck%2Fmoji&pr=3&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"><img alt="Fix in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixInCodex.svg?v=6"></picture></a>

</details>

<!-- /greptile_failed_comments -->

<a href="https://app.greptile.com/api/ide/codex?prompt=IMPORTANT%3A%20Work%20in%20the%20repository%20%22microck%2Fmoji%22%20on%20the%20existing%20branch%20%22fix%2Finstall-command%22.%20Checkout%20that%20branch%20%E2%80%94%20do%20NOT%20create%20a%20new%20branch%20or%20open%20a%20new%20PR.%20Push%20your%20changes%20to%20%22fix%2Finstall-command%22.%0A%0AFix%20the%20following%201%20code%20review%20issue.%20Work%20through%20them%20one%20at%20a%20time%2C%20proposing%20concise%20fixes.%0A%0A---%0A%0A%23%23%23%20Issue%201%20of%201%0Adocs%2Fcontent%2Fdocs%2Ftutorial.mdx%3A38%0A**Update%20displayed%20version**%0AThe%20tutorial%20still%20tells%20users%20that%20%60moji%20--version%60%20prints%20%600.1.0%60%2C%20but%20this%20PR%20bumps%20the%20package%20metadata%20to%20%600.1.1%60%20in%20%60package.json%60%20and%20%60package-lock.json%60.%20After%20installing%20the%20new%20package%2C%20the%20verification%20step%20documents%20the%20wrong%20expected%20output.%0A%0A&repo=microck%2Fmoji&pr=3&platform=github"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodexDark.svg?v=6"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"><img alt="Fix All in Codex" src="https://greptile-static-assets.s3.amazonaws.com/badges/FixAllInCodex.svg?v=6"></picture></a>

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 1 code review issue. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 1
docs/content/docs/tutorial.mdx:38
**Update displayed version**
The tutorial still tells users that `moji --version` prints `0.1.0`, but this PR bumps the package metadata to `0.1.1` in `package.json` and `package-lock.json`. After installing the new package, the verification step documents the wrong expected output.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: use short global install flags"](https://github.com/microck/moji/commit/7b8a84d0d615bc0a78f35a3b66f2b3f7f18dae93) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43505877)</sub>

<!-- /greptile_comment -->