### PR TITLE
feat: expand direct font discovery

### DIFF
--- a/.workflow/direct-font-discovery-expansion/final-report.md
+++ b/.workflow/direct-font-discovery-expansion/final-report.md
@@ -1,0 +1,60 @@
+# Final Report: Direct font discovery expansion
+
+## Outcome
+
+Implemented all six requested discovery mechanisms behind one direct-file
+contract. Search results remain downloadable HTTPS font files or safe members
+of supported archives. Webpages and gated download flows are not promoted to
+results.
+
+## Accepted Results
+
+- ZIP, TAR, and TGZ members with safe paths and configured font formats.
+- CSS `url(...)` sources with a supported extension or declared `format(...)`.
+- Raw GitHub tree files and direct release font/archive assets.
+- Fontsource variant URLs and Google Fonts stylesheet URLs.
+- Version 1 plugin responses that resolve through the same discovery boundary.
+
+## Rejected Results
+
+- HTML pages, insecure URLs and redirect downgrades, unsupported formats, and
+  malformed plugin responses.
+- Unsafe archive paths, excessive entry counts, oversized members, and
+  archives over the expanded-size limit.
+- Sources that expose only a gated publisher flow rather than a direct file.
+
+## Conflicts Resolved
+
+- GitHub Code Search remains authenticated, while bounded repository, tree,
+  and release discovery uses GitHub's unauthenticated REST path when no token
+  is configured.
+- Kagi remains an internal `websearch` backend rather than a public provider.
+- Structured catalogs are exposed as one public `registry` provider.
+
+## Verification Evidence
+
+- Focused unit and HTTP integration tests cover ZIP/TAR/TGZ, extraction,
+  stylesheet resolution, insecure redirects, GitHub trees/releases, both
+  registries, adaptive query variants, and a real plugin subprocess.
+- `CGO_ENABLED=1 go test -race -count=1 ./...` passed.
+- `go vet ./...` passed.
+- `npm run verify` passed Go tests, docs type generation, TypeScript, ESLint,
+  the production Next.js build, and 51 generated static pages.
+- A no-Kagi, no-token live corpus returned direct results for Operator Mono
+  and MonoLisa. PragmataPro, Catedra, CSTM Xprmntl, Nida, and Loes still had no
+  legal public direct result in the enabled sources during the run.
+
+## Remaining Risks
+
+- Public availability is not guaranteed for proprietary fonts. Source plugins
+  provide an extension point but do not bypass publisher access controls.
+- GitHub's unauthenticated request allowance is small; the TUI recommends a
+  token for Code Search and higher limits.
+- License metadata is best effort and remains `unknown` when the source does
+  not provide a specific license identifier.
+
+## Reusable Follow-up
+
+The source plugin request/response contract is documented at
+`docs/content/docs/reference/source-plugins.mdx`. New structured sources can
+also be added behind the existing `Provider` interface and discovery resolver.

--- a/.workflow/direct-font-discovery-expansion/orchestration.md
+++ b/.workflow/direct-font-discovery-expansion/orchestration.md
@@ -1,0 +1,30 @@
+# Orchestration: Direct font discovery expansion
+
+## Execution Rules
+
+- Keep the original objective intact.
+- Ask for approval before risky, expensive, external, or destructive actions.
+- Keep immediate blocking work local.
+- Delegate only bounded, disjoint, materially useful packets.
+- Integrate packet results before final verification.
+
+## Branching Rules
+
+## Packet Prompts
+
+## Completion Audit
+# Orchestration
+
+1. Establish result and safety contracts before provider expansion.
+2. Implement archive and CSS resolvers with deterministic fixtures.
+3. Add bounded GitHub and registry discovery using those contracts.
+4. Add plugin execution behind the same validation boundary.
+5. Integrate provider selection, cache keys, output, and docs.
+6. Run security-focused tests, live corpus checks, and full verification.
+
+Branching rules:
+
+- If a source exposes only a webpage, it is not a result.
+- If a direct archive cannot be enumerated within safety limits, discard it.
+- If a provider cannot establish a usable direct URL, report no result rather than downgrade the contract.
+- Partial backend failure must preserve healthy backend results.

--- a/.workflow/direct-font-discovery-expansion/packets/01-contracts.md
+++ b/.workflow/direct-font-discovery-expansion/packets/01-contracts.md
@@ -1,0 +1,11 @@
+# Packet 1: Contracts
+
+## Scope
+
+Extend results with archive identity and preserve uniqueness by URL plus member.
+
+## Acceptance
+
+- Direct files and archive members have stable identities.
+- Downloader validation remains the final file boundary.
+

--- a/.workflow/direct-font-discovery-expansion/packets/02-archives.md
+++ b/.workflow/direct-font-discovery-expansion/packets/02-archives.md
@@ -1,0 +1,11 @@
+# Packet 2: Archives
+
+## Scope
+
+Inspect and extract ZIP, TAR, and TGZ font members within fixed limits.
+
+## Acceptance
+
+- Traversal and unsafe paths are ignored.
+- Entry, member, container, and expanded sizes are bounded.
+

--- a/.workflow/direct-font-discovery-expansion/packets/03-css.md
+++ b/.workflow/direct-font-discovery-expansion/packets/03-css.md
@@ -1,0 +1,11 @@
+# Packet 3: CSS discovery
+
+## Scope
+
+Resolve `@font-face` URLs from HTTPS stylesheets.
+
+## Acceptance
+
+- Relative URLs and declared formats are supported.
+- Pages, insecure redirects, and unsupported formats are rejected.
+

--- a/.workflow/direct-font-discovery-expansion/packets/04-github-adaptive.md
+++ b/.workflow/direct-font-discovery-expansion/packets/04-github-adaptive.md
@@ -1,0 +1,11 @@
+# Packet 4: GitHub and adaptive search
+
+## Scope
+
+Add bounded tree and release discovery plus filename convention rounds.
+
+## Acceptance
+
+- Tokenless search uses the repository API allowance.
+- Authenticated search retains exact and broad Code Search rounds.
+

--- a/.workflow/direct-font-discovery-expansion/packets/05-registries.md
+++ b/.workflow/direct-font-discovery-expansion/packets/05-registries.md
@@ -1,0 +1,11 @@
+# Packet 5: Registries
+
+## Scope
+
+Add Fontsource metadata and Google Fonts CSS2 behind `registry`.
+
+## Acceptance
+
+- Both backends emit direct configured formats only.
+- Backend failure is isolated when the other backend completes.
+

--- a/.workflow/direct-font-discovery-expansion/packets/06-plugins.md
+++ b/.workflow/direct-font-discovery-expansion/packets/06-plugins.md
@@ -1,0 +1,11 @@
+# Packet 6: Source plugins
+
+## Scope
+
+Run configured executables through a versioned JSON protocol.
+
+## Acceptance
+
+- Output is bounded and protocol versions are enforced.
+- Every plugin URL passes through built-in discovery validation.
+

--- a/.workflow/direct-font-discovery-expansion/packets/07-integration.md
+++ b/.workflow/direct-font-discovery-expansion/packets/07-integration.md
@@ -1,0 +1,11 @@
+# Packet 7: Integration
+
+## Scope
+
+Wire configuration, CLI/TUI behavior, documentation, and verification.
+
+## Acceptance
+
+- Public provider names and configuration are documented.
+- Focused tests, race tests, vet, and repository verification pass.
+

--- a/.workflow/direct-font-discovery-expansion/plan.md
+++ b/.workflow/direct-font-discovery-expansion/plan.md
@@ -1,0 +1,67 @@
+# Direct font discovery expansion
+
+## Goal
+
+Increase Moji's verified direct-font success rate through six integrated discovery mechanisms without treating HTML pages as font results or bypassing access gates.
+
+## Success Criteria
+
+- Direct ZIP/TAR archives can be inspected safely and selected font members can be downloaded and validated.
+- CSS and `@font-face` sources yield validated direct font URLs.
+- GitHub discovery can inspect relevant repository trees and release assets after bounded search discovery.
+- At least two structured public font registries are integrated with direct-file contracts.
+- Adaptive query rounds broaden only after exact/family searches fail and remain request-bounded.
+- External source plugins have a documented JSON protocol, configuration, validation, and failure isolation.
+- Existing CLI, TUI, table, JSON, cache, and family-selection behavior remains coherent.
+- Race tests, vet, repository verification, docs build, and focused live searches pass.
+
+## Current Context
+
+Moji currently has GetFonts, authenticated GitHub Code Search, and a combined websearch provider with Kagi CLI and optional SearXNG backends. Search results must be direct supported font files. The working copy already contains uncommitted search, format, ranking, and TUI improvements that must be preserved.
+
+## Constraints
+
+- No webpage-only results.
+- No gated-flow bypasses or fabricated license claims.
+- Preserve direct-file magic/structural validation.
+- Bound network requests, archive sizes, expansion ratios, recursion, and redirects.
+- Support Linux, macOS, and Windows on amd64 and arm64.
+- Do not commit or publish without explicit instruction.
+
+## Risks
+
+- Archive traversal, zip bombs, decompression bombs, and ambiguous members.
+- SSRF or unbounded crawling during CSS discovery.
+- GitHub and web-search rate exhaustion.
+- Plugin executable trust and malformed output.
+- Paid/proprietary fonts with no authorized public direct source.
+
+## Approval Required
+
+No additional approval for local implementation and read-only live verification. Publishing, committing, or bypassing publisher access controls remains unauthorized.
+
+## Work Packets
+
+1. Core result/source contracts: archive members, registry metadata, plugin protocol.
+2. Safe archive inspection and downloader extraction.
+3. CSS discovery and URL safety boundary.
+4. GitHub tree/release discovery and adaptive query planner.
+5. Structured registry providers.
+6. Plugin loading, process isolation, and validation.
+7. Integration, docs, live corpus, security audit, and full verification.
+
+## Integration Policy
+
+Add the smallest shared contracts first. Providers may emit only results that the downloader can validate. Merge by canonical direct source plus archive member. Exact family relevance stays above discovery breadth and completeness scoring.
+
+## Verification
+
+- Focused unit tests for pure parsers and safety limits.
+- `httptest` integration tests for HTTP/provider boundaries.
+- Real subprocess fixture for plugins.
+- `go test -race ./...`, `go vet ./...`, and `npm run verify`.
+- Live searches covering common, obscure, archive-distributed, CSS-hosted, and legacy fonts.
+
+## Reusable Artifacts
+
+Document the source-plugin protocol and provider safety contract under the existing docs reference tree.

--- a/.workflow/direct-font-discovery-expansion/results/integrated-result.md
+++ b/.workflow/direct-font-discovery-expansion/results/integrated-result.md
@@ -1,0 +1,6 @@
+# Integrated result
+
+All seven packets were integrated in the shared working copy. The final report
+records accepted and rejected result classes, verification evidence, live
+corpus outcomes, and remaining public-availability constraints.
+

--- a/.workflow/direct-font-discovery-expansion/state.json
+++ b/.workflow/direct-font-discovery-expansion/state.json
@@ -1,0 +1,30 @@
+{
+  "title": "Direct font discovery expansion",
+  "slug": "direct-font-discovery-expansion",
+  "created_at": "2026-07-11T15:08:23+00:00",
+  "status": "completed",
+  "approval": {
+    "required": false,
+    "granted": true,
+    "notes": "User explicitly requested the local implementation goal. External publishing remains out of scope."
+  },
+  "packets": [
+    {"id":"contracts","status":"completed"},
+    {"id":"archives","status":"completed"},
+    {"id":"css","status":"completed"},
+    {"id":"github-adaptive","status":"completed"},
+    {"id":"registries","status":"completed"},
+    {"id":"plugins","status":"completed"},
+    {"id":"integration","status":"completed"}
+  ],
+  "verification": {
+    "status": "completed",
+    "checks": [
+      "focused unit and integration tests",
+      "uncached race suite",
+      "go vet",
+      "npm run verify",
+      "live no-Kagi corpus"
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -57,9 +57,16 @@ moji get "Inter entire family" --download-dir ~/Downloads/moji
 
 ## providers
 
-the default GetFonts provider works without an account. GitHub Code Search
-requires authentication, so `moji` activates it only when `GITHUB_TOKEN` or
-`github_token` is configured.
+the default GetFonts and registry providers work without an account. GitHub's
+repository, tree, and release search also uses its small unauthenticated
+allowance. set `GITHUB_TOKEN` or `github_token` to add Code Search and higher
+limits. the TUI points this out when GitHub search is limited.
+
+the `websearch` provider automatically uses
+[`kagi-cli`](https://github.com/Microck/kagi-cli) when it is installed. Run
+`kagi auth` once. Ordinary web pages are ignored. direct CSS font URLs and
+bounded ZIP or TAR archive members can become results. configured source
+plugins pass through the same HTTPS, format, and download validation boundary.
 
 ```bash
 export GITHUB_TOKEN=github_pat_example
@@ -69,8 +76,8 @@ moji "Inter" --provider github
 do not pass tokens as command-line flags. use `--token-stdin` when a token only
 needs to exist for one invocation.
 
-SearXNG search is also available, but it stays disabled until both the provider
-and an instance URL are configured.
+the same `websearch` provider also uses SearXNG when an instance URL is
+configured.
 
 ## commands
 
@@ -105,15 +112,18 @@ the default config lives at `~/.moji/config.yaml` and is written with mode
 download_dir: ~/Downloads/moji
 search_timeout_seconds: 15
 cache_ttl_seconds: 3600
-default_formats: [otf, ttf, woff2]
+default_formats: [otf, ttf, woff2, dfont, pfb, pfm]
+source_plugins: []
 
 providers:
   github:
     enabled: true
   getfonts:
     enabled: true
+  registry:
+    enabled: true
   websearch:
-    enabled: false
+    enabled: true
     instance: ""
 ```
 

--- a/docs/content/docs/explanation/ranking-and-families.mdx
+++ b/docs/content/docs/explanation/ranking-and-families.mdx
@@ -12,18 +12,23 @@ SourceSans-SemiBoldItalic.woff2
 Inter[wght].ttf
 ```
 
-Moji splits camel case, replaces filename separators, removes variable-font
-markers, and recognizes common weight and italic suffixes. This produces a
-canonical family name and tags without changing the original filename.
+Moji splits camel case, replaces filename separators, records variable-font
+markers, and recognizes common weight, italic, and foundry-style abbreviations.
+This produces a canonical family name and tags without changing the original
+filename.
+
+JSON keeps the underlying `format` and exposes `variable: true`. Human output
+labels the same file as `TTF-VAR` or `OTF-VAR`.
 
 ## Score components
 
 The score combines:
 
-- format preference: OTF, then TTF, WOFF2, and WOFF;
+- format preference: OTF, TTF, DFONT, PFB, WOFF2, WOFF, then PFM;
 - the number of weights found for a family at one source;
 - a trust boost when a provider can establish trust;
-- a requested-weight match; and
+- a requested-weight match;
+- a variable-font bonus; and
 - a penalty for suspiciously small files.
 
 Ranking weights are configurable because a desktop design workflow and a web

--- a/docs/content/docs/how-to/automate-with-json.mdx
+++ b/docs/content/docs/how-to/automate-with-json.mdx
@@ -15,6 +15,7 @@ Search output is an array of result objects. Each object includes:
 - `size_bytes` when known
 - `source` and the direct `url`
 - `trusted` and the best-effort `license` hint
+- `archive_format` and `archive_member` when the font is inside an archive
 - the calculated `score`
 
 ## Select a field with jq

--- a/docs/content/docs/how-to/search-and-filter.mdx
+++ b/docs/content/docs/how-to/search-and-filter.mdx
@@ -15,8 +15,10 @@ moji "Source Sans" --format otf,ttf
 moji "Source Sans" --format woff2
 ```
 
-Supported values are `otf`, `ttf`, `woff`, and `woff2`. Moji rejects other
-values before starting a provider request.
+Supported values are `otf`, `ttf`, `woff`, `woff2`, `dfont`, `pfb`, and `pfm`.
+Moji rejects other values before starting a provider request. PFM is a metrics
+companion for a Type 1 PFB font, so family mode is the useful way to retrieve
+both files together.
 
 ## Select a weight
 
@@ -37,10 +39,12 @@ Use a comma-separated provider list:
 ```sh
 moji "Inter" --provider getfonts
 moji "Inter" --provider github,getfonts
+moji "Inter" --provider registry,websearch
 ```
 
 GitHub search appears only when a token is configured. SearXNG web search
-appears only when it is enabled with an instance URL.
+appears only when it is enabled with an instance URL. The `plugins` provider
+appears only when at least one executable is listed in `source_plugins`.
 
 ## Limit output
 

--- a/docs/content/docs/reference/cli.mdx
+++ b/docs/content/docs/reference/cli.mdx
@@ -48,10 +48,10 @@ Delete cached provider responses and recreate the cache directory.
 
 | Flag | Short | Default | Meaning |
 | --- | --- | --- | --- |
-| `--format <list>` | `-f` | config default | Comma-separated `otf`, `ttf`, `woff`, or `woff2` |
+| `--format <list>` | `-f` | config default | Comma-separated `otf`, `ttf`, `woff`, `woff2`, `dfont`, `pfb`, or `pfm` |
 | `--weight <name>` | `-w` | any | Keep only a normalized font weight |
 | `--max <count>` | `-n` | all in TUI / 10 output / 1 get | Maximum results or downloads |
-| `--provider <list>` | | all enabled | Comma-separated `github`, `getfonts`, or configured `websearch` |
+| `--provider <list>` | | all enabled | Comma-separated `github`, `getfonts`, `registry`, `plugins`, or `websearch` |
 | `--json` | | off | Print machine-readable JSON |
 | `--dry-run` | | off | Preview a `get` selection without downloading |
 | `--download-dir <path>` | `-d` | `~/Downloads/moji` | Download destination |

--- a/docs/content/docs/reference/configuration.mdx
+++ b/docs/content/docs/reference/configuration.mdx
@@ -18,14 +18,16 @@ download_dir: ~/Downloads/moji
 github_token: ""
 search_timeout_seconds: 15
 cache_ttl_seconds: 3600
-default_formats: [otf, ttf, woff2]
+default_formats: [otf, ttf, woff2, dfont, pfb, pfm]
+source_plugins: []
 
 ranking:
   format: 3.0
-  family_size: 2.0
+  family_size: 4.0
   trusted: 1.5
   size_penalty: 0.5
   weight_bonus: 2.0
+  variable_bonus: 1.5
 
 rate_limits:
   github:
@@ -34,6 +36,12 @@ rate_limits:
   getfonts:
     timeout_seconds: 15
     retries: 1
+  registry:
+    timeout_seconds: 15
+    retries: 1
+  plugins:
+    timeout_seconds: 20
+    retries: 0
   websearch:
     timeout_seconds: 20
     retries: 0
@@ -43,8 +51,12 @@ providers:
     enabled: true
   getfonts:
     enabled: true
+  registry:
+    enabled: true
+  plugins:
+    enabled: true
   websearch:
-    enabled: false
+    enabled: true
     instance: ""
 ```
 
@@ -56,7 +68,8 @@ providers:
 | `github_token` | string | empty | GitHub Code Search token |
 | `search_timeout_seconds` | positive integer | 15 | Overall search deadline |
 | `cache_ttl_seconds` | non-negative integer | 3600 | Cache lifetime; `0` disables cache hits |
-| `default_formats` | string array | OTF, TTF, WOFF2 | Formats used without `--format` |
+| `default_formats` | string array | OTF, TTF, WOFF2, DFONT, PFB, PFM | Formats used without `--format` |
+| `source_plugins` | string array | empty | Executable paths implementing the source plugin protocol |
 | `ranking` | mapping | shown above | Relative score weights |
 | `rate_limits` | mapping | shown above | Per-provider timeout and retry count |
 | `providers` | mapping | shown above | Provider enablement and optional instance |

--- a/docs/content/docs/reference/meta.json
+++ b/docs/content/docs/reference/meta.json
@@ -1,5 +1,5 @@
 {
   "title": "Reference",
   "icon": "BookOpen",
-  "pages": ["cli", "configuration", "providers", "errors-and-exit-codes"]
+  "pages": ["cli", "configuration", "providers", "source-plugins", "errors-and-exit-codes"]
 }

--- a/docs/content/docs/reference/providers.mdx
+++ b/docs/content/docs/reference/providers.mdx
@@ -17,25 +17,70 @@ GetFonts is the zero-configuration default.
 ## GitHub
 
 - Name: `github`
-- Default: enabled when configured
-- Authentication: required
+- Default: enabled
+- Authentication: optional; required for Code Search
 - Token sources: `GITHUB_TOKEN`, config, or `--token-stdin`
-- Queries: one GitHub Code Search request per selected format
+- Queries: one filename-variant request, then at most one broad extension fallback
 - Result trust: untrusted
 
-GitHub is not added to the active provider set without a token or custom
-endpoint. This prevents predictable unauthenticated failures.
+GitHub's general unauthenticated REST allowance does not unlock Code Search;
+the Code Search endpoint returns `Requires authentication`. Without a token,
+Moji skips that guaranteed failure and uses its bounded repository, tree, and
+release search. The TUI home screen explains that `GITHUB_TOKEN` enables code
+search and higher limits.
+
+The filename request covers compact, hyphenated, underscored, lowercase, and
+quoted exact-extension forms. Selected formats are still validated locally.
+When both code queries miss, Moji inspects at most two matching repositories.
+For each repository it reads one recursive tree and up to three releases. Tree
+files use raw GitHub URLs; release results must be direct font or supported
+archive assets.
+
+## Registry
+
+- Name: `registry`
+- Default: enabled
+- Backends: Fontsource metadata and Google Fonts CSS2
+- Authentication: none
+- Result trust: trusted catalog metadata
+
+Registry searches use structured endpoints rather than general webpages.
+Fontsource supplies direct variant URLs. Google Fonts supplies direct WOFF or
+WOFF2 URLs from its generated stylesheet. A missing family is an empty result,
+not a provider failure.
 
 ## Web search
 
 - Name: `websearch`
-- Default: disabled
-- Engine: SearXNG JSON search
+- Default: enabled when `kagi-cli` is installed or SearXNG is configured
+- Backends: auto-detected Kagi CLI and optional SearXNG JSON search
 - Configuration: `providers.websearch.instance`
 - Result policy: only direct links with a selected font extension
 - Result trust: untrusted
 
-Web search is registered only when enabled and given an instance URL.
+Kagi authentication is managed by `kagi-cli`; run `kagi auth`. Its backend
+runs one structured search and converts GitHub blob links to HTTPS raw-file
+URLs. Ordinary pages are discarded.
+
+The SearXNG backend runs six bounded queries concurrently: quoted TTF and OTF
+filenames, a VK-scoped query, an index-of query covering configured formats,
+GitHub title query, and CSS `@font-face` query. Direct ZIP, TAR, and compressed
+TAR results are inspected within fixed entry and expanded-size limits. Both
+backends run concurrently and merge by direct URL plus archive member. A
+failure in one backend does not discard results from the other.
+
+## Source plugins
+
+- Name: `plugins`
+- Default: enabled when `source_plugins` contains an executable
+- Configuration: `source_plugins`
+- Protocol: versioned JSON over stdin and stdout
+- Result trust: supplied per result, default false
+
+Plugins extend discovery without extending Moji's download trust boundary.
+Moji accepts only direct HTTPS URLs for configured formats, CSS files that
+resolve to such URLs, or supported archives with safe font members. See the
+[source plugin protocol](./source-plugins).
 
 ## Partial failure
 

--- a/docs/content/docs/reference/source-plugins.mdx
+++ b/docs/content/docs/reference/source-plugins.mdx
@@ -1,0 +1,62 @@
+---
+title: Source plugin protocol
+description: Add direct font discovery sources with a local executable.
+---
+
+A source plugin is an executable listed in `source_plugins`. Moji starts each
+configured executable once per adaptive search round, writes one JSON request
+to stdin, and reads one JSON response from stdout. Diagnostics belong on
+stderr.
+
+## Request
+
+```json
+{
+  "version": 1,
+  "query": "Silka Mono",
+  "formats": ["otf", "ttf", "woff2"]
+}
+```
+
+Version `1` has three fields: the protocol version, the current query variant,
+and the formats accepted by the user.
+
+## Response
+
+```json
+{
+  "version": 1,
+  "results": [
+    {
+      "url": "https://cdn.example/SilkaMono-Regular.otf",
+      "license": "OFL-1.1",
+      "trusted": true
+    }
+  ]
+}
+```
+
+The response `version` must be `1`. Within each result, only `url` is required.
+`license` is metadata, not a grant of permission.
+`trusted` defaults to false and should be true only when the plugin can vouch
+for the file source.
+
+Moji discards webpages, unsupported formats, non-HTTPS URLs, and malformed
+results. CSS and supported archive URLs pass through the same bounded
+discovery and extraction code as built-in providers. Plugin output is limited
+to 2 MiB. A failed plugin does not discard results from another configured
+plugin.
+
+## Configuration
+
+```yaml
+source_plugins:
+  - /home/me/.local/bin/my-font-source
+
+providers:
+  plugins:
+    enabled: true
+```
+
+Plugin executables are trusted local code and run with Moji's environment and
+user permissions. Configure only executables you have inspected and trust.

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -58,7 +58,7 @@ func TestMojiBinaryEndToEnd(t *testing.T) {
 
 	configPath := filepath.Join(root, "config.yaml")
 	downloadDirectory := filepath.Join(root, "downloads")
-	configBody := fmt.Sprintf("download_dir: %s\nsearch_timeout_seconds: 2\ncache_ttl_seconds: 60\ndefault_formats: [otf]\nproviders:\n  github:\n    enabled: false\n  getfonts:\n    enabled: true\n    instance: %s\n  websearch:\n    enabled: false\n", downloadDirectory, server.URL+"/api/search")
+	configBody := fmt.Sprintf("download_dir: %s\nsearch_timeout_seconds: 2\ncache_ttl_seconds: 60\ndefault_formats: [otf]\nproviders:\n  github:\n    enabled: false\n  getfonts:\n    enabled: true\n    instance: %s\n  registry:\n    enabled: false\n  websearch:\n    enabled: false\n", downloadDirectory, server.URL+"/api/search")
 	if err := os.WriteFile(configPath, []byte(configBody), 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -77,11 +77,11 @@ func TestMojiBinaryEndToEnd(t *testing.T) {
 		t.Fatalf("non-interactive default returned %d results, want 10: %s", count, searchOutput)
 	}
 
-	interactiveOutput := runTUI(t, binary, []string{"MojiFixture", "--no-cache"}, environment, nil, "MojiFixture-Regular.otf")
+	interactiveOutput := runTUI(t, binary, []string{"MojiFixture", "--no-cache"}, environment, nil, "Found 12 results")
 	if !bytes.Contains(interactiveOutput, []byte("Found 12 results")) || !bytes.Contains(interactiveOutput, []byte("MojiFixture-Regular.otf")) {
 		t.Fatalf("TUI did not render fixture result: %q", interactiveOutput)
 	}
-	homeOutput := runTUI(t, binary, nil, environment, []byte("MojiFixture\r"), "MojiFixture-Regular.otf")
+	homeOutput := runTUI(t, binary, nil, environment, []byte("MojiFixture\r"), "Found 12 results")
 	if !bytes.Contains(homeOutput, []byte("Type a font name")) || !bytes.Contains(homeOutput, []byte("Found 12 results")) {
 		t.Fatalf("home TUI did not transition to results: %q", homeOutput)
 	}

--- a/internal/aggregator/aggregator.go
+++ b/internal/aggregator/aggregator.go
@@ -64,8 +64,11 @@ func (a Aggregator) searchProvider(ctx context.Context, source provider.Provider
 		for {
 			select {
 			case event := <-attemptOut:
-				if event.Status == provider.StateThrottled && event.RetryAfter > 0 {
-					providerRetryAfter = event.RetryAfter
+				if event.Type == provider.EventStatus && event.Status == provider.StateThrottled {
+					if event.RetryAfter > 0 {
+						providerRetryAfter = event.RetryAfter
+					}
+					continue
 				}
 				if event.Type == provider.EventResult {
 					count++
@@ -87,7 +90,7 @@ func (a Aggregator) searchProvider(ctx context.Context, source provider.Provider
 			emit(ctx, out, provider.Event{Provider: name, Type: provider.EventStatus, Status: provider.StateDone, Count: count})
 			return
 		}
-		if errors.Is(searchErr, provider.ErrBlocked) || errors.Is(searchErr, context.Canceled) || attempt == policy.Retries {
+		if errors.Is(searchErr, provider.ErrBlocked) || errors.Is(searchErr, provider.ErrNonRetryable) || errors.Is(searchErr, context.Canceled) || attempt == policy.Retries {
 			emit(ctx, out, provider.Event{Provider: name, Type: provider.EventStatus, Status: provider.StateFailed, Err: searchErr, Count: count})
 			return
 		}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -126,7 +126,7 @@ func (application App) Run(ctx context.Context, args []string) int {
 	if parsed.weight != "" {
 		results = rank.FilterWeight(results, strings.ToLower(parsed.weight))
 	}
-	results = rank.Results(results, strings.ToLower(parsed.weight), current.Ranking)
+	results = rank.Results(results, query, strings.ToLower(parsed.weight), current.Ranking)
 	if getMode && intent.WantFamily {
 		results = rank.SelectFamily(results, parsed.max)
 	}

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -25,7 +25,7 @@ func TestRunSearchJSONAndGetDownload(t *testing.T) {
 
 	root := t.TempDir()
 	configPath := filepath.Join(root, "config.yaml")
-	configBody := fmt.Sprintf("download_dir: %s\nsearch_timeout_seconds: 2\ncache_ttl_seconds: 60\ndefault_formats: [otf]\nproviders:\n  github:\n    enabled: false\n  getfonts:\n    enabled: true\n    instance: %s\n  websearch:\n    enabled: false\n", filepath.Join(root, "fonts"), server.URL)
+	configBody := fmt.Sprintf("download_dir: %s\nsearch_timeout_seconds: 2\ncache_ttl_seconds: 60\ndefault_formats: [otf]\nproviders:\n  github:\n    enabled: false\n  getfonts:\n    enabled: true\n    instance: %s\n  registry:\n    enabled: false\n  websearch:\n    enabled: false\n", filepath.Join(root, "fonts"), server.URL)
 	if err := os.WriteFile(configPath, []byte(configBody), 0o600); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/app/output.go
+++ b/internal/app/output.go
@@ -33,7 +33,11 @@ func (application App) writeTable(results []provider.Result) {
 		if weight == "" {
 			weight = "-"
 		}
-		fmt.Fprintf(writer, "%d\t%s\t%s\t%s\t%s\t%s\n", index+1, strings.ToUpper(result.Format), weight, result.Source, formatSize(result.SizeBytes), result.License)
+		format := strings.ToUpper(result.Format)
+		if result.Variable {
+			format += "-VAR"
+		}
+		fmt.Fprintf(writer, "%d\t%s\t%s\t%s\t%s\t%s\n", index+1, format, weight, result.Source, formatSize(result.SizeBytes), result.License)
 	}
 	writer.Flush()
 }
@@ -98,10 +102,10 @@ Examples:
   moji get "Inter bold" --download-dir ~/Downloads/moji
 
 Flags:
-  -f, --format <list>                  otf, ttf, woff, woff2
+  -f, --format <list>                  otf, ttf, woff, woff2, dfont, pfb, pfm
   -w, --weight <name>                  Filter by font weight
   -n, --max <count>                    Maximum results or downloads
-      --provider <list>                github,getfonts
+--provider <list>                github,getfonts,registry,plugins,websearch
       --json                           Machine-readable output
       --dry-run                        Preview get downloads
   -d, --download-dir <path>            Download destination

--- a/internal/app/search.go
+++ b/internal/app/search.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os/exec"
 	"sort"
 	"strings"
 	"time"
@@ -13,6 +14,7 @@ import (
 	"github.com/microck/moji/internal/config"
 	"github.com/microck/moji/internal/download"
 	"github.com/microck/moji/internal/provider"
+	"github.com/microck/moji/internal/rank"
 	"github.com/microck/moji/internal/tui"
 )
 
@@ -22,23 +24,32 @@ func (application App) search(ctx context.Context, current config.Config, query 
 		return nil, nil, err
 	}
 	results := make([]provider.Result, 0)
-	failures := make([]string, 0)
+	completed := make(map[string]bool)
+	failuresByProvider := make(map[string]string)
 	started := time.Now()
 	for event := range events {
 		if event.Type == provider.EventResult {
 			results = append(results, event.Result)
+		} else if event.Status == provider.StateDone {
+			completed[event.Provider] = true
+			delete(failuresByProvider, event.Provider)
 		} else if event.Status == provider.StateFailed {
-			failures = append(failures, provider.DescribeFailure(event.Provider, event.Err))
+			failuresByProvider[event.Provider] = provider.DescribeFailure(event.Provider, event.Err)
 		}
 		if parsed.debug {
 			fmt.Fprintf(application.Stderr, "debug: provider=%s state=%d count=%d retry_after=%s\n", event.Provider, event.Status, event.Count, event.RetryAfter)
 		}
 	}
 	results = provider.UniqueResults(results)
+	failures := make([]string, 0, len(failuresByProvider))
+	for _, failure := range failuresByProvider {
+		failures = append(failures, failure)
+	}
+	sort.Strings(failures)
 	if parsed.verbose {
 		fmt.Fprintf(application.Stderr, "searched %d providers in %s; %d unique results\n", providerCount, time.Since(started).Round(time.Millisecond), len(results))
 	}
-	if len(results) == 0 && len(failures) == providerCount {
+	if len(results) == 0 && len(completed) == 0 {
 		return nil, failures, fmt.Errorf("no providers could complete the search. %s. Check your connection and provider settings, then try again", strings.Join(failures, "; "))
 	}
 	return results, failures, nil
@@ -52,13 +63,21 @@ func (application App) searchEvents(ctx context.Context, current config.Config, 
 	store := cache.Store{Directory: cacheDirectory, TTL: time.Duration(current.CacheTTLSeconds) * time.Second}
 	available := map[string]provider.Provider{
 		"getfonts": provider.GetFonts{Client: application.Client, Endpoint: current.Providers["getfonts"].Instance},
+		"registry": provider.RegistrySearch{
+			Fontsource:  provider.Fontsource{Client: application.Client},
+			GoogleFonts: provider.GoogleFonts{Client: application.Client},
+		},
+	}
+	if len(current.SourcePlugins) > 0 {
+		available["plugins"] = provider.PluginSearch{Client: application.Client, Paths: current.SourcePlugins}
 	}
 	githubSettings := current.Providers["github"]
-	if token := current.Token(); token != "" || githubSettings.Instance != "" {
-		available["github"] = provider.GitHub{Client: application.Client, Endpoint: githubSettings.Instance, Token: token}
-	}
-	if web := current.Providers["websearch"]; web.Enabled && web.Instance != "" {
-		available["websearch"] = provider.WebSearch{Client: application.Client, Instance: web.Instance}
+	available["github"] = provider.GitHub{Client: application.Client, Endpoint: githubSettings.Instance, Token: current.Token()}
+	if web := current.Providers["websearch"]; web.Enabled {
+		executable, _ := exec.LookPath("kagi")
+		if web.Instance != "" || executable != "" {
+			available["websearch"] = provider.WebSearch{Client: application.Client, Instance: web.Instance, KagiExecutable: executable}
+		}
 	}
 	selected, err := selectProviders(available, current, parsed.providers)
 	if err != nil {
@@ -70,13 +89,27 @@ func (application App) searchEvents(ctx context.Context, current config.Config, 
 	}
 	searchCtx, cancel := context.WithTimeout(ctx, time.Duration(current.SearchTimeoutSeconds)*time.Second)
 	aggregate := aggregator.Aggregator{Providers: cached, Policies: current.Policies()}
-	sourceEvents := aggregate.Search(searchCtx, query, formats)
 	events := make(chan provider.Event)
 	go func() {
 		defer close(events)
 		defer cancel()
-		for event := range sourceEvents {
-			events <- event
+		forward := func(searchQuery string) (relevantCount, completedCount int) {
+			for event := range aggregate.Search(searchCtx, searchQuery, formats) {
+				if event.Type == provider.EventResult && rank.Relevance(event.Result, searchQuery) > 0 {
+					relevantCount++
+				}
+				if event.Type == provider.EventStatus && event.Status == provider.StateDone {
+					completedCount++
+				}
+				events <- event
+			}
+			return relevantCount, completedCount
+		}
+		for _, searchQuery := range rank.AdaptiveQueries(query) {
+			resultCount, completedCount := forward(searchQuery)
+			if resultCount > 0 || completedCount == 0 {
+				break
+			}
 		}
 	}()
 	return events, len(selected), nil
@@ -87,7 +120,7 @@ func (application App) runInteractive(ctx context.Context, current config.Config
 	if err != nil {
 		return application.fail(err, 1)
 	}
-	model := tui.NewLiveModel(events, application.interactiveDownloader(ctx, parsed), colorEnabled(), strings.ToLower(parsed.weight), current.Ranking, parsed.max)
+	model := tui.NewLiveModel(events, application.interactiveDownloader(ctx, parsed), colorEnabled(), query, strings.ToLower(parsed.weight), current.Ranking, parsed.max)
 	if err := tui.Run(application.Stdin, application.Stdout, model); err != nil {
 		return application.fail(fmt.Errorf("interactive interface: %w", err), 1)
 	}
@@ -95,10 +128,17 @@ func (application App) runInteractive(ctx context.Context, current config.Config
 }
 
 func (application App) runHome(ctx context.Context, current config.Config, formats []string, parsed options) int {
+	homeHint := ""
+	github := current.Providers["github"]
+	if github.Enabled && current.Token() == "" && github.Instance == "" {
+		homeHint = "GitHub search is limited. Set GITHUB_TOKEN to search code and more repositories."
+	} else if !github.Enabled {
+		homeHint = "GitHub search is off. Enable it in the config to search more repositories."
+	}
 	model := tui.NewHomeModel(func(query string) (<-chan provider.Event, error) {
 		events, _, err := application.searchEvents(ctx, current, query, formats, parsed)
 		return events, err
-	}, application.interactiveDownloader(ctx, parsed), colorEnabled(), "", current.Ranking, parsed.max)
+	}, application.interactiveDownloader(ctx, parsed), colorEnabled(), "", current.Ranking, parsed.max, homeHint)
 	if err := tui.Run(application.Stdin, application.Stdout, model); err != nil {
 		return application.fail(fmt.Errorf("interactive interface: %w", err), 1)
 	}
@@ -134,12 +174,15 @@ func selectProviders(available map[string]provider.Provider, current config.Conf
 			if name == "github" {
 				return nil, errors.New("GitHub search isn't configured. Set GITHUB_TOKEN or github_token in the config file, then try again")
 			}
+			if name == "websearch" {
+				return nil, errors.New("web search isn't available. Install kagi-cli or configure a SearXNG instance, then try again")
+			}
 			return nil, fmt.Errorf("provider %q isn't configured. Enable it in the config file, then try again", name)
 		}
 		selected = append(selected, source)
 	}
 	if len(selected) == 0 {
-		return nil, errors.New("no search providers are enabled. Enable getfonts in the config file, then try again")
+		return nil, errors.New("no search providers are enabled. Enable at least one provider in the config file, then try again")
 	}
 	return selected, nil
 }
@@ -150,8 +193,8 @@ func validateProviderNames(value string) error {
 	}
 	for _, raw := range strings.Split(value, ",") {
 		name := strings.TrimSpace(strings.ToLower(raw))
-		if name != "github" && name != "getfonts" && name != "websearch" {
-			return fmt.Errorf("unknown provider %q (choose github, getfonts, or configured websearch)", name)
+		if name != "github" && name != "getfonts" && name != "registry" && name != "plugins" && name != "websearch" {
+			return fmt.Errorf("unknown provider %q (choose github, getfonts, registry, plugins, or websearch)", name)
 		}
 	}
 	return nil

--- a/internal/archivefont/archive.go
+++ b/internal/archivefont/archive.go
@@ -1,0 +1,192 @@
+package archivefont
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"fmt"
+	"io"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+type Limits struct {
+	MaxEntries      int
+	MaxMemberSize   int64
+	MaxExpandedSize int64
+}
+
+type Member struct {
+	Path   string
+	Format string
+	Size   int64
+}
+
+func DefaultLimits() Limits {
+	return Limits{MaxEntries: 2_000, MaxMemberSize: 50 << 20, MaxExpandedSize: 250 << 20}
+}
+
+func Inspect(content []byte, format string, allowed map[string]bool, limits Limits) ([]Member, error) {
+	if limits.MaxEntries <= 0 || limits.MaxMemberSize <= 0 || limits.MaxExpandedSize <= 0 {
+		limits = DefaultLimits()
+	}
+	switch strings.ToLower(format) {
+	case "zip":
+		reader, err := zip.NewReader(bytes.NewReader(content), int64(len(content)))
+		if err != nil {
+			return nil, fmt.Errorf("invalid ZIP archive: %w", err)
+		}
+		if len(reader.File) > limits.MaxEntries {
+			return nil, fmt.Errorf("archive has %d entries; limit is %d", len(reader.File), limits.MaxEntries)
+		}
+		members := make([]Member, 0)
+		var expanded int64
+		for _, file := range reader.File {
+			if !safePath(file.Name) || file.FileInfo().IsDir() {
+				continue
+			}
+			if file.UncompressedSize64 > uint64(limits.MaxMemberSize) {
+				return nil, errors.New("archive exceeds expanded-size safety limits")
+			}
+			size := int64(file.UncompressedSize64)
+			if size > limits.MaxExpandedSize-expanded {
+				return nil, errors.New("archive exceeds expanded-size safety limits")
+			}
+			expanded += size
+			if format := memberFormat(file.Name, allowed); format != "" {
+				members = append(members, Member{Path: file.Name, Format: format, Size: size})
+			}
+		}
+		return members, nil
+	case "tar", "tgz", "tar.gz":
+		return inspectTar(content, format, allowed, limits)
+	default:
+		return nil, fmt.Errorf("unsupported archive format %q", format)
+	}
+}
+
+func Extract(content []byte, format, memberPath string, limits Limits) ([]byte, error) {
+	allowed := map[string]bool{strings.TrimPrefix(strings.ToLower(filepath.Ext(memberPath)), "."): true}
+	members, err := Inspect(content, format, allowed, limits)
+	if err != nil {
+		return nil, err
+	}
+	found := false
+	for _, member := range members {
+		if member.Path == memberPath {
+			found = true
+			break
+		}
+	}
+	if !found {
+		return nil, fmt.Errorf("archive member %q is missing or unsafe", memberPath)
+	}
+	if strings.EqualFold(format, "zip") {
+		reader, _ := zip.NewReader(bytes.NewReader(content), int64(len(content)))
+		for _, file := range reader.File {
+			if file.Name == memberPath {
+				opened, err := file.Open()
+				if err != nil {
+					return nil, err
+				}
+				defer opened.Close()
+				return readBounded(opened, limits.MaxMemberSize)
+			}
+		}
+	}
+	reader, closer, err := tarReader(content, format)
+	if err != nil {
+		return nil, err
+	}
+	if closer != nil {
+		defer closer.Close()
+	}
+	for {
+		header, err := reader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+		if header.Name == memberPath {
+			return readBounded(reader, limits.MaxMemberSize)
+		}
+	}
+	return nil, fmt.Errorf("archive member %q was not found", memberPath)
+}
+
+func inspectTar(content []byte, format string, allowed map[string]bool, limits Limits) ([]Member, error) {
+	reader, closer, err := tarReader(content, format)
+	if err != nil {
+		return nil, err
+	}
+	if closer != nil {
+		defer closer.Close()
+	}
+	members := make([]Member, 0)
+	entries := 0
+	var expanded int64
+	for {
+		header, err := reader.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, fmt.Errorf("invalid TAR archive: %w", err)
+		}
+		entries++
+		if entries > limits.MaxEntries || header.Size < 0 || header.Size > limits.MaxMemberSize || header.Size > limits.MaxExpandedSize-expanded {
+			return nil, errors.New("archive exceeds entry or expanded-size safety limits")
+		}
+		expanded += header.Size
+		if header.Typeflag == tar.TypeReg && safePath(header.Name) {
+			if format := memberFormat(header.Name, allowed); format != "" {
+				members = append(members, Member{Path: header.Name, Format: format, Size: header.Size})
+			}
+		}
+	}
+	return members, nil
+}
+
+func tarReader(content []byte, format string) (*tar.Reader, io.Closer, error) {
+	reader := bytes.NewReader(content)
+	if strings.EqualFold(format, "tgz") || strings.EqualFold(format, "tar.gz") {
+		gzipReader, err := gzip.NewReader(reader)
+		if err != nil {
+			return nil, nil, fmt.Errorf("invalid gzip archive: %w", err)
+		}
+		return tar.NewReader(gzipReader), gzipReader, nil
+	}
+	return tar.NewReader(reader), nil, nil
+}
+
+func safePath(value string) bool {
+	if value == "" || strings.Contains(value, "\\") || strings.HasPrefix(value, "/") {
+		return false
+	}
+	cleaned := path.Clean(value)
+	return cleaned == value && cleaned != "." && !strings.HasPrefix(cleaned, "../")
+}
+
+func memberFormat(name string, allowed map[string]bool) string {
+	format := strings.TrimPrefix(strings.ToLower(filepath.Ext(name)), ".")
+	if allowed[format] {
+		return format
+	}
+	return ""
+}
+
+func readBounded(reader io.Reader, maximum int64) ([]byte, error) {
+	content, err := io.ReadAll(io.LimitReader(reader, maximum+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(content)) > maximum {
+		return nil, errors.New("archive member exceeds the size limit")
+	}
+	return content, nil
+}

--- a/internal/archivefont/archive_test.go
+++ b/internal/archivefont/archive_test.go
@@ -1,0 +1,92 @@
+package archivefont
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"io"
+	"testing"
+)
+
+func TestInspectAndExtractZIPFonts(t *testing.T) {
+	t.Parallel()
+	var content bytes.Buffer
+	writer := zip.NewWriter(&content)
+	font, _ := writer.Create("Family/Example-Regular.otf")
+	font.Write([]byte("OTTOfont"))
+	unsafe, _ := writer.Create("../escape.ttf")
+	unsafe.Write([]byte("ignored"))
+	writer.Close()
+	allowed := map[string]bool{"otf": true, "ttf": true}
+	members, err := Inspect(content.Bytes(), "zip", allowed, DefaultLimits())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(members) != 1 || members[0].Path != "Family/Example-Regular.otf" {
+		t.Fatalf("members = %#v", members)
+	}
+	extracted, err := Extract(content.Bytes(), "zip", members[0].Path, DefaultLimits())
+	if err != nil || string(extracted) != "OTTOfont" {
+		t.Fatalf("content=%q err=%v", extracted, err)
+	}
+}
+
+func TestInspectAndExtractTarFonts(t *testing.T) {
+	t.Parallel()
+	for _, format := range []string{"tar", "tgz"} {
+		format := format
+		t.Run(format, func(t *testing.T) {
+			var content bytes.Buffer
+			var destination io.Writer = &content
+			var gzipWriter *gzip.Writer
+			if format == "tgz" {
+				gzipWriter = gzip.NewWriter(&content)
+				destination = gzipWriter
+			}
+			writer := tar.NewWriter(destination)
+			fontContent := []byte("OTTOfont")
+			if err := writer.WriteHeader(&tar.Header{Name: "Family/Example-Regular.otf", Mode: 0o600, Size: int64(len(fontContent))}); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := writer.Write(fontContent); err != nil {
+				t.Fatal(err)
+			}
+			if err := writer.WriteHeader(&tar.Header{Name: "../escape.ttf", Mode: 0o600, Size: 0}); err != nil {
+				t.Fatal(err)
+			}
+			if err := writer.Close(); err != nil {
+				t.Fatal(err)
+			}
+			if gzipWriter != nil {
+				if err := gzipWriter.Close(); err != nil {
+					t.Fatal(err)
+				}
+			}
+			members, err := Inspect(content.Bytes(), format, map[string]bool{"otf": true, "ttf": true}, DefaultLimits())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(members) != 1 || members[0].Path != "Family/Example-Regular.otf" {
+				t.Fatalf("members = %#v", members)
+			}
+			extracted, err := Extract(content.Bytes(), format, members[0].Path, DefaultLimits())
+			if err != nil || !bytes.Equal(extracted, fontContent) {
+				t.Fatalf("content=%q err=%v", extracted, err)
+			}
+		})
+	}
+}
+
+func TestInspectRejectsExpandedArchiveLimit(t *testing.T) {
+	t.Parallel()
+	var content bytes.Buffer
+	writer := zip.NewWriter(&content)
+	font, _ := writer.Create("Example.ttf")
+	font.Write(make([]byte, 32))
+	writer.Close()
+	_, err := Inspect(content.Bytes(), "zip", map[string]bool{"ttf": true}, Limits{MaxEntries: 5, MaxMemberSize: 8, MaxExpandedSize: 16})
+	if err == nil {
+		t.Fatal("expected expanded-size rejection")
+	}
+}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -78,7 +78,7 @@ func DefaultDirectory() (string, error) {
 func (store Store) key(query, source string, formats []string) string {
 	ordered := append([]string(nil), formats...)
 	sort.Strings(ordered)
-	digest := sha256.Sum256([]byte(strings.ToLower(strings.TrimSpace(query)) + "\x00" + source + "\x00" + strings.Join(ordered, ",")))
+	digest := sha256.Sum256([]byte("v2\x00" + strings.ToLower(strings.TrimSpace(query)) + "\x00" + source + "\x00" + strings.Join(ordered, ",")))
 	return hex.EncodeToString(digest[:]) + ".json"
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	Ranking              rank.Weights               `yaml:"ranking"`
 	RateLimits           map[string]RateLimitConfig `yaml:"rate_limits"`
 	Providers            map[string]ProviderConfig  `yaml:"providers"`
+	SourcePlugins        []string                   `yaml:"source_plugins,omitempty"`
 }
 
 type RateLimitConfig struct {
@@ -39,15 +40,17 @@ func Default() Config {
 	return Config{
 		DownloadDir:          filepath.Join(home, "Downloads", "moji"),
 		SearchTimeoutSeconds: 15, CacheTTLSeconds: 3600,
-		DefaultFormats: []string{"otf", "ttf", "woff2"}, Ranking: rank.DefaultWeights(),
+		DefaultFormats: []string{"otf", "ttf", "woff2", "dfont", "pfb", "pfm"}, Ranking: rank.DefaultWeights(),
 		RateLimits: map[string]RateLimitConfig{
 			"github":    {TimeoutSeconds: 15, Retries: 2},
 			"getfonts":  {TimeoutSeconds: 15, Retries: 1},
+			"registry":  {TimeoutSeconds: 15, Retries: 1},
+			"plugins":   {TimeoutSeconds: 20, Retries: 0},
 			"websearch": {TimeoutSeconds: 20, Retries: 0},
 		},
 		Providers: map[string]ProviderConfig{
 			"github": {Enabled: true}, "getfonts": {Enabled: true},
-			"websearch": {Enabled: false},
+			"registry": {Enabled: true}, "plugins": {Enabled: true}, "websearch": {Enabled: true},
 		},
 	}
 }
@@ -122,14 +125,14 @@ func Save(path string, config Config) error {
 
 func ParseFormats(value string) ([]string, error) {
 	if strings.TrimSpace(value) == "" || strings.EqualFold(value, "all") {
-		return []string{"otf", "ttf", "woff", "woff2"}, nil
+		return []string{"otf", "ttf", "woff", "woff2", "dfont", "pfb", "pfm"}, nil
 	}
 	seen := make(map[string]bool)
 	formats := make([]string, 0, 4)
 	for _, raw := range strings.Split(value, ",") {
 		format := strings.ToLower(strings.TrimSpace(raw))
-		if format != "otf" && format != "ttf" && format != "woff" && format != "woff2" {
-			return nil, fmt.Errorf("unsupported format %q (choose otf, ttf, woff, or woff2)", raw)
+		if format != "otf" && format != "ttf" && format != "woff" && format != "woff2" && format != "dfont" && format != "pfb" && format != "pfm" {
+			return nil, fmt.Errorf("unsupported format %q (choose otf, ttf, woff, woff2, dfont, pfb, or pfm)", raw)
 		}
 		if !seen[format] {
 			seen[format] = true

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -44,6 +44,10 @@ func TestParseFormats(t *testing.T) {
 	if _, err := ParseFormats("exe"); err == nil {
 		t.Fatal("expected unsupported format error")
 	}
+	legacy, err := ParseFormats("dfont,pfb,pfm")
+	if err != nil || !reflect.DeepEqual(legacy, []string{"dfont", "pfb", "pfm"}) {
+		t.Fatalf("legacy formats = %#v, err=%v", legacy, err)
+	}
 }
 
 func TestEnvironmentTokenPrecedesConfig(t *testing.T) {

--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -1,8 +1,10 @@
 package download
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
+	"encoding/binary"
 	"encoding/hex"
 	"errors"
 	"fmt"
@@ -13,6 +15,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/microck/moji/internal/archivefont"
 	"github.com/microck/moji/internal/provider"
 )
 
@@ -76,6 +79,21 @@ func (d Downloader) Download(ctx context.Context, result provider.Result, destin
 	if response.ContentLength > limit {
 		return File{}, fmt.Errorf("the font is larger than the %d-byte safety limit, so no file was saved. Try another result", limit)
 	}
+	contentReader := io.Reader(response.Body)
+	if result.ArchiveMember != "" {
+		archive, readErr := io.ReadAll(io.LimitReader(response.Body, limit+1))
+		if readErr != nil {
+			return File{}, fmt.Errorf("the archive download stopped before it completed: %w. No file was saved", readErr)
+		}
+		if int64(len(archive)) > limit {
+			return File{}, fmt.Errorf("the archive is larger than the %d-byte safety limit, so no file was saved", limit)
+		}
+		member, extractErr := archivefont.Extract(archive, result.ArchiveFormat, result.ArchiveMember, archivefont.DefaultLimits())
+		if extractErr != nil {
+			return File{}, fmt.Errorf("Moji couldn't safely extract %s: %w. No file was saved", result.ArchiveMember, extractErr)
+		}
+		contentReader = bytes.NewReader(member)
+	}
 	if err := os.MkdirAll(destination, 0o755); err != nil {
 		return File{}, fmt.Errorf("Moji couldn't create the download directory %s: %w. Check the directory permissions, then try again", destination, err)
 	}
@@ -90,7 +108,7 @@ func (d Downloader) Download(ctx context.Context, result provider.Result, destin
 	temporaryPath := temporary.Name()
 	defer os.Remove(temporaryPath)
 	hash := sha256.New()
-	written, copyErr := io.Copy(io.MultiWriter(temporary, hash), io.LimitReader(response.Body, limit+1))
+	written, copyErr := io.Copy(io.MultiWriter(temporary, hash), io.LimitReader(contentReader, limit+1))
 	closeErr := temporary.Close()
 	if copyErr != nil {
 		return File{}, fmt.Errorf("the download stopped before it completed: %w. No font was saved; check your connection and try again", copyErr)
@@ -156,13 +174,67 @@ func ValidateMagic(format string, content []byte) error {
 	}
 	magic := string(content[:4])
 	valid := map[string][]string{"otf": {"OTTO"}, "ttf": {"\x00\x01\x00\x00", "OTTO"}, "woff": {"wOFF"}, "woff2": {"wOF2"}}
-	for _, expected := range valid[strings.ToLower(format)] {
+	format = strings.ToLower(format)
+	switch format {
+	case "pfb":
+		if validatePFB(content) {
+			return nil
+		}
+		return errors.New("the downloaded content is not a valid pfb Type 1 font. No file was saved; try another source")
+	case "pfm":
+		if len(content) >= 117 && binary.LittleEndian.Uint16(content[:2]) == 0x0100 && int(binary.LittleEndian.Uint32(content[2:6])) == len(content) {
+			return nil
+		}
+		return errors.New("the downloaded content is not a valid pfm metrics file. No file was saved; try another source")
+	case "dfont":
+		if validateDFont(content) {
+			return nil
+		}
+		return errors.New("the downloaded content is not a valid dfont resource font. No file was saved; try another source")
+	}
+	for _, expected := range valid[format] {
 		if magic == expected {
 			return nil
 		}
 	}
-	if _, supported := valid[strings.ToLower(format)]; !supported {
-		return fmt.Errorf("Moji can't validate the %q font format. No file was saved; choose otf, ttf, woff, or woff2", format)
+	if _, supported := valid[format]; !supported {
+		return fmt.Errorf("Moji can't validate the %q font format. No file was saved; choose otf, ttf, woff, woff2, dfont, pfb, or pfm", format)
 	}
 	return fmt.Errorf("the downloaded content is not a valid %s font. No file was saved; try another source", format)
+}
+
+func validatePFB(content []byte) bool {
+	for offset := 0; offset+2 <= len(content); {
+		if content[offset] != 0x80 {
+			return false
+		}
+		kind := content[offset+1]
+		if kind == 0x03 {
+			return offset+2 == len(content)
+		}
+		if (kind != 0x01 && kind != 0x02) || offset+6 > len(content) {
+			return false
+		}
+		length := int(binary.LittleEndian.Uint32(content[offset+2 : offset+6]))
+		if length <= 0 || offset+6+length > len(content) {
+			return false
+		}
+		offset += 6 + length
+	}
+	return false
+}
+
+func validateDFont(content []byte) bool {
+	if len(content) < 16 {
+		return false
+	}
+	dataOffset := int(binary.BigEndian.Uint32(content[0:4]))
+	mapOffset := int(binary.BigEndian.Uint32(content[4:8]))
+	dataLength := int(binary.BigEndian.Uint32(content[8:12]))
+	mapLength := int(binary.BigEndian.Uint32(content[12:16]))
+	if dataOffset < 16 || mapOffset < 16 || dataLength <= 0 || mapLength <= 0 ||
+		dataOffset > len(content)-dataLength || mapOffset > len(content)-mapLength {
+		return false
+	}
+	return bytes.Contains(content[mapOffset:mapOffset+mapLength], []byte("sfnt"))
 }

--- a/internal/download/download_test.go
+++ b/internal/download/download_test.go
@@ -1,7 +1,10 @@
 package download
 
 import (
+	"archive/zip"
+	"bytes"
 	"context"
+	"encoding/binary"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -11,6 +14,53 @@ import (
 
 	"github.com/microck/moji/internal/provider"
 )
+
+func TestDownloadExtractsAndValidatesArchiveMember(t *testing.T) {
+	t.Parallel()
+	var archive bytes.Buffer
+	writer := zip.NewWriter(&archive)
+	member, _ := writer.Create("Family/Example-Regular.otf")
+	member.Write(append([]byte("OTTO"), make([]byte, 32)...))
+	writer.Close()
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		response.Write(archive.Bytes())
+	}))
+	defer server.Close()
+	destination := t.TempDir()
+	file, err := (Downloader{Client: server.Client()}).Download(context.Background(), provider.Result{
+		Filename: "Example-Regular.otf", Format: "otf", URL: server.URL, Source: "fixture",
+		ArchiveFormat: "zip", ArchiveMember: "Family/Example-Regular.otf",
+	}, destination)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content, err := os.ReadFile(file.Path)
+	if err != nil || string(content[:4]) != "OTTO" {
+		t.Fatalf("content=%x err=%v", content, err)
+	}
+}
+
+func TestValidateLegacyFontFormats(t *testing.T) {
+	t.Parallel()
+	pfb := []byte{0x80, 0x01, 0x04, 0x00, 0x00, 0x00, 'f', 'o', 'n', 't', 0x80, 0x03}
+	pfm := make([]byte, 117)
+	binary.LittleEndian.PutUint16(pfm[:2], 0x0100)
+	binary.LittleEndian.PutUint32(pfm[2:6], uint32(len(pfm)))
+	dfont := make([]byte, 64)
+	binary.BigEndian.PutUint32(dfont[0:4], 16)
+	binary.BigEndian.PutUint32(dfont[4:8], 24)
+	binary.BigEndian.PutUint32(dfont[8:12], 8)
+	binary.BigEndian.PutUint32(dfont[12:16], 40)
+	copy(dfont[32:], "sfnt")
+	for format, content := range map[string][]byte{"pfb": pfb, "pfm": pfm, "dfont": dfont} {
+		if err := ValidateMagic(format, content); err != nil {
+			t.Errorf("%s validation failed: %v", format, err)
+		}
+		if err := ValidateMagic(format, content[:len(content)-1]); err == nil {
+			t.Errorf("truncated %s passed validation", format)
+		}
+	}
+}
 
 func TestDownloadValidatesAndDeduplicates(t *testing.T) {
 	t.Parallel()

--- a/internal/provider/discovery.go
+++ b/internal/provider/discovery.go
@@ -1,0 +1,168 @@
+package provider
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/microck/moji/internal/archivefont"
+)
+
+const maxDiscoveryContainerSize int64 = 50 << 20
+
+const maxDiscoveryStylesheetSize int64 = 2 << 20
+
+var cssSource = regexp.MustCompile(`(?i)url\(\s*['"]?([^'")\s]+)['"]?\s*\)\s*(?:format\(\s*['"]?([a-z0-9-]+)['"]?\s*\))?`)
+
+func resolveDiscoveredURL(ctx context.Context, client *http.Client, rawURL, query string, allowed map[string]bool) ([]Result, error) {
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Scheme != "https" || parsed.Host == "" {
+		return nil, nil
+	}
+	if strings.EqualFold(parsed.Host, "github.com") {
+		if converted := githubRawURL(parsed); converted != nil {
+			parsed = converted
+			rawURL = converted.String()
+		}
+	}
+	filename := filepath.Base(parsed.Path)
+	format := strings.TrimPrefix(strings.ToLower(filepath.Ext(filename)), ".")
+	if allowed[format] {
+		return []Result{{
+			Name: query, Filename: filename, Format: format, Source: parsed.Host,
+			URL: rawURL, Trusted: false, License: "unknown",
+		}}, nil
+	}
+	if format == "css" {
+		content, fetchErr := fetchDiscoveryContent(ctx, client, rawURL, maxDiscoveryStylesheetSize)
+		if fetchErr != nil {
+			return nil, fetchErr
+		}
+		results := make([]Result, 0)
+		for _, match := range cssSource.FindAllSubmatch(content, -1) {
+			reference, parseErr := url.Parse(string(match[1]))
+			if parseErr != nil {
+				continue
+			}
+			resolved := parsed.ResolveReference(reference)
+			fontFormat := cssFontFormat(resolved.Path, string(match[2]))
+			if resolved.Scheme == "https" && resolved.Host != "" && allowed[fontFormat] {
+				results = append(results, Result{
+					Name: query, Filename: discoveredFilename(resolved.Path, query, fontFormat), Format: fontFormat,
+					Source: resolved.Host, URL: resolved.String(), Trusted: false, License: "unknown",
+				})
+			}
+		}
+		return results, nil
+	}
+	archiveFormat := discoveredArchiveFormat(parsed.Path)
+	if archiveFormat == "" {
+		return nil, nil
+	}
+	content, err := fetchDiscoveryContent(ctx, client, rawURL, maxDiscoveryContainerSize)
+	if err != nil {
+		return nil, err
+	}
+	members, err := archivefont.Inspect(content, archiveFormat, allowed, archivefont.DefaultLimits())
+	if err != nil {
+		return nil, err
+	}
+	results := make([]Result, 0, len(members))
+	for _, member := range members {
+		results = append(results, Result{
+			Name: query, Filename: filepath.Base(member.Path), Format: member.Format,
+			SizeBytes: member.Size, Source: parsed.Host, URL: rawURL,
+			Trusted: false, License: "unknown", ArchiveFormat: archiveFormat, ArchiveMember: member.Path,
+		})
+	}
+	return results, nil
+}
+
+func discoveredFilename(pathValue, query, format string) string {
+	filename := filepath.Base(pathValue)
+	if filename == "." || filename == "/" || filename == "" {
+		filename = strings.Join(strings.Fields(query), "-")
+	}
+	if filepath.Ext(filename) == "" {
+		filename += "." + format
+	}
+	return filename
+}
+
+func fetchDiscoveryContent(ctx context.Context, client *http.Client, rawURL string, maximum int64) ([]byte, error) {
+	if client == nil {
+		client = &http.Client{}
+	}
+	clientCopy := *client
+	originalRedirect := clientCopy.CheckRedirect
+	clientCopy.CheckRedirect = func(request *http.Request, via []*http.Request) error {
+		if request.URL.Scheme != "https" {
+			return errors.New("discovery redirected to an insecure URL")
+		}
+		if len(via) >= 5 {
+			return errors.New("discovery redirected more than 5 times")
+		}
+		if originalRedirect != nil {
+			return originalRedirect(request, via)
+		}
+		return nil
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	response, err := clientCopy.Do(request)
+	if err != nil {
+		return nil, fmt.Errorf("%w: discovery request: %v", ErrUnavailable, err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode < 200 || response.StatusCode >= 300 {
+		return nil, nil
+	}
+	if response.ContentLength > maximum {
+		return nil, errors.New("discovery response exceeds the size limit")
+	}
+	content, err := io.ReadAll(io.LimitReader(response.Body, maximum+1))
+	if err != nil {
+		return nil, err
+	}
+	if int64(len(content)) > maximum {
+		return nil, errors.New("discovery response exceeds the size limit")
+	}
+	return content, nil
+}
+
+func cssFontFormat(pathValue, declared string) string {
+	format := strings.TrimPrefix(strings.ToLower(filepath.Ext(pathValue)), ".")
+	if format != "" {
+		return format
+	}
+	switch strings.ToLower(declared) {
+	case "opentype":
+		return "otf"
+	case "truetype":
+		return "ttf"
+	default:
+		return strings.ToLower(declared)
+	}
+}
+
+func discoveredArchiveFormat(path string) string {
+	lower := strings.ToLower(path)
+	switch {
+	case strings.HasSuffix(lower, ".zip"):
+		return "zip"
+	case strings.HasSuffix(lower, ".tar.gz"), strings.HasSuffix(lower, ".tgz"):
+		return "tgz"
+	case strings.HasSuffix(lower, ".tar"):
+		return "tar"
+	default:
+		return ""
+	}
+}

--- a/internal/provider/discovery_test.go
+++ b/internal/provider/discovery_test.go
@@ -1,0 +1,85 @@
+package provider
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestResolveDiscoveredArchiveMembers(t *testing.T) {
+	t.Parallel()
+	var archive bytes.Buffer
+	writer := zip.NewWriter(&archive)
+	font, _ := writer.Create("Family/Example-Bold.otf")
+	font.Write([]byte("OTTOfont"))
+	writer.Close()
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		response.Write(archive.Bytes())
+	}))
+	defer server.Close()
+	results, err := resolveDiscoveredURL(context.Background(), server.Client(), server.URL+"/family.zip", "Example", map[string]bool{"otf": true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0].ArchiveMember != "Family/Example-Bold.otf" || results[0].Filename != "Example-Bold.otf" {
+		t.Fatalf("results = %#v", results)
+	}
+}
+
+func TestResolveDiscoveredStylesheetFonts(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		response.Write([]byte(`@font-face { src: url("../fonts/Example.woff2") format("woff2"); }`))
+	}))
+	defer server.Close()
+	results, err := resolveDiscoveredURL(context.Background(), server.Client(), server.URL+"/css/family.css", "Example", map[string]bool{"woff2": true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0].URL != server.URL+"/fonts/Example.woff2" {
+		t.Fatalf("results = %#v", results)
+	}
+}
+
+func TestResolveDiscoveredStylesheetUsesDeclaredFormatWithoutExtension(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		response.Write([]byte(`@font-face { src: url("/font?id=example") format("woff2"); }`))
+	}))
+	defer server.Close()
+	results, err := resolveDiscoveredURL(context.Background(), server.Client(), server.URL+"/family.css", "Example", map[string]bool{"woff2": true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0].Format != "woff2" || results[0].Filename != "font.woff2" {
+		t.Fatalf("results = %#v", results)
+	}
+}
+
+func TestDiscoveryRejectsInsecureRedirect(t *testing.T) {
+	t.Parallel()
+	insecure := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		response.Write([]byte("font"))
+	}))
+	defer insecure.Close()
+	secure := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		http.Redirect(response, request, insecure.URL+"/Example.woff2", http.StatusFound)
+	}))
+	defer secure.Close()
+	if _, err := fetchDiscoveryContent(context.Background(), secure.Client(), secure.URL+"/family.css", 1024); err == nil {
+		t.Fatal("expected insecure redirect rejection")
+	}
+}
+
+func TestResolveDiscoveredURLConvertsGitHubBlobToRaw(t *testing.T) {
+	results, err := resolveDiscoveredURL(context.Background(), nil, "https://github.com/acme/fonts/blob/main/Example.otf", "Example", map[string]bool{"otf": true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0].URL != "https://raw.githubusercontent.com/acme/fonts/main/Example.otf" {
+		t.Fatalf("results = %#v", results)
+	}
+}

--- a/internal/provider/github.go
+++ b/internal/provider/github.go
@@ -3,14 +3,21 @@ package provider
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/url"
 	"path/filepath"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
 )
+
+const maxGitHubResponseSize int64 = 20 << 20
+
+const maxGitHubTreeResults = 500
 
 type GitHub struct {
 	Client   *http.Client
@@ -32,6 +39,29 @@ type githubSearchResponse struct {
 	} `json:"items"`
 }
 
+type githubRepositorySearchResponse struct {
+	Items []struct {
+		FullName      string `json:"full_name"`
+		DefaultBranch string `json:"default_branch"`
+	} `json:"items"`
+}
+
+type githubTreeResponse struct {
+	Tree []struct {
+		Path string `json:"path"`
+		Type string `json:"type"`
+		Size int64  `json:"size"`
+	} `json:"tree"`
+}
+
+type githubRelease struct {
+	Assets []struct {
+		Name               string `json:"name"`
+		BrowserDownloadURL string `json:"browser_download_url"`
+		Size               int64  `json:"size"`
+	} `json:"assets"`
+}
+
 func (source GitHub) Search(ctx context.Context, query string, formats []string, out chan<- Event) error {
 	client := source.Client
 	if client == nil {
@@ -41,53 +71,259 @@ func (source GitHub) Search(ctx context.Context, query string, formats []string,
 	if endpoint == "" {
 		endpoint = "https://api.github.com/search/code"
 	}
+	allowed := make(map[string]bool, len(formats))
 	for _, format := range formats {
-		parameters := url.Values{"q": {fmt.Sprintf("%s extension:%s", query, format)}, "per_page": {"30"}}
-		request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+"?"+parameters.Encode(), nil)
+		allowed[strings.TrimPrefix(strings.ToLower(format), ".")] = true
+	}
+	// GitHub Code Search requires authentication. Repository search, trees, and
+	// releases retain a small unauthenticated allowance, so tokenless users skip
+	// directly to that bounded fallback instead of making a guaranteed 401 call.
+	useCodeSearch := source.Token != "" || source.Endpoint != ""
+	for _, searchQuery := range githubSearchQueries(query, formats) {
+		if !useCodeSearch {
+			break
+		}
+		payload, err := source.search(ctx, client, endpoint, searchQuery, out)
 		if err != nil {
 			return err
 		}
-		request.Header.Set("Accept", "application/vnd.github+json")
-		request.Header.Set("X-GitHub-Api-Version", "2022-11-28")
-		request.Header.Set("User-Agent", "moji-font-finder")
-		if source.Token != "" {
-			request.Header.Set("Authorization", "Bearer "+source.Token)
-		}
-		response, err := client.Do(request)
-		if err != nil {
-			return fmt.Errorf("%w: github request: %v", ErrUnavailable, err)
-		}
-		if response.StatusCode == http.StatusForbidden || response.StatusCode == http.StatusTooManyRequests {
-			retryAfter := parseRetryAfter(response.Header.Get("Retry-After"))
-			response.Body.Close()
-			out <- Event{Type: EventStatus, Status: StateThrottled, Err: ErrRateLimited, RetryAfter: retryAfter}
-			return ErrRateLimited
-		}
-		if response.StatusCode != http.StatusOK {
-			response.Body.Close()
-			return fmt.Errorf("%w: github returned HTTP %d", ErrBadResponse, response.StatusCode)
-		}
-		var payload githubSearchResponse
-		err = json.NewDecoder(response.Body).Decode(&payload)
-		response.Body.Close()
-		if err != nil {
-			return fmt.Errorf("%w: decode github response: %v", ErrBadResponse, err)
-		}
+		emitted := 0
 		for _, item := range payload.Items {
+			format := strings.TrimPrefix(strings.ToLower(filepath.Ext(item.Name)), ".")
+			if !allowed[format] {
+				continue
+			}
 			branch := item.Repository.DefaultBranch
 			if branch == "" {
 				branch = branchFromHTMLURL(item.HTMLURL)
 			}
-			rawURL := "https://raw.githubusercontent.com/" + item.Repository.FullName + "/" + branch + "/" + strings.TrimPrefix(item.Path, "/")
+			rawURL := githubRepositoryRawURL(item.Repository.FullName, branch, item.Path)
 			out <- Event{Type: EventResult, Result: Result{
-				Name: query, Filename: filepath.Base(item.Name),
-				Format: strings.TrimPrefix(strings.ToLower(filepath.Ext(item.Name)), "."),
+				Name: query, Filename: filepath.Base(item.Name), Format: format,
 				Source: "github.com/" + item.Repository.FullName, URL: rawURL,
 				Trusted: false, License: "unknown",
 			}}
+			emitted++
+		}
+		if emitted > 0 {
+			return nil
+		}
+	}
+	return source.searchRepositories(ctx, client, endpoint, query, allowed, out)
+}
+
+func (source GitHub) searchRepositories(ctx context.Context, client *http.Client, codeEndpoint, query string, allowed map[string]bool, out chan<- Event) error {
+	base, err := url.Parse(codeEndpoint)
+	if err != nil {
+		return err
+	}
+	base.Path = strings.TrimSuffix(base.Path, "/search/code")
+	searchURL := strings.TrimRight(base.String(), "/") + "/search/repositories"
+	var repositories githubRepositorySearchResponse
+	if err := source.getJSON(ctx, client, searchURL, url.Values{"q": {`"` + query + `" font`}, "per_page": {"2"}}, &repositories, out); err != nil {
+		return err
+	}
+	for _, repository := range repositories.Items {
+		branch := repository.DefaultBranch
+		if branch == "" {
+			branch = "HEAD"
+		}
+		apiRoot := strings.TrimRight(base.String(), "/") + "/repos/" + repository.FullName
+		var tree githubTreeResponse
+		treeErr := source.getJSON(ctx, client, apiRoot+"/git/trees/"+url.PathEscape(branch), url.Values{"recursive": {"1"}}, &tree, out)
+		if stopGitHubFallback(treeErr) {
+			return treeErr
+		}
+		if treeErr == nil {
+			emittedFromTree := 0
+			for _, item := range tree.Tree {
+				format := strings.TrimPrefix(strings.ToLower(filepath.Ext(item.Path)), ".")
+				if item.Type != "blob" || !allowed[format] {
+					continue
+				}
+				out <- Event{Type: EventResult, Result: Result{
+					Name: query, Filename: filepath.Base(item.Path), Format: format, SizeBytes: item.Size,
+					Source:  "github.com/" + repository.FullName,
+					URL:     githubRepositoryRawURL(repository.FullName, branch, item.Path),
+					Trusted: false, License: "unknown",
+				}}
+				emittedFromTree++
+				if emittedFromTree >= maxGitHubTreeResults {
+					break
+				}
+			}
+		}
+		var releases []githubRelease
+		releaseErr := source.getJSON(ctx, client, apiRoot+"/releases", url.Values{"per_page": {"3"}}, &releases, out)
+		if stopGitHubFallback(releaseErr) {
+			return releaseErr
+		}
+		if releaseErr != nil {
+			continue
+		}
+		for _, release := range releases {
+			for _, asset := range release.Assets {
+				results, resolveErr := resolveDiscoveredURL(ctx, client, asset.BrowserDownloadURL, query, allowed)
+				if resolveErr != nil {
+					continue
+				}
+				for _, result := range results {
+					result.Source = "github.com/" + repository.FullName
+					if result.SizeBytes == 0 && result.ArchiveMember == "" {
+						result.SizeBytes = asset.Size
+					}
+					out <- Event{Type: EventResult, Result: result}
+				}
+			}
 		}
 	}
 	return nil
+}
+
+func stopGitHubFallback(err error) bool {
+	return errors.Is(err, ErrRateLimited) || errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+func (source GitHub) getJSON(ctx context.Context, client *http.Client, endpoint string, parameters url.Values, destination any, out chan<- Event) error {
+	if encoded := parameters.Encode(); encoded != "" {
+		endpoint += "?" + encoded
+	}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return err
+	}
+	request.Header.Set("Accept", "application/vnd.github+json")
+	request.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	request.Header.Set("User-Agent", "moji-font-finder")
+	if source.Token != "" {
+		request.Header.Set("Authorization", "Bearer "+source.Token)
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return fmt.Errorf("%w: github request: %v", ErrUnavailable, err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode == http.StatusTooManyRequests ||
+		(response.StatusCode == http.StatusForbidden && response.Header.Get("X-RateLimit-Remaining") == "0") {
+		retryAfter := githubRetryAfter(response.Header, time.Now())
+		out <- Event{Type: EventStatus, Status: StateThrottled, Err: ErrRateLimited, RetryAfter: retryAfter}
+		return ErrRateLimited
+	}
+	if response.StatusCode >= 400 && response.StatusCode < 500 {
+		return fmt.Errorf("%w: github returned HTTP %d", ErrNonRetryable, response.StatusCode)
+	}
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("%w: github returned HTTP %d", ErrBadResponse, response.StatusCode)
+	}
+	if err := decodeGitHubJSON(response.Body, destination); err != nil {
+		return fmt.Errorf("%w: decode github response: %v", ErrBadResponse, err)
+	}
+	return nil
+}
+
+func githubRepositoryRawURL(repository, branch, filePath string) string {
+	return (&url.URL{
+		Scheme: "https",
+		Host:   "raw.githubusercontent.com",
+		Path:   "/" + repository + "/" + branch + "/" + strings.TrimPrefix(filePath, "/"),
+	}).String()
+}
+
+func decodeGitHubJSON(reader io.Reader, destination any) error {
+	content, err := io.ReadAll(io.LimitReader(reader, maxGitHubResponseSize+1))
+	if err != nil {
+		return err
+	}
+	if int64(len(content)) > maxGitHubResponseSize {
+		return fmt.Errorf("response exceeds %d bytes", maxGitHubResponseSize)
+	}
+	return json.Unmarshal(content, destination)
+}
+
+func (source GitHub) search(ctx context.Context, client *http.Client, endpoint, query string, out chan<- Event) (githubSearchResponse, error) {
+	parameters := url.Values{"q": {query}, "per_page": {"100"}}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+"?"+parameters.Encode(), nil)
+	if err != nil {
+		return githubSearchResponse{}, err
+	}
+	request.Header.Set("Accept", "application/vnd.github+json")
+	request.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	request.Header.Set("User-Agent", "moji-font-finder")
+	if source.Token != "" {
+		request.Header.Set("Authorization", "Bearer "+source.Token)
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return githubSearchResponse{}, fmt.Errorf("%w: github request: %v", ErrUnavailable, err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode == http.StatusTooManyRequests ||
+		(response.StatusCode == http.StatusForbidden && response.Header.Get("X-RateLimit-Remaining") == "0") {
+		retryAfter := githubRetryAfter(response.Header, time.Now())
+		out <- Event{Type: EventStatus, Status: StateThrottled, Err: ErrRateLimited, RetryAfter: retryAfter}
+		return githubSearchResponse{}, ErrRateLimited
+	}
+	if response.StatusCode >= 400 && response.StatusCode < 500 {
+		return githubSearchResponse{}, fmt.Errorf("%w: github returned HTTP %d", ErrNonRetryable, response.StatusCode)
+	}
+	if response.StatusCode != http.StatusOK {
+		return githubSearchResponse{}, fmt.Errorf("%w: github returned HTTP %d", ErrBadResponse, response.StatusCode)
+	}
+	var payload githubSearchResponse
+	if err := decodeGitHubJSON(response.Body, &payload); err != nil {
+		return githubSearchResponse{}, fmt.Errorf("%w: decode github response: %v", ErrBadResponse, err)
+	}
+	return payload, nil
+}
+
+func githubSearchQueries(query string, formats []string) []string {
+	words := strings.Fields(query)
+	variants := []string{
+		strings.Join(words, ""),
+		strings.Join(words, "-"),
+		strings.Join(words, "_"),
+		strings.ToLower(strings.Join(words, "")),
+	}
+	seen := make(map[string]bool)
+	terms := make([]string, 0, len(variants)+len(variants)*len(formats))
+	appendTerm := func(term string) {
+		if term != "" && !seen[term] {
+			seen[term] = true
+			terms = append(terms, term)
+		}
+	}
+	for _, variant := range variants {
+		appendTerm("filename:" + variant)
+	}
+	for _, variant := range variants {
+		for _, format := range formats {
+			appendTerm(fmt.Sprintf("%q", variant+"."+strings.TrimPrefix(strings.ToLower(format), ".")))
+		}
+	}
+	exact := make([]string, 0, len(terms))
+	length := 0
+	for _, term := range terms {
+		addition := len(term)
+		if len(exact) > 0 {
+			addition += len(" OR ")
+		}
+		if length+addition > 240 {
+			break
+		}
+		exact = append(exact, term)
+		length += addition
+	}
+	qualifiers := make([]string, 0, len(formats))
+	seenQualifiers := make(map[string]bool)
+	for _, format := range formats {
+		qualifier := "extension:" + strings.TrimPrefix(strings.ToLower(format), ".")
+		if !seenQualifiers[qualifier] {
+			seenQualifiers[qualifier] = true
+			qualifiers = append(qualifiers, qualifier)
+		}
+	}
+	sort.Strings(qualifiers)
+	return []string{strings.Join(exact, " OR "), query + " " + strings.Join(qualifiers, " OR ")}
 }
 
 func branchFromHTMLURL(value string) string {
@@ -100,10 +336,20 @@ func branchFromHTMLURL(value string) string {
 	return "HEAD"
 }
 
-func parseRetryAfter(value string) time.Duration {
-	seconds, err := strconv.Atoi(value)
-	if err == nil {
-		return time.Duration(seconds) * time.Second
+func githubRetryAfter(header http.Header, now time.Time) time.Duration {
+	if value := header.Get("Retry-After"); value != "" {
+		if seconds, err := strconv.Atoi(value); err == nil && seconds > 0 {
+			return time.Duration(seconds) * time.Second
+		}
+		if when, err := http.ParseTime(value); err == nil && when.After(now) {
+			return when.Sub(now)
+		}
+	}
+	if reset, err := strconv.ParseInt(header.Get("X-RateLimit-Reset"), 10, 64); err == nil {
+		when := time.Unix(reset, 0)
+		if when.After(now) {
+			return when.Sub(now)
+		}
 	}
 	return 0
 }

--- a/internal/provider/github_test.go
+++ b/internal/provider/github_test.go
@@ -1,26 +1,38 @@
 package provider
 
 import (
+	"archive/zip"
+	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 )
 
-func TestGitHubBuildsFormatQueriesAndRawURLs(t *testing.T) {
+func TestGitHubSearchesOnceAndFiltersFormats(t *testing.T) {
 	t.Parallel()
-	queries := make(chan string, 2)
+	requests := 0
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		requests++
 		if request.Header.Get("Authorization") != "Bearer secret" {
 			t.Errorf("authorization was not set")
 		}
-		queries <- request.URL.Query().Get("q")
+		query := request.URL.Query().Get("q")
+		if !strings.Contains(query, "filename:Example") || !strings.Contains(query, `"Example.otf"`) || strings.Contains(query, "extension:") {
+			t.Errorf("filename query = %q", query)
+		}
+		if got := request.URL.Query().Get("per_page"); got != "100" {
+			t.Errorf("per_page = %q", got)
+		}
 		response.Header().Set("Content-Type", "application/json")
-		fmt.Fprint(response, "{\"items\":[{\"name\":\"Example-Bold.otf\",\"path\":\"fonts/Example-Bold.otf\",\"html_url\":\"https://github.com/acme/fonts/blob/main/fonts/Example-Bold.otf\",\"repository\":{\"full_name\":\"acme/fonts\",\"default_branch\":\"main\"}}]}")
+		fmt.Fprint(response, `{"items":[{"name":"Example-Bold.otf","path":"fonts/Example-Bold.otf","html_url":"https://github.com/acme/fonts/blob/main/fonts/Example-Bold.otf","repository":{"full_name":"acme/fonts","default_branch":"main"}},{"name":"Example-Regular.TTF","path":"fonts/Example-Regular.TTF","repository":{"full_name":"acme/fonts","default_branch":"main"}},{"name":"Example.woff2","path":"Example.woff2","repository":{"full_name":"acme/fonts","default_branch":"main"}}]}`)
 	}))
 	defer server.Close()
 
@@ -30,18 +42,173 @@ func TestGitHubBuildsFormatQueriesAndRawURLs(t *testing.T) {
 		t.Fatal(err)
 	}
 	close(out)
-	close(queries)
 	if len(out) != 2 {
 		t.Fatalf("result count = %d", len(out))
 	}
 	for event := range out {
-		if event.Result.URL != "https://raw.githubusercontent.com/acme/fonts/main/fonts/Example-Bold.otf" {
+		if !strings.HasPrefix(event.Result.URL, "https://raw.githubusercontent.com/acme/fonts/main/fonts/Example-") {
 			t.Fatalf("raw URL = %q", event.Result.URL)
 		}
 	}
-	seen := strings.Join([]string{<-queries, <-queries}, " ")
-	if !strings.Contains(seen, "extension:otf") || !strings.Contains(seen, "extension:ttf") {
-		t.Fatalf("queries = %q", seen)
+	if requests != 1 {
+		t.Fatalf("requests = %d, want 1", requests)
+	}
+}
+
+func TestGitHubFallsBackToBroadExtensionQuery(t *testing.T) {
+	t.Parallel()
+	var queries []string
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		queries = append(queries, request.URL.Query().Get("q"))
+		if len(queries) == 1 {
+			fmt.Fprint(response, `{"items":[]}`)
+			return
+		}
+		fmt.Fprint(response, `{"items":[{"name":"ProximaNova-Regular.ttf","path":"ProximaNova-Regular.ttf","repository":{"full_name":"fixture/fonts","default_branch":"main"}}]}`)
+	}))
+	defer server.Close()
+	out := make(chan Event, 2)
+	if err := (GitHub{Client: server.Client(), Endpoint: server.URL}).Search(context.Background(), "Proxima Nova", []string{"ttf"}, out); err != nil {
+		t.Fatal(err)
+	}
+	if len(queries) != 2 || queries[1] != "Proxima Nova extension:ttf" {
+		t.Fatalf("queries = %#v", queries)
+	}
+	if len(out) != 1 {
+		t.Fatalf("results = %d", len(out))
+	}
+}
+
+func TestGitHubFallsBackToRepositoryTreeAndReleaseAssets(t *testing.T) {
+	t.Parallel()
+	var server *httptest.Server
+	server = httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/search/code":
+			fmt.Fprint(response, `{"items":[]}`)
+		case "/search/repositories":
+			fmt.Fprint(response, `{"items":[{"full_name":"fixture/fonts","default_branch":"main"}]}`)
+		case "/repos/fixture/fonts/git/trees/main":
+			fmt.Fprint(response, `{"tree":[{"path":"dist/Catedra-Regular.otf","type":"blob","size":1234}]}`)
+		case "/repos/fixture/fonts/releases":
+			fmt.Fprintf(response, `[{"assets":[{"name":"Catedra-Bold.ttf","browser_download_url":%q,"size":2345}]}]`, server.URL+"/assets/Catedra-Bold.ttf")
+		default:
+			http.NotFound(response, request)
+		}
+	}))
+	defer server.Close()
+
+	out := make(chan Event, 4)
+	if err := (GitHub{Client: server.Client(), Endpoint: server.URL + "/search/code"}).Search(context.Background(), "Catedra", []string{"otf", "ttf"}, out); err != nil {
+		t.Fatal(err)
+	}
+	close(out)
+	if len(out) != 2 {
+		t.Fatalf("results = %d, want 2", len(out))
+	}
+	first := (<-out).Result
+	second := (<-out).Result
+	if !strings.Contains(first.URL, "raw.githubusercontent.com/fixture/fonts/main/dist/Catedra-Regular.otf") {
+		t.Fatalf("tree URL = %q", first.URL)
+	}
+	if second.URL != server.URL+"/assets/Catedra-Bold.ttf" {
+		t.Fatalf("release URL = %q", second.URL)
+	}
+}
+
+func TestGitHubRepositoryFallbackPropagatesRateLimit(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/search/code":
+			fmt.Fprint(response, `{"items":[]}`)
+		case "/search/repositories":
+			fmt.Fprint(response, `{"items":[{"full_name":"fixture/fonts","default_branch":"main"}]}`)
+		case "/repos/fixture/fonts/git/trees/main":
+			response.Header().Set("X-RateLimit-Remaining", "0")
+			response.WriteHeader(http.StatusForbidden)
+		default:
+			http.NotFound(response, request)
+		}
+	}))
+	defer server.Close()
+
+	out := make(chan Event, 2)
+	err := (GitHub{Client: server.Client(), Endpoint: server.URL + "/search/code"}).Search(context.Background(), "Example", []string{"otf"}, out)
+	if !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("error = %v, want rate limit", err)
+	}
+	if len(out) != 1 || (<-out).Status != StateThrottled {
+		t.Fatal("rate limit status was not propagated")
+	}
+}
+
+func TestGitHubRepositoryFallbackChecksReleasesAfterTreeFailure(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/search/code":
+			fmt.Fprint(response, `{"items":[]}`)
+		case "/search/repositories":
+			fmt.Fprint(response, `{"items":[{"full_name":"fixture/fonts","default_branch":"main"}]}`)
+		case "/repos/fixture/fonts/git/trees/main":
+			response.WriteHeader(http.StatusInternalServerError)
+		case "/repos/fixture/fonts/releases":
+			fmt.Fprint(response, `[{"assets":[{"name":"Example.otf","browser_download_url":"https://releases.example/Example.otf","size":123}]}]`)
+		default:
+			http.NotFound(response, request)
+		}
+	}))
+	defer server.Close()
+
+	out := make(chan Event, 2)
+	if err := (GitHub{Client: server.Client(), Endpoint: server.URL + "/search/code"}).Search(context.Background(), "Example", []string{"otf"}, out); err != nil {
+		t.Fatal(err)
+	}
+	if len(out) != 1 || (<-out).Result.URL != "https://releases.example/Example.otf" {
+		t.Fatal("release asset was not checked after tree failure")
+	}
+}
+
+func TestGitHubFilenameVariants(t *testing.T) {
+	t.Parallel()
+	query := githubSearchQueries("Proxima Nova", []string{"ttf"})[0]
+	for _, want := range []string{"filename:ProximaNova", "filename:Proxima-Nova", "filename:Proxima_Nova", "filename:proximanova", `"ProximaNova.ttf"`} {
+		if !strings.Contains(query, want) {
+			t.Errorf("query %q missing %q", query, want)
+		}
+	}
+	if len(query) > 240 {
+		t.Fatalf("query length = %d", len(query))
+	}
+}
+
+func TestGitHubRawURLEscapesFilenameSpaces(t *testing.T) {
+	got := githubRepositoryRawURL("fixture/fonts", "main", "Family/Example Regular.otf")
+	if got != "https://raw.githubusercontent.com/fixture/fonts/main/Family/Example%20Regular.otf" {
+		t.Fatalf("URL = %q", got)
+	}
+}
+
+func TestGitHubRetryAfter(t *testing.T) {
+	t.Parallel()
+	now := time.Unix(1_700_000_000, 0)
+	tests := []struct {
+		name   string
+		header http.Header
+		want   time.Duration
+	}{
+		{"seconds", http.Header{"Retry-After": {"7"}}, 7 * time.Second},
+		{"date", http.Header{"Retry-After": {now.Add(9 * time.Second).Format(http.TimeFormat)}}, 9 * time.Second},
+		{"reset", http.Header{"X-Ratelimit-Reset": {fmt.Sprint(now.Add(11 * time.Second).Unix())}}, 11 * time.Second},
+		{"retry after wins", http.Header{"Retry-After": {"7"}, "X-Ratelimit-Reset": {fmt.Sprint(now.Add(11 * time.Second).Unix())}}, 7 * time.Second},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := githubRetryAfter(test.header, now); got != test.want {
+				t.Fatalf("retry after = %s, want %s", got, test.want)
+			}
+		})
 	}
 }
 
@@ -64,7 +231,18 @@ func TestGetFontsFiltersFormats(t *testing.T) {
 
 func TestWebSearchOnlyReturnsDirectFontLinks(t *testing.T) {
 	t.Parallel()
+	var requests atomic.Int32
+	var release sync.Once
+	ready := make(chan struct{})
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if requests.Add(1) == 6 {
+			release.Do(func() { close(ready) })
+		}
+		select {
+		case <-ready:
+		case <-time.After(time.Second):
+			t.Error("expanded web searches did not run concurrently")
+		}
 		fmt.Fprint(response, "{\"results\":[{\"url\":\"https://cdn.test/Example.woff2\",\"title\":\"font\"},{\"url\":\"https://site.test/page\",\"title\":\"page\"}]}")
 	}))
 	defer server.Close()
@@ -76,6 +254,66 @@ func TestWebSearchOnlyReturnsDirectFontLinks(t *testing.T) {
 	close(out)
 	if len(out) != 1 || (<-out).Result.Filename != "Example.woff2" {
 		t.Fatal("direct font result was not extracted")
+	}
+	if requests.Load() != 6 {
+		t.Fatalf("requests = %d, want 6", requests.Load())
+	}
+}
+
+func TestWebSearchPreservesEveryArchiveMember(t *testing.T) {
+	t.Parallel()
+	var archive bytes.Buffer
+	writer := zip.NewWriter(&archive)
+	for _, name := range []string{"Example-Regular.otf", "Example-Bold.otf"} {
+		font, err := writer.Create(name)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := font.Write([]byte("OTTOfont")); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	var server *httptest.Server
+	server = httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.URL.Path == "/family.zip" {
+			_, _ = response.Write(archive.Bytes())
+			return
+		}
+		fmt.Fprintf(response, `{"results":[{"url":%q}]}`, server.URL+"/family.zip")
+	}))
+	defer server.Close()
+
+	out := make(chan Event, 12)
+	if err := (WebSearch{Client: server.Client(), Instance: server.URL}).Search(context.Background(), "Example", []string{"otf"}, out); err != nil {
+		t.Fatal(err)
+	}
+	close(out)
+	if len(out) != 2 {
+		t.Fatalf("results = %d, want both archive members", len(out))
+	}
+}
+
+func TestWebSearchQueriesCoverDorkVariants(t *testing.T) {
+	t.Parallel()
+	queries := webSearchQueries("Proxima Nova", []string{"otf", "ttf", "dfont"})
+	want := []string{
+		`"Proxima Nova.ttf"`,
+		`"Proxima Nova.otf"`,
+		`site:vk.com "Proxima Nova"`,
+		`"Proxima Nova" "index of" .otf OR .ttf OR .dfont OR .zip OR .tar.gz`,
+		`intitle:"Proxima Nova" github`,
+		`"Proxima Nova" "@font-face" filetype:css`,
+	}
+	if len(queries) != len(want) {
+		t.Fatalf("queries = %#v", queries)
+	}
+	for index := range want {
+		if queries[index] != want[index] {
+			t.Errorf("query %d = %q, want %q", index, queries[index], want[index])
+		}
 	}
 }
 

--- a/internal/provider/kagi.go
+++ b/internal/provider/kagi.go
@@ -1,0 +1,85 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"os/exec"
+	"strings"
+)
+
+type KagiCLI struct {
+	Executable string
+	Client     *http.Client
+}
+
+func (KagiCLI) Name() string { return "kagi" }
+
+func (source KagiCLI) Search(ctx context.Context, query string, formats []string, out chan<- Event) error {
+	executable := source.Executable
+	if executable == "" {
+		executable = "kagi"
+	}
+	command := exec.CommandContext(ctx, executable, "search", "--format", "json", "--error-format", "json", "--limit", "20", query+" font "+strings.Join(kagiQueryFormats(formats), " ")+" zip css")
+	content, err := command.Output()
+	if err != nil {
+		if exitError, ok := err.(*exec.ExitError); ok {
+			message := strings.TrimSpace(string(exitError.Stderr))
+			if message != "" {
+				return fmt.Errorf("%w: kagi search: %s", ErrUnavailable, message)
+			}
+		}
+		return fmt.Errorf("%w: kagi search: %v", ErrUnavailable, err)
+	}
+	var response struct {
+		Data []struct {
+			URL     string `json:"url"`
+			Title   string `json:"title"`
+			Snippet string `json:"snippet"`
+		} `json:"data"`
+	}
+	if err := json.Unmarshal(content, &response); err != nil {
+		return fmt.Errorf("%w: decode kagi response: %v", ErrBadResponse, err)
+	}
+	allowed := make(map[string]bool, len(formats))
+	for _, format := range formats {
+		allowed[strings.ToLower(format)] = true
+	}
+	for _, item := range response.Data {
+		resolved, resolveErr := resolveDiscoveredURL(ctx, source.Client, item.URL, query, allowed)
+		if resolveErr == nil {
+			for _, result := range resolved {
+				out <- Event{Type: EventResult, Result: result}
+			}
+		}
+	}
+	return nil
+}
+
+func kagiQueryFormats(formats []string) []string {
+	modern := make([]string, 0, len(formats))
+	for _, format := range formats {
+		switch strings.TrimPrefix(strings.ToLower(format), ".") {
+		case "otf", "ttf", "woff", "woff2":
+			modern = append(modern, format)
+		}
+	}
+	if len(modern) > 0 {
+		return modern
+	}
+	return formats
+}
+
+func githubRawURL(value *url.URL) *url.URL {
+	parts := strings.Split(strings.Trim(value.Path, "/"), "/")
+	if len(parts) < 5 || parts[2] != "blob" {
+		return nil
+	}
+	return &url.URL{
+		Scheme: "https",
+		Host:   "raw.githubusercontent.com",
+		Path:   "/" + strings.Join(append(parts[:2], parts[3:]...), "/"),
+	}
+}

--- a/internal/provider/kagi_test.go
+++ b/internal/provider/kagi_test.go
@@ -1,0 +1,39 @@
+package provider
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestWebSearchUsesInstalledKagiBackend(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fixture executable uses a POSIX shell")
+	}
+	executable := filepath.Join(t.TempDir(), "kagi")
+	script := `#!/bin/sh
+case "$*" in
+  *"search --format json --error-format json --limit 20 Basier Narrow font otf zip css"*)
+    printf '%s' '{"data":[{"url":"https://github.com/example/fonts/blob/main/BasierNarrow-Regular.otf","title":"Basier Narrow font"},{"url":"https://example.test/fonts/basier-narrow","title":"web page"}]}'
+    ;;
+  *) exit 2 ;;
+esac
+`
+	if err := os.WriteFile(executable, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	out := make(chan Event, 2)
+	if err := (WebSearch{KagiExecutable: executable}).Search(context.Background(), "Basier Narrow", []string{"otf"}, out); err != nil {
+		t.Fatal(err)
+	}
+	close(out)
+	if len(out) != 1 {
+		t.Fatalf("results = %d, want 1", len(out))
+	}
+	result := (<-out).Result
+	if result.Filename != "BasierNarrow-Regular.otf" || result.URL != "https://raw.githubusercontent.com/example/fonts/main/BasierNarrow-Regular.otf" {
+		t.Fatalf("result = %#v", result)
+	}
+}

--- a/internal/provider/plugins.go
+++ b/internal/provider/plugins.go
@@ -1,0 +1,117 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+const maxPluginResponseSize int64 = 2 << 20
+
+type PluginSearch struct {
+	Client *http.Client
+	Paths  []string
+}
+
+func (PluginSearch) Name() string { return "plugins" }
+
+type pluginRequest struct {
+	Version int      `json:"version"`
+	Query   string   `json:"query"`
+	Formats []string `json:"formats"`
+}
+
+type pluginResponse struct {
+	Version int `json:"version"`
+	Results []struct {
+		URL     string `json:"url"`
+		License string `json:"license,omitempty"`
+		Trusted bool   `json:"trusted,omitempty"`
+	} `json:"results"`
+}
+
+func (source PluginSearch) Search(ctx context.Context, query string, formats []string, out chan<- Event) error {
+	allowed := formatSet(formats)
+	completed := 0
+	errorsByPlugin := make([]string, 0)
+	for _, path := range source.Paths {
+		response, err := runSourcePlugin(ctx, path, pluginRequest{Version: 1, Query: query, Formats: formats})
+		if err != nil {
+			errorsByPlugin = append(errorsByPlugin, filepath.Base(path)+": "+err.Error())
+			continue
+		}
+		completed++
+		for _, candidate := range response.Results {
+			results, resolveErr := resolveDiscoveredURL(ctx, source.Client, candidate.URL, query, allowed)
+			if resolveErr != nil {
+				continue
+			}
+			for _, result := range results {
+				result.Source = "plugin:" + filepath.Base(path)
+				result.Trusted = candidate.Trusted
+				if candidate.License != "" {
+					result.License = candidate.License
+				}
+				out <- Event{Type: EventResult, Result: result}
+			}
+		}
+	}
+	if completed == 0 {
+		return fmt.Errorf("%w: %s", ErrUnavailable, strings.Join(errorsByPlugin, "; "))
+	}
+	return nil
+}
+
+func runSourcePlugin(ctx context.Context, path string, request pluginRequest) (pluginResponse, error) {
+	input, err := json.Marshal(request)
+	if err != nil {
+		return pluginResponse{}, err
+	}
+	command := exec.CommandContext(ctx, path)
+	configurePluginCommand(command)
+	command.Stdin = bytes.NewReader(input)
+	stdout, err := command.StdoutPipe()
+	if err != nil {
+		return pluginResponse{}, err
+	}
+	var stderr bytes.Buffer
+	command.Stderr = &stderr
+	if err := command.Start(); err != nil {
+		return pluginResponse{}, err
+	}
+	content, readErr := io.ReadAll(io.LimitReader(stdout, maxPluginResponseSize+1))
+	if int64(len(content)) > maxPluginResponseSize {
+		// A plugin may spawn a child that inherits stdout. Close Moji's read end
+		// before waiting so that descendant cannot keep the pipe alive after the
+		// plugin process is killed.
+		_ = stdout.Close()
+		_ = terminatePluginCommand(command)
+		_ = command.Wait()
+		return pluginResponse{}, fmt.Errorf("response exceeds %d bytes", maxPluginResponseSize)
+	}
+	waitErr := command.Wait()
+	if readErr != nil {
+		return pluginResponse{}, readErr
+	}
+	if waitErr != nil {
+		message := strings.TrimSpace(stderr.String())
+		if message != "" {
+			return pluginResponse{}, fmt.Errorf("%v: %s", waitErr, message)
+		}
+		return pluginResponse{}, waitErr
+	}
+	var response pluginResponse
+	if err := json.Unmarshal(content, &response); err != nil {
+		return pluginResponse{}, fmt.Errorf("invalid JSON response: %w", err)
+	}
+	if response.Version != 1 {
+		return pluginResponse{}, fmt.Errorf("unsupported response version %d", response.Version)
+	}
+	return response, nil
+}

--- a/internal/provider/plugins_process_unix.go
+++ b/internal/provider/plugins_process_unix.go
@@ -1,0 +1,22 @@
+//go:build unix
+
+package provider
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+func configurePluginCommand(command *exec.Cmd) {
+	// A separate process group lets cancellation and output-limit enforcement
+	// stop descendants that inherited the plugin's stdout pipe.
+	command.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+	command.Cancel = func() error { return terminatePluginCommand(command) }
+}
+
+func terminatePluginCommand(command *exec.Cmd) error {
+	if command.Process == nil {
+		return nil
+	}
+	return syscall.Kill(-command.Process.Pid, syscall.SIGKILL)
+}

--- a/internal/provider/plugins_process_windows.go
+++ b/internal/provider/plugins_process_windows.go
@@ -1,0 +1,25 @@
+//go:build windows
+
+package provider
+
+import (
+	"os/exec"
+	"strconv"
+	"syscall"
+)
+
+func configurePluginCommand(command *exec.Cmd) {
+	command.SysProcAttr = &syscall.SysProcAttr{CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP}
+	command.Cancel = func() error { return terminatePluginCommand(command) }
+}
+
+func terminatePluginCommand(command *exec.Cmd) error {
+	if command.Process == nil {
+		return nil
+	}
+	// taskkill /T terminates descendants that inherited the plugin's handles.
+	if err := exec.Command("taskkill", "/PID", strconv.Itoa(command.Process.Pid), "/T", "/F").Run(); err == nil {
+		return nil
+	}
+	return command.Process.Kill()
+}

--- a/internal/provider/plugins_test.go
+++ b/internal/provider/plugins_test.go
@@ -1,0 +1,76 @@
+package provider
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPluginSearchAcceptsOnlyDirectConfiguredFormats(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fixture uses a POSIX executable")
+	}
+	path := filepath.Join(t.TempDir(), "fixture-plugin")
+	script := `#!/bin/sh
+read request
+printf '%s' '{"version":1,"results":[{"url":"https://cdn.example/SilkaMono-Regular.otf","license":"fixture"},{"url":"https://example.com/font-page"}]}'
+`
+	if err := os.WriteFile(path, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	out := make(chan Event, 2)
+	if err := (PluginSearch{Paths: []string{path}}).Search(context.Background(), "Silka Mono", []string{"otf"}, out); err != nil {
+		t.Fatal(err)
+	}
+	close(out)
+	if len(out) != 1 {
+		t.Fatalf("results = %d, want 1", len(out))
+	}
+	result := (<-out).Result
+	if result.Source != "plugin:fixture-plugin" || result.License != "fixture" || result.Format != "otf" {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestPluginSearchRejectsUnknownProtocolVersion(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fixture uses a POSIX executable")
+	}
+	path := filepath.Join(t.TempDir(), "future-plugin")
+	script := `#!/bin/sh
+read request
+printf '%s' '{"version":2,"results":[]}'
+`
+	if err := os.WriteFile(path, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := (PluginSearch{Paths: []string{path}}).Search(context.Background(), "Example", []string{"otf"}, make(chan Event, 1)); err == nil {
+		t.Fatal("expected unsupported protocol version error")
+	}
+}
+
+func TestPluginOutputLimitStopsNonClosingProcessImmediately(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fixture uses POSIX head and sleep")
+	}
+	path := filepath.Join(t.TempDir(), "oversized-plugin")
+	script := `#!/bin/sh
+head -c 2097153 /dev/zero
+sleep 5
+`
+	if err := os.WriteFile(path, []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	started := time.Now()
+	_, err := runSourcePlugin(context.Background(), path, pluginRequest{Version: 1, Query: "Example", Formats: []string{"otf"}})
+	if err == nil || !strings.Contains(err.Error(), "response exceeds") {
+		t.Fatalf("error = %v", err)
+	}
+	if elapsed := time.Since(started); elapsed >= 2*time.Second {
+		t.Fatalf("output limit took %s; process was not stopped immediately", elapsed)
+	}
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -8,10 +8,11 @@ import (
 )
 
 var (
-	ErrRateLimited = errors.New("rate limited")
-	ErrBlocked     = errors.New("blocked by site protection")
-	ErrUnavailable = errors.New("provider unavailable")
-	ErrBadResponse = errors.New("bad response from provider")
+	ErrRateLimited  = errors.New("rate limited")
+	ErrBlocked      = errors.New("blocked by site protection")
+	ErrUnavailable  = errors.New("provider unavailable")
+	ErrBadResponse  = errors.New("bad response from provider")
+	ErrNonRetryable = errors.New("non-retryable provider failure")
 )
 
 func DescribeFailure(name string, err error) string {
@@ -26,6 +27,8 @@ func DescribeFailure(name string, err error) string {
 		return fmt.Sprintf("%s blocked the search request. Try another enabled provider", name)
 	case errors.Is(err, ErrUnavailable):
 		return fmt.Sprintf("Moji couldn't connect to %s. Check your connection, then try again", name)
+	case errors.Is(err, ErrNonRetryable):
+		return fmt.Sprintf("%s rejected the search request. Check the query or provider configuration", name)
 	case errors.Is(err, ErrBadResponse):
 		return fmt.Sprintf("%s returned a response Moji couldn't use. Try again later or use another provider", name)
 	case err != nil:
@@ -52,26 +55,26 @@ const (
 )
 
 type Result struct {
-	Name      string  `json:"name" yaml:"name"`
-	Filename  string  `json:"filename" yaml:"filename"`
-	Format    string  `json:"format" yaml:"format"`
-	Weight    string  `json:"weight,omitempty" yaml:"weight,omitempty"`
-	SizeBytes int64   `json:"size_bytes" yaml:"size_bytes"`
-	Source    string  `json:"source" yaml:"source"`
-	URL       string  `json:"url" yaml:"url"`
-	Trusted   bool    `json:"trusted" yaml:"trusted"`
-	License   string  `json:"license" yaml:"license"`
-	Score     float64 `json:"score,omitempty" yaml:"score,omitempty"`
+	Name          string  `json:"name" yaml:"name"`
+	Filename      string  `json:"filename" yaml:"filename"`
+	Format        string  `json:"format" yaml:"format"`
+	Weight        string  `json:"weight,omitempty" yaml:"weight,omitempty"`
+	SizeBytes     int64   `json:"size_bytes" yaml:"size_bytes"`
+	Source        string  `json:"source" yaml:"source"`
+	URL           string  `json:"url" yaml:"url"`
+	Trusted       bool    `json:"trusted" yaml:"trusted"`
+	License       string  `json:"license" yaml:"license"`
+	Variable      bool    `json:"variable,omitempty" yaml:"variable,omitempty"`
+	ArchiveFormat string  `json:"archive_format,omitempty" yaml:"archive_format,omitempty"`
+	ArchiveMember string  `json:"archive_member,omitempty" yaml:"archive_member,omitempty"`
+	Score         float64 `json:"score,omitempty" yaml:"score,omitempty"`
 }
 
 func UniqueResults(results []Result) []Result {
 	seen := make(map[string]bool, len(results))
 	unique := make([]Result, 0, len(results))
 	for _, result := range results {
-		key := result.URL
-		if key == "" {
-			key = result.Source + "\x00" + result.Filename
-		}
+		key := resultIdentity(result)
 		if seen[key] {
 			continue
 		}
@@ -79,6 +82,13 @@ func UniqueResults(results []Result) []Result {
 		unique = append(unique, result)
 	}
 	return unique
+}
+
+func resultIdentity(result Result) string {
+	if result.URL != "" {
+		return result.URL + "\x00" + result.ArchiveMember
+	}
+	return result.Source + "\x00" + result.Filename
 }
 
 type Event struct {

--- a/internal/provider/registries.go
+++ b/internal/provider/registries.go
@@ -1,0 +1,222 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+type Fontsource struct {
+	Client   *http.Client
+	Endpoint string
+}
+
+func (Fontsource) Name() string { return "fontsource" }
+
+func (source Fontsource) Search(ctx context.Context, query string, formats []string, out chan<- Event) error {
+	client := source.Client
+	if client == nil {
+		client = http.DefaultClient
+	}
+	endpoint := source.Endpoint
+	if endpoint == "" {
+		endpoint = "https://api.fontsource.org/v1/fonts"
+	}
+	id := strings.ToLower(strings.Join(strings.Fields(query), "-"))
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(endpoint, "/")+"/"+url.PathEscape(id), nil)
+	if err != nil {
+		return err
+	}
+	response, err := client.Do(request)
+	if err != nil {
+		return fmt.Errorf("%w: Fontsource request: %v", ErrUnavailable, err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode == http.StatusNotFound {
+		return nil
+	}
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("%w: Fontsource returned HTTP %d", ErrBadResponse, response.StatusCode)
+	}
+	var payload struct {
+		Family   string `json:"family"`
+		License  string `json:"license"`
+		Variable bool   `json:"variable"`
+		Variants map[string]map[string]map[string]struct {
+			URL map[string]string `json:"url"`
+		} `json:"variants"`
+	}
+	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
+		return fmt.Errorf("%w: decode Fontsource response: %v", ErrBadResponse, err)
+	}
+	allowed := formatSet(formats)
+	for weight, styles := range payload.Variants {
+		for style, subsets := range styles {
+			for _, subset := range subsets {
+				for format, directURL := range subset.URL {
+					format = strings.ToLower(format)
+					if !allowed[format] || !isHTTPSURL(directURL) {
+						continue
+					}
+					normalizedWeight := registryWeight(weight)
+					filename := syntheticFilename(payload.Family, normalizedWeight, style, format)
+					out <- Event{Type: EventResult, Result: Result{
+						Name: payload.Family, Filename: filename, Format: format, Weight: normalizedWeight,
+						Source: "fontsource.org", URL: directURL, Trusted: true, License: payload.License,
+						Variable: payload.Variable && strings.Contains(strings.ToLower(directURL), "variable"),
+					}}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+type GoogleFonts struct {
+	Client   *http.Client
+	Endpoint string
+}
+
+type RegistrySearch struct {
+	Fontsource  Fontsource
+	GoogleFonts GoogleFonts
+}
+
+func (RegistrySearch) Name() string { return "registry" }
+
+func (source RegistrySearch) Search(ctx context.Context, query string, formats []string, out chan<- Event) error {
+	backends := []Provider{source.Fontsource, source.GoogleFonts}
+	type backendResult struct {
+		name string
+		err  error
+	}
+	done := make(chan backendResult, len(backends))
+	for _, backend := range backends {
+		go func() {
+			done <- backendResult{name: backend.Name(), err: backend.Search(ctx, query, formats, out)}
+		}()
+	}
+	errorsByBackend := make([]string, 0, len(backends))
+	completed := 0
+	for range backends {
+		result := <-done
+		if result.err != nil {
+			errorsByBackend = append(errorsByBackend, result.name+": "+result.err.Error())
+			continue
+		}
+		completed++
+	}
+	if completed == 0 {
+		return fmt.Errorf("%w: %s", ErrUnavailable, strings.Join(errorsByBackend, "; "))
+	}
+	return nil
+}
+
+func (GoogleFonts) Name() string { return "googlefonts" }
+
+func (source GoogleFonts) Search(ctx context.Context, query string, formats []string, out chan<- Event) error {
+	allowed := formatSet(formats)
+	if !allowed["woff2"] && !allowed["woff"] {
+		return nil
+	}
+	client := source.Client
+	if client == nil {
+		client = http.DefaultClient
+	}
+	endpoint := source.Endpoint
+	if endpoint == "" {
+		endpoint = "https://fonts.googleapis.com/css2"
+	}
+	parameters := url.Values{"family": {query}}
+	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+"?"+parameters.Encode(), nil)
+	if err != nil {
+		return err
+	}
+	request.Header.Set("User-Agent", "Mozilla/5.0 moji-font-finder")
+	response, err := client.Do(request)
+	if err != nil {
+		return fmt.Errorf("%w: Google Fonts request: %v", ErrUnavailable, err)
+	}
+	defer response.Body.Close()
+	if response.StatusCode == http.StatusBadRequest || response.StatusCode == http.StatusNotFound {
+		return nil
+	}
+	if response.StatusCode != http.StatusOK {
+		return fmt.Errorf("%w: Google Fonts returned HTTP %d", ErrBadResponse, response.StatusCode)
+	}
+	content, err := io.ReadAll(io.LimitReader(response.Body, maxDiscoveryStylesheetSize+1))
+	if err != nil {
+		return fmt.Errorf("%w: read Google Fonts response: %v", ErrBadResponse, err)
+	}
+	if int64(len(content)) > maxDiscoveryStylesheetSize {
+		return fmt.Errorf("%w: Google Fonts stylesheet exceeds %d bytes", ErrBadResponse, maxDiscoveryStylesheetSize)
+	}
+	seen := make(map[string]bool)
+	for _, match := range cssSource.FindAllSubmatch(content, -1) {
+		directURL := string(match[1])
+		parsed, parseErr := url.Parse(directURL)
+		if parseErr != nil || parsed.Scheme != "https" || seen[directURL] {
+			continue
+		}
+		format := cssFontFormat(parsed.Path, string(match[2]))
+		if !allowed[format] {
+			continue
+		}
+		seen[directURL] = true
+		out <- Event{Type: EventResult, Result: Result{
+			Name: query, Filename: syntheticFilename(query, "regular", "normal", format),
+			Format: format, Weight: "regular", Source: "fonts.google.com", URL: directURL,
+			Trusted: true, License: "unknown",
+		}}
+	}
+	return nil
+}
+
+func formatSet(formats []string) map[string]bool {
+	allowed := make(map[string]bool, len(formats))
+	for _, format := range formats {
+		allowed[strings.TrimPrefix(strings.ToLower(format), ".")] = true
+	}
+	return allowed
+}
+
+func isHTTPSURL(value string) bool {
+	parsed, err := url.Parse(value)
+	return err == nil && parsed.Scheme == "https" && parsed.Host != ""
+}
+
+func syntheticFilename(family, weight, style, format string) string {
+	name := strings.Join(strings.Fields(family), "-")
+	if weight != "" {
+		name += "-" + weight
+	}
+	if style != "" && style != "normal" {
+		name += "-" + style
+	}
+	return name + "." + format
+}
+
+func registryWeight(value string) string {
+	switch value {
+	case "100":
+		return "thin"
+	case "300":
+		return "light"
+	case "400":
+		return "regular"
+	case "500":
+		return "medium"
+	case "600":
+		return "semibold"
+	case "700", "800":
+		return "bold"
+	case "900":
+		return "black"
+	default:
+		return value
+	}
+}

--- a/internal/provider/registries_test.go
+++ b/internal/provider/registries_test.go
@@ -1,0 +1,85 @@
+package provider
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestFontsourceSearchReturnsDirectVariantURLs(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/basier-circle" {
+			t.Fatalf("path = %q", request.URL.Path)
+		}
+		writer.Header().Set("Content-Type", "application/json")
+		_, _ = writer.Write([]byte(`{"family":"Basier Circle","license":"OFL-1.1","variable":false,"variants":{"400":{"normal":{"latin":{"url":{"woff2":"https://cdn.example/BasierCircle-Regular.woff2"}}}}}}`))
+	}))
+	defer server.Close()
+
+	events := make(chan Event, 1)
+	if err := (Fontsource{Client: server.Client(), Endpoint: server.URL}).Search(context.Background(), "Basier Circle", []string{"woff2"}, events); err != nil {
+		t.Fatal(err)
+	}
+	result := (<-events).Result
+	if result.URL != "https://cdn.example/BasierCircle-Regular.woff2" || result.Filename != "Basier-Circle-regular.woff2" || result.Format != "woff2" || result.Weight != "regular" || result.License != "OFL-1.1" {
+		t.Fatalf("result = %#v", result)
+	}
+}
+
+func TestRegistrySearchRunsBackendsIndependently(t *testing.T) {
+	t.Parallel()
+	googleStarted := make(chan struct{})
+	server := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		switch {
+		case strings.HasPrefix(request.URL.Path, "/fontsource/"):
+			select {
+			case <-googleStarted:
+				writer.WriteHeader(http.StatusNotFound)
+			case <-time.After(time.Second):
+				t.Error("Google Fonts was blocked behind Fontsource")
+				writer.WriteHeader(http.StatusGatewayTimeout)
+			}
+		case request.URL.Path == "/google":
+			close(googleStarted)
+			_, _ = writer.Write([]byte(`@font-face { src: url(https://fonts.example/example.woff2) format('woff2'); }`))
+		default:
+			http.NotFound(writer, request)
+		}
+	}))
+	defer server.Close()
+
+	out := make(chan Event, 2)
+	source := RegistrySearch{
+		Fontsource:  Fontsource{Client: server.Client(), Endpoint: server.URL + "/fontsource"},
+		GoogleFonts: GoogleFonts{Client: server.Client(), Endpoint: server.URL + "/google"},
+	}
+	if err := source.Search(context.Background(), "Example", []string{"woff2"}, out); err != nil {
+		t.Fatal(err)
+	}
+	close(out)
+	if len(out) != 1 || !strings.Contains((<-out).Result.URL, "example.woff2") {
+		t.Fatal("healthy registry backend result was not preserved")
+	}
+}
+
+func TestGoogleFontsSearchReturnsStylesheetFontURLs(t *testing.T) {
+	server := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+		if request.URL.Query().Get("family") != "Ariol Serif" {
+			t.Fatalf("family = %q", request.URL.Query().Get("family"))
+		}
+		_, _ = writer.Write([]byte(`@font-face { src: url(https://fonts.example/ariol-serif.woff2) format('woff2'); }`))
+	}))
+	defer server.Close()
+
+	events := make(chan Event, 1)
+	if err := (GoogleFonts{Client: server.Client(), Endpoint: server.URL}).Search(context.Background(), "Ariol Serif", []string{"woff2"}, events); err != nil {
+		t.Fatal(err)
+	}
+	result := (<-events).Result
+	if result.URL != "https://fonts.example/ariol-serif.woff2" || result.Source != "fonts.google.com" {
+		t.Fatalf("result = %#v", result)
+	}
+}

--- a/internal/provider/websearch.go
+++ b/internal/provider/websearch.go
@@ -7,20 +7,62 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"path/filepath"
 	"strings"
 )
 
 type WebSearch struct {
-	Client   *http.Client
-	Instance string
+	Client         *http.Client
+	Instance       string
+	KagiExecutable string
 }
 
 func (WebSearch) Name() string { return "websearch" }
 func (source WebSearch) Search(ctx context.Context, query string, formats []string, out chan<- Event) error {
-	if source.Instance == "" {
-		return errors.New("websearch requires a SearXNG instance in config")
+	backends := 0
+	backendEvents := make(chan Event)
+	done := make(chan error, 2)
+	if source.Instance != "" {
+		backends++
+		go func() { done <- source.searchSearXNG(ctx, query, formats, backendEvents) }()
 	}
+	if source.KagiExecutable != "" {
+		backends++
+		go func() {
+			done <- (KagiCLI{Executable: source.KagiExecutable, Client: source.Client}).Search(ctx, query, formats, backendEvents)
+		}()
+	}
+	if backends == 0 {
+		return errors.New("websearch requires kagi-cli or a configured SearXNG instance")
+	}
+	seen := make(map[string]bool)
+	var firstError error
+	successes := 0
+	for backends > 0 {
+		select {
+		case event := <-backendEvents:
+			key := resultIdentity(event.Result)
+			if event.Type != EventResult || !seen[key] {
+				if event.Type == EventResult {
+					seen[key] = true
+				}
+				out <- event
+			}
+		case err := <-done:
+			backends--
+			if err == nil {
+				successes++
+			} else if firstError == nil {
+				firstError = err
+			}
+		}
+	}
+	if successes == 0 {
+		return firstError
+	}
+	return nil
+}
+
+func (source WebSearch) searchSearXNG(ctx context.Context, query string, formats []string, out chan<- Event) error {
 	client := source.Client
 	if client == nil {
 		client = http.DefaultClient
@@ -29,42 +71,97 @@ func (source WebSearch) Search(ctx context.Context, query string, formats []stri
 	for _, format := range formats {
 		allowed[format] = true
 	}
-	parameters := url.Values{"q": {query + " font " + strings.Join(formats, " ")}, "format": {"json"}}
+	type searchResult struct {
+		results []Result
+		err     error
+	}
+	queries := webSearchQueries(query, formats)
+	completed := make(chan searchResult, len(queries))
+	for _, searchQuery := range queries {
+		go func() {
+			results, err := source.search(ctx, client, searchQuery, query, allowed)
+			completed <- searchResult{results: results, err: err}
+		}()
+	}
+	seen := make(map[string]bool)
+	var firstError error
+	successes := 0
+	for range queries {
+		search := <-completed
+		if search.err != nil {
+			if firstError == nil {
+				firstError = search.err
+			}
+			continue
+		}
+		successes++
+		for _, result := range search.results {
+			key := resultIdentity(result)
+			if !seen[key] {
+				seen[key] = true
+				out <- Event{Type: EventResult, Result: result}
+			}
+		}
+	}
+	if successes == 0 && firstError != nil {
+		return firstError
+	}
+	return nil
+}
+
+func (source WebSearch) search(ctx context.Context, client *http.Client, searchQuery, fontQuery string, allowed map[string]bool) ([]Result, error) {
+	parameters := url.Values{"q": {searchQuery}, "format": {"json"}}
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, strings.TrimRight(source.Instance, "/")+"/search?"+parameters.Encode(), nil)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	response, err := client.Do(request)
 	if err != nil {
-		return fmt.Errorf("%w: websearch request: %v", ErrUnavailable, err)
+		return nil, fmt.Errorf("%w: websearch request: %v", ErrUnavailable, err)
 	}
 	defer response.Body.Close()
 	if response.StatusCode != http.StatusOK {
-		return fmt.Errorf("%w: websearch returned HTTP %d", ErrBadResponse, response.StatusCode)
+		return nil, fmt.Errorf("%w: websearch returned HTTP %d", ErrBadResponse, response.StatusCode)
 	}
 	var payload struct {
 		Results []struct {
-			URL   string `json:"url"`
-			Title string `json:"title"`
+			URL string `json:"url"`
 		} `json:"results"`
 	}
 	if err := json.NewDecoder(response.Body).Decode(&payload); err != nil {
-		return fmt.Errorf("%w: decode websearch response: %v", ErrBadResponse, err)
+		return nil, fmt.Errorf("%w: decode websearch response: %v", ErrBadResponse, err)
 	}
+	results := make([]Result, 0, len(payload.Results))
 	for _, item := range payload.Results {
-		parsed, err := url.Parse(item.URL)
-		if err != nil {
-			continue
+		resolved, resolveErr := resolveDiscoveredURL(ctx, client, item.URL, fontQuery, allowed)
+		if resolveErr == nil {
+			results = append(results, resolved...)
 		}
-		filename := filepath.Base(parsed.Path)
-		format := strings.TrimPrefix(strings.ToLower(filepath.Ext(filename)), ".")
-		if !allowed[format] {
-			continue
-		}
-		out <- Event{Type: EventResult, Result: Result{
-			Name: query, Filename: filename, Format: format, Source: parsed.Host,
-			URL: item.URL, Trusted: false, License: "unknown",
-		}}
 	}
-	return nil
+	return results, nil
+}
+
+func webSearchQueries(query string, formats []string) []string {
+	quoted := fmt.Sprintf("%q", query)
+	queries := make([]string, 0, 6)
+	primary := []string{"ttf", "otf"}
+	for _, format := range primary {
+		queries = append(queries, fmt.Sprintf("%q", query+"."+format))
+	}
+	queries = append(queries,
+		"site:vk.com "+quoted,
+		quoted+" \"index of\" "+strings.Join(prefixedFormats(formats), " OR "),
+		"intitle:"+quoted+" github",
+		quoted+" \"@font-face\" filetype:css",
+	)
+	return queries
+}
+
+func prefixedFormats(formats []string) []string {
+	values := make([]string, 0, len(formats))
+	for _, format := range formats {
+		values = append(values, "."+strings.TrimPrefix(strings.ToLower(format), "."))
+	}
+	values = append(values, ".zip", ".tar.gz")
+	return values
 }

--- a/internal/rank/rank.go
+++ b/internal/rank/rank.go
@@ -16,15 +16,17 @@ type Tags struct {
 	Format       string
 	Weight       string
 	Italic       bool
+	Variable     bool
 	FamilyMember bool
 }
 
 type Weights struct {
-	Format      float64 `yaml:"format"`
-	FamilySize  float64 `yaml:"family_size"`
-	Trusted     float64 `yaml:"trusted"`
-	SizePenalty float64 `yaml:"size_penalty"`
-	WeightBonus float64 `yaml:"weight_bonus"`
+	Format        float64 `yaml:"format"`
+	FamilySize    float64 `yaml:"family_size"`
+	Trusted       float64 `yaml:"trusted"`
+	SizePenalty   float64 `yaml:"size_penalty"`
+	WeightBonus   float64 `yaml:"weight_bonus"`
+	VariableBonus float64 `yaml:"variable_bonus"`
 }
 
 type Intent struct {
@@ -36,30 +38,33 @@ type Intent struct {
 }
 
 var (
-	separators = regexp.MustCompile(`[-_.]+`)
+	separators = regexp.MustCompile(`[^\pL\pN]+`)
 	spaces     = regexp.MustCompile(`\s+`)
-	variable   = regexp.MustCompile(`(?i)(?:\[wght\]|\bvar(?:iable)?\b)`)
+	variable   = regexp.MustCompile(`(?i)(?:\[[a-z,]+\]|variablefont|\bvar(?:iable)?(?:font)?\b)`)
 	weights    = map[string]string{
 		"thin": "thin", "hairline": "thin", "extralight": "light", "ultralight": "light",
 		"light": "light", "book": "regular", "regular": "regular", "normal": "regular",
 		"medium": "medium", "semibold": "semibold", "demi": "semibold", "demibold": "semibold",
 		"bold": "bold", "extrabold": "bold", "ultrabold": "bold", "heavy": "black",
-		"black": "black", "ultra": "black",
+		"black": "black", "blk": "black", "ultra": "black",
+		"reg": "regular", "roman": "regular", "med": "medium",
+		"bd": "bold", "bld": "bold", "sb": "semibold", "semibd": "semibold",
 	}
 )
 
 func DefaultWeights() Weights {
-	return Weights{Format: 3, FamilySize: 2, Trusted: 1.5, SizePenalty: 0.5, WeightBonus: 2}
+	return Weights{Format: 3, FamilySize: 4, Trusted: 1.5, SizePenalty: 0.5, WeightBonus: 2, VariableBonus: 1.5}
 }
 
 func ParseFilename(filename string) Tags {
 	text := strings.TrimSuffix(filepath.Base(filename), filepath.Ext(filename))
 	format := strings.TrimPrefix(strings.ToLower(filepath.Ext(filename)), ".")
+	isVariable := variable.MatchString(text)
 	text = variable.ReplaceAllString(text, "")
 	text = splitCamelCase(text)
 	parts := strings.Fields(strings.ToLower(separators.ReplaceAllString(text, " ")))
 
-	tags := Tags{Format: format}
+	tags := Tags{Format: format, Variable: isVariable}
 	family := make([]string, 0, len(parts))
 	for index := 0; index < len(parts); index++ {
 		part := parts[index]
@@ -84,6 +89,9 @@ func ParseFilename(filename string) Tags {
 		}
 		if compact == "it" {
 			tags.Italic = true
+			continue
+		}
+		if compact == "sc" || compact == "smallcaps" {
 			continue
 		}
 		if weight, ok := weights[compact]; ok {
@@ -114,8 +122,63 @@ func splitCamelCase(value string) string {
 	return out.String()
 }
 
-func Results(results []provider.Result, wantedWeight string, weights Weights) []provider.Result {
-	ranked := append([]provider.Result(nil), results...)
+func NormalizeQuery(query string) string {
+	return strings.Join(strings.Fields(separators.ReplaceAllString(query, " ")), " ")
+}
+
+func FamilyQuery(query string) string {
+	parts := strings.Fields(NormalizeQuery(query))
+	for len(parts) > 1 {
+		last := strings.ToLower(parts[len(parts)-1])
+		if last == "italic" || last == "oblique" || last == "retina" {
+			parts = parts[:len(parts)-1]
+			continue
+		}
+		if len(parts) > 2 {
+			compound := strings.ToLower(parts[len(parts)-2] + parts[len(parts)-1])
+			if _, ok := weights[compound]; ok {
+				parts = parts[:len(parts)-2]
+				continue
+			}
+		}
+		if _, ok := weights[last]; ok {
+			parts = parts[:len(parts)-1]
+			continue
+		}
+		break
+	}
+	return strings.Join(parts, " ")
+}
+
+func AdaptiveQueries(query string) []string {
+	canonical := FamilyQuery(query)
+	words := strings.Fields(canonical)
+	candidates := []string{
+		canonical,
+		strings.Join(words, ""),
+		strings.Join(words, "-"),
+		strings.Join(words, "_"),
+	}
+	seen := make(map[string]bool, len(candidates))
+	queries := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		if candidate != "" && !seen[candidate] {
+			seen[candidate] = true
+			queries = append(queries, candidate)
+		}
+	}
+	return queries
+}
+
+func Results(results []provider.Result, query, wantedWeight string, weights Weights) []provider.Result {
+	normalizedQuery := strings.ToLower(NormalizeQuery(query))
+	compactQuery := strings.ReplaceAll(normalizedQuery, " ", "")
+	ranked := make([]provider.Result, 0, len(results))
+	for _, result := range results {
+		if compactQuery == "" || relevance(result, normalizedQuery, compactQuery) > 0 {
+			ranked = append(ranked, result)
+		}
+	}
 	familySizes := make(map[string]map[string]struct{})
 	for i := range ranked {
 		tags := ParseFilename(ranked[i].Filename)
@@ -124,6 +187,9 @@ func Results(results []provider.Result, wantedWeight string, weights Weights) []
 		}
 		if ranked[i].Weight == "" {
 			ranked[i].Weight = tags.Weight
+		}
+		if tags.Variable {
+			ranked[i].Variable = true
 		}
 		key := tags.Family + "\x00" + ranked[i].Source
 		if familySizes[key] == nil {
@@ -135,7 +201,7 @@ func Results(results []provider.Result, wantedWeight string, weights Weights) []
 	}
 	for i := range ranked {
 		tags := ParseFilename(ranked[i].Filename)
-		formatRank := map[string]float64{"otf": 3, "ttf": 2, "woff2": 1, "woff": 0.5}[ranked[i].Format]
+		formatRank := map[string]float64{"otf": 3, "ttf": 2, "dfont": 1.5, "pfb": 1, "woff2": 0.75, "woff": 0.5, "pfm": 0.1}[ranked[i].Format]
 		score := weights.Format * formatRank
 		score += weights.FamilySize * math.Log2(1+float64(len(familySizes[tags.Family+"\x00"+ranked[i].Source])))
 		if ranked[i].Trusted {
@@ -144,13 +210,104 @@ func Results(results []provider.Result, wantedWeight string, weights Weights) []
 		if wantedWeight != "" && ranked[i].Weight == wantedWeight {
 			score += weights.WeightBonus * 3
 		}
+		if ranked[i].Variable {
+			score += weights.VariableBonus
+		}
 		if ranked[i].SizeBytes > 0 && ranked[i].SizeBytes < 10_000 {
 			score -= weights.SizePenalty
 		}
 		ranked[i].Score = score
 	}
-	sort.SliceStable(ranked, func(i, j int) bool { return ranked[i].Score > ranked[j].Score })
+	sort.Slice(ranked, func(i, j int) bool {
+		leftRelevance := relevance(ranked[i], normalizedQuery, compactQuery)
+		rightRelevance := relevance(ranked[j], normalizedQuery, compactQuery)
+		if leftRelevance != rightRelevance {
+			return leftRelevance > rightRelevance
+		}
+		if ranked[i].Score != ranked[j].Score {
+			return ranked[i].Score > ranked[j].Score
+		}
+		if ranked[i].Filename != ranked[j].Filename {
+			return ranked[i].Filename < ranked[j].Filename
+		}
+		if ranked[i].Source != ranked[j].Source {
+			return ranked[i].Source < ranked[j].Source
+		}
+		return ranked[i].URL < ranked[j].URL
+	})
 	return ranked
+}
+
+func Relevance(result provider.Result, query string) int {
+	normalizedQuery := strings.ToLower(NormalizeQuery(query))
+	return relevance(result, normalizedQuery, strings.ReplaceAll(normalizedQuery, " ", ""))
+}
+
+func relevance(result provider.Result, normalizedQuery, compactQuery string) int {
+	family := strings.ToLower(NormalizeQuery(ParseFilename(result.Filename).Family))
+	if normalizedQuery != "" && family == normalizedQuery {
+		return 10_000
+	}
+	if compactQuery != "" && strings.ReplaceAll(family, " ", "") == compactQuery {
+		return 9_000
+	}
+	compactFamily := strings.ReplaceAll(family, " ", "")
+	if compactQuery != "" && compactFamily != "" &&
+		(strings.HasPrefix(compactQuery, compactFamily) || strings.HasPrefix(compactFamily, compactQuery)) {
+		return len(compactFamily)
+	}
+	if fuzzyPrefixMatch(compactFamily, compactQuery) {
+		return len(compactFamily)
+	}
+	// Some direct CSS and archive sources use filenames such as Regular.woff2
+	// or font.woff2. In that narrow case the provider's family name is the only
+	// useful identity. Do not use the hint for meaningful but unrelated names.
+	if family == "" || family == "font" || family == "webfont" {
+		name := strings.ToLower(NormalizeQuery(result.Name))
+		if name == normalizedQuery {
+			return 8_000
+		}
+		if compactQuery != "" && strings.ReplaceAll(name, " ", "") == compactQuery {
+			return 7_000
+		}
+	}
+	return 0
+}
+
+func fuzzyPrefixMatch(family, query string) bool {
+	familyRunes, queryRunes := []rune(family), []rune(query)
+	if len(familyRunes) < 5 || len(queryRunes) < len(familyRunes)-1 {
+		return false
+	}
+	for _, length := range []int{len(familyRunes) - 1, len(familyRunes), len(familyRunes) + 1} {
+		if length <= len(queryRunes) && editDistance(familyRunes, queryRunes[:length]) <= 1 {
+			return true
+		}
+	}
+	return false
+}
+
+func editDistance(left, right []rune) int {
+	previous := make([]int, len(right)+1)
+	for index := range previous {
+		previous[index] = index
+	}
+	for leftIndex := 1; leftIndex <= len(left); leftIndex++ {
+		current := make([]int, len(right)+1)
+		current[0] = leftIndex
+		for rightIndex := 1; rightIndex <= len(right); rightIndex++ {
+			cost := 0
+			if left[leftIndex-1] != right[rightIndex-1] {
+				cost = 1
+			}
+			current[rightIndex] = min(
+				min(current[rightIndex-1]+1, previous[rightIndex]+1),
+				previous[rightIndex-1]+cost,
+			)
+		}
+		previous = current
+	}
+	return previous[len(right)]
 }
 
 func WeightOf(result provider.Result) string {
@@ -185,7 +342,7 @@ func ParseIntent(input string) Intent {
 	parts := strings.Fields(intent.Query)
 	if len(parts) > 1 {
 		last := strings.ToLower(parts[len(parts)-1])
-		if last == "otf" || last == "ttf" || last == "woff" || last == "woff2" {
+		if last == "otf" || last == "ttf" || last == "woff" || last == "woff2" || last == "dfont" || last == "pfb" || last == "pfm" {
 			intent.Format = last
 			parts = parts[:len(parts)-1]
 			intent.Query = strings.Join(parts, " ")
@@ -198,6 +355,7 @@ func ParseIntent(input string) Intent {
 			intent.Query = strings.Join(parts[:len(parts)-1], " ")
 		}
 	}
+	intent.Query = NormalizeQuery(intent.Query)
 	return intent
 }
 

--- a/internal/rank/rank_test.go
+++ b/internal/rank/rank_test.go
@@ -1,6 +1,7 @@
 package rank
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/microck/moji/internal/provider"
@@ -15,18 +16,22 @@ func TestParseFilename(t *testing.T) {
 		weight   string
 		format   string
 		italic   bool
+		variable bool
 	}{
-		{"ProximaNova-Bold.ttf", "proxima nova", "bold", "ttf", false},
-		{"Proxima-Nova-Regular.otf", "proxima nova", "regular", "otf", false},
-		{"HelveticaNeueLTStd-Light.otf", "helvetica neue lt std", "light", "otf", false},
-		{"SourceSans-SemiBoldItalic.woff2", "source sans", "semibold", "woff2", true},
-		{"Avenir-DemiBoldOblique.ttf", "avenir", "semibold", "ttf", true},
-		{"Inter-ExtraBold.otf", "inter", "bold", "otf", false},
-		{"Inter-Extra-Bold.ttf", "inter", "bold", "ttf", false},
-		{"Inter-UltraLightItalic.woff2", "inter", "light", "woff2", true},
-		{"Inter.var.ttf", "inter", "", "ttf", false},
-		{"Inter[wght].ttf", "inter", "", "ttf", false},
-		{"font-awesome-webfont.woff2", "font awesome webfont", "", "woff2", false},
+		{"ProximaNova-Bold.ttf", "proxima nova", "bold", "ttf", false, false},
+		{"Proxima-Nova-Regular.otf", "proxima nova", "regular", "otf", false, false},
+		{"HelveticaNeueLTStd-Light.otf", "helvetica neue lt std", "light", "otf", false, false},
+		{"AvenirNextCondensed-Bold.ttf", "avenir next condensed", "bold", "ttf", false, false},
+		{"FF-Meta-Pro-Normal-Italic.otf", "ff meta pro", "regular", "otf", true, false},
+		{"ExampleSC-Bd.pfb", "example", "bold", "pfb", false, false},
+		{"SourceSans-SemiBoldItalic.woff2", "source sans", "semibold", "woff2", true, false},
+		{"Avenir-DemiBoldOblique.ttf", "avenir", "semibold", "ttf", true, false},
+		{"Inter-ExtraBold.otf", "inter", "bold", "otf", false, false},
+		{"Inter-Extra-Bold.ttf", "inter", "bold", "ttf", false, false},
+		{"Inter-UltraLightItalic.woff2", "inter", "light", "woff2", true, false},
+		{"Inter.var.ttf", "inter", "", "ttf", false, true},
+		{"Inter[wdth,wght].ttf", "inter", "", "ttf", false, true},
+		{"font-awesome-webfont.woff2", "font awesome webfont", "", "woff2", false, false},
 	}
 
 	for _, test := range tests {
@@ -34,10 +39,35 @@ func TestParseFilename(t *testing.T) {
 		t.Run(test.filename, func(t *testing.T) {
 			t.Parallel()
 			tags := ParseFilename(test.filename)
-			if tags.Family != test.family || tags.Weight != test.weight || tags.Format != test.format || tags.Italic != test.italic {
+			if tags.Family != test.family || tags.Weight != test.weight || tags.Format != test.format || tags.Italic != test.italic || tags.Variable != test.variable {
 				t.Fatalf("ParseFilename(%q) = %#v", test.filename, tags)
 			}
 		})
+	}
+}
+
+func TestRankPrefersCompleteFamilySource(t *testing.T) {
+	t.Parallel()
+	results := []provider.Result{
+		{Filename: "Example-Regular.otf", Format: "otf", Source: "single"},
+		{Filename: "Example-Regular.ttf", Format: "ttf", Source: "family"},
+		{Filename: "Example-Bold.ttf", Format: "ttf", Source: "family"},
+		{Filename: "Example-Light.ttf", Format: "ttf", Source: "family"},
+	}
+	if got := Results(results, "Example", "", DefaultWeights())[0].Source; got != "family" {
+		t.Fatalf("best source = %q", got)
+	}
+}
+
+func TestRankRecognizesAndPrefersVariableFont(t *testing.T) {
+	t.Parallel()
+	results := []provider.Result{
+		{Filename: "Inter-Regular.ttf", Format: "ttf", Source: "same"},
+		{Filename: "Inter[wdth,wght].ttf", Format: "ttf", Source: "same"},
+	}
+	ranked := Results(results, "Inter", "", DefaultWeights())
+	if !ranked[0].Variable {
+		t.Fatalf("ranked = %#v", ranked)
 	}
 }
 
@@ -49,9 +79,73 @@ func TestRankPrefersRequestedWeightThenFormat(t *testing.T) {
 		{Filename: "Example-Bold.ttf", Format: "ttf", Weight: "bold", Trusted: true, SizeBytes: 100_000},
 		{Filename: "Example-Bold.woff2", Format: "woff2", Weight: "bold", Trusted: false, SizeBytes: 50_000},
 	}
-	ranked := Results(results, "bold", DefaultWeights())
+	ranked := Results(results, "Example", "bold", DefaultWeights())
 	if ranked[0].Filename != "Example-Bold.ttf" {
 		t.Fatalf("best result = %q, want requested trusted bold", ranked[0].Filename)
+	}
+}
+
+func TestRankPrefersRelevantFamilyOverQuality(t *testing.T) {
+	t.Parallel()
+	results := []provider.Result{
+		{Filename: "Montserrat-Regular.otf", Format: "otf", Trusted: true, Source: "trusted"},
+		{Filename: "Inter-Regular.woff", Format: "woff", Source: "other"},
+	}
+	if got := Results(results, "inter", "", DefaultWeights())[0].Filename; got != "Inter-Regular.woff" {
+		t.Fatalf("best result = %q", got)
+	}
+}
+
+func TestRankKeepsOneCharacterSearchCorrection(t *testing.T) {
+	t.Parallel()
+	results := []provider.Result{{Filename: "Bariol Serif.ttf", Source: "search"}}
+	ranked := Results(results, "ariol serif italic", "", DefaultWeights())
+	if len(ranked) != 1 || ranked[0].Filename != "Bariol Serif.ttf" {
+		t.Fatalf("ranked = %#v", ranked)
+	}
+}
+
+func TestRankUsesFamilyHintOnlyForOpaqueFilenames(t *testing.T) {
+	t.Parallel()
+	results := []provider.Result{
+		{Name: "Inter", Filename: "Regular.woff2", Source: "css"},
+		{Name: "Inter", Filename: "Montserrat-Regular.woff2", Source: "unrelated"},
+	}
+	ranked := Results(results, "Inter", "", DefaultWeights())
+	if len(ranked) != 1 || ranked[0].Filename != "Regular.woff2" {
+		t.Fatalf("ranked = %#v", ranked)
+	}
+}
+
+func TestFamilyQueryRemovesStyleAndWeightSuffixes(t *testing.T) {
+	t.Parallel()
+	tests := map[string]string{
+		"BASIER narrow regular":     "BASIER narrow",
+		"bariol_serif italic":       "bariol serif",
+		"geo manist extra-light":    "geo manist",
+		"ibm plex sans bold italic": "ibm plex sans",
+		"fira-code retina":          "fira code",
+		"Source Sans 3":             "Source Sans 3",
+	}
+	for input, want := range tests {
+		if got := FamilyQuery(input); got != want {
+			t.Errorf("FamilyQuery(%q) = %q, want %q", input, got, want)
+		}
+	}
+}
+
+func TestAdaptiveQueriesUseCommonFilenameConventions(t *testing.T) {
+	want := []string{"Proxima Nova", "ProximaNova", "Proxima-Nova", "Proxima_Nova"}
+	got := AdaptiveQueries("Proxima Nova Bold")
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("queries = %#v, want %#v", got, want)
+	}
+}
+
+func TestRankReturnsNonNilEmptySlice(t *testing.T) {
+	t.Parallel()
+	if ranked := Results(nil, "missing", "", DefaultWeights()); ranked == nil {
+		t.Fatal("empty ranked results must encode as []")
 	}
 }
 
@@ -66,6 +160,7 @@ func TestParseIntent(t *testing.T) {
 		{"helvetica neue entire family", Intent{Query: "helvetica neue", WantFamily: true, Max: 10}},
 		{"FF Meta Serif regular", Intent{Query: "FF Meta Serif", WantWeight: "regular", Max: 1}},
 		{"proxima nova bold otf", Intent{Query: "proxima nova", WantWeight: "bold", Format: "otf", Max: 1}},
+		{"legacy family pfb", Intent{Query: "legacy family", Format: "pfb", Max: 1}},
 	}
 	for _, test := range tests {
 		got := ParseIntent(test.input)

--- a/internal/tui/home.go
+++ b/internal/tui/home.go
@@ -21,13 +21,14 @@ var mojiWordmark = []string{
 	"█ ▀ █ █▄█ █▄█ █",
 }
 
-func NewHomeModel(search SearchFunc, downloader DownloadFunc, color bool, wantedWeight string, ranking rank.Weights, maximum int) Model {
+func NewHomeModel(search SearchFunc, downloader DownloadFunc, color bool, wantedWeight string, ranking rank.Weights, maximum int, homeHint string) Model {
 	model := NewModel(nil, downloader, color)
 	model.home = true
 	model.search = search
 	model.wantedWeight = wantedWeight
 	model.ranking = ranking
 	model.maximum = maximum
+	model.homeHint = homeHint
 	return model
 }
 
@@ -115,6 +116,14 @@ func (model Model) viewHome() string {
 	body = append(body, model.accent.Render("└"+strings.Repeat("─", max(0, inputWidth-2))+"┘"))
 	if model.termHeight() >= 12 {
 		body = append(body, model.faint.Render("Type a font name, then press Enter."))
+	}
+	if model.homeHint != "" {
+		body = append(body, "")
+		for _, line := range wrapCells("[!] "+model.homeHint, contentWidth) {
+			if line != "" {
+				body = append(body, model.warning.Render(line))
+			}
+		}
 	}
 	if model.status != "" {
 		body = append(body, model.accent.Render(truncate(model.status, contentWidth)))

--- a/internal/tui/results.go
+++ b/internal/tui/results.go
@@ -18,6 +18,7 @@ type DownloadFunc func(provider.Result) (string, error)
 
 type Model struct {
 	home           bool
+	homeHint       string
 	query          string
 	search         SearchFunc
 	all            []provider.Result
@@ -40,6 +41,7 @@ type Model struct {
 	brand          lipgloss.Style
 	accent         lipgloss.Style
 	faint          lipgloss.Style
+	warning        lipgloss.Style
 	width          int
 	height         int
 }
@@ -63,15 +65,17 @@ func NewModel(results []provider.Result, downloader DownloadFunc, color bool) Mo
 		model.brand = lipgloss.NewStyle().Foreground(lipgloss.Color("#FF8C00")).Bold(true)
 		model.accent = lipgloss.NewStyle().Foreground(lipgloss.Color("#FFA500"))
 		model.faint = lipgloss.NewStyle().Foreground(lipgloss.Color("#666666"))
+		model.warning = lipgloss.NewStyle().Foreground(lipgloss.Color("#FFD75F")).Bold(true)
 	}
 	model.refresh()
 	return model
 }
 
-func NewLiveModel(events <-chan provider.Event, downloader DownloadFunc, color bool, wantedWeight string, ranking rank.Weights, maximum int) Model {
+func NewLiveModel(events <-chan provider.Event, downloader DownloadFunc, color bool, query, wantedWeight string, ranking rank.Weights, maximum int) Model {
 	model := NewModel(nil, downloader, color)
 	model.events = events
 	model.loading = true
+	model.query = rank.NormalizeQuery(query)
 	model.wantedWeight = wantedWeight
 	model.ranking = ranking
 	model.maximum = maximum
@@ -399,18 +403,19 @@ func (model Model) resultRow(result provider.Result, selected bool) []string {
 		}
 		return line
 	}
+	format := displayFormat(result)
 	if width >= 72 {
-		formatWidth, weightWidth := 6, 11
+		formatWidth, weightWidth := 7, 11
 		sourceWidth := min(28, max(12, width/4))
 		nameWidth := max(8, width-2-formatWidth-weightWidth-sourceWidth-6)
 		line := prefix + padRight(truncate(result.Filename, nameWidth), nameWidth) + "  " +
-			padRight(strings.ToUpper(result.Format), formatWidth) + " " +
+			padRight(format, formatWidth) + " " +
 			padRight(truncate(displayWeight(result.Weight), weightWidth), weightWidth) + " " +
 			truncate(result.Source, sourceWidth)
 		return []string{decorate(line)}
 	}
 	name := prefix + truncate(result.Filename, max(1, width-2))
-	metadata := "  " + strings.ToUpper(result.Format) + "  " + displayWeight(result.Weight)
+	metadata := "  " + format + "  " + displayWeight(result.Weight)
 	if width >= 42 && result.Source != "" {
 		metadata += "  " + result.Source
 	}
@@ -424,7 +429,7 @@ func (model Model) detailLines(result provider.Result) []string {
 	for index := range nameLines {
 		lines[index] = model.accent.Render(nameLines[index])
 	}
-	fields := [][2]string{{"Format", strings.ToUpper(result.Format)}, {"Weight", displayWeight(result.Weight)}, {"Source", result.Source}, {"License", result.License}, {"URL", result.URL}}
+	fields := [][2]string{{"Format", displayFormat(result)}, {"Weight", displayWeight(result.Weight)}, {"Source", result.Source}, {"License", result.License}, {"URL", result.URL}}
 	for _, field := range fields {
 		lines = append(lines, wrapCells(field[0]+": "+field[1], width)...)
 	}
@@ -532,7 +537,7 @@ func eventStatus(event provider.Event) string {
 func (model *Model) refresh() {
 	model.visible = model.visible[:0]
 	filter := strings.ToLower(model.filter)
-	for _, result := range rank.Results(model.all, model.wantedWeight, model.ranking) {
+	for _, result := range rank.Results(model.all, model.query, model.wantedWeight, model.ranking) {
 		weight := rank.WeightOf(result)
 		if model.wantedWeight != "" && weight != model.wantedWeight {
 			continue
@@ -554,8 +559,6 @@ func (model *Model) refresh() {
 		sort.SliceStable(model.visible, func(i, j int) bool { return model.visible[i].Format < model.visible[j].Format })
 	case 2:
 		sort.SliceStable(model.visible, func(i, j int) bool { return model.visible[i].SizeBytes < model.visible[j].SizeBytes })
-	default:
-		sort.SliceStable(model.visible, func(i, j int) bool { return model.visible[i].Score > model.visible[j].Score })
 	}
 	if model.cursor >= len(model.visible) {
 		model.cursor = max(0, len(model.visible)-1)
@@ -575,6 +578,14 @@ func displayWeight(weight string) string {
 		return "-"
 	}
 	return weight
+}
+
+func displayFormat(result provider.Result) string {
+	format := strings.ToUpper(result.Format)
+	if result.Variable {
+		format += "-VAR"
+	}
+	return format
 }
 
 func Run(input io.Reader, output io.Writer, model Model) error {

--- a/internal/tui/results_test.go
+++ b/internal/tui/results_test.go
@@ -68,7 +68,7 @@ func TestModelViewIncludesMonaMascot(t *testing.T) {
 func TestHomeUsesFullMonaAndBlockWordmark(t *testing.T) {
 	t.Parallel()
 	for _, size := range []struct{ width, height int }{{100, 30}, {40, 16}} {
-		model := sizedModel(t, NewHomeModel(nil, nil, false, "", rank.DefaultWeights(), 10), size.width, size.height)
+		model := sizedModel(t, NewHomeModel(nil, nil, false, "", rank.DefaultWeights(), 10, ""), size.width, size.height)
 		view := model.View()
 		assertViewFits(t, view, size.width, size.height)
 		for _, wanted := range []string{"（　・∀・）", "█▀▄▀█ █▀█   █ █", "█ ▀ █ █▄█ █▄█ █"} {
@@ -102,7 +102,7 @@ func TestViewsFitSupportedTerminalSizes(t *testing.T) {
 			model.preview = true
 			assertViewFits(t, model.View(), size.width, size.height)
 
-			home := sizedModel(t, NewHomeModel(nil, nil, false, "", rank.DefaultWeights(), 10), size.width, size.height)
+			home := sizedModel(t, NewHomeModel(nil, nil, false, "", rank.DefaultWeights(), 10, ""), size.width, size.height)
 			assertViewFits(t, home.View(), size.width, size.height)
 		})
 	}
@@ -239,14 +239,14 @@ func TestHomeModelStartsLiveSearchFromTypedQuery(t *testing.T) {
 	t.Parallel()
 
 	events := make(chan provider.Event, 2)
-	events <- provider.Event{Provider: "fixture", Type: provider.EventResult, Result: provider.Result{Filename: "Inter-Regular.otf", Format: "otf"}}
+	events <- provider.Event{Provider: "fixture", Type: provider.EventResult, Result: provider.Result{Filename: "Quicksand-Regular.otf", Format: "otf"}}
 	events <- provider.Event{Provider: "fixture", Type: provider.EventStatus, Status: provider.StateDone, Count: 1}
 	close(events)
 	var searched string
 	model := NewHomeModel(func(query string) (<-chan provider.Event, error) {
 		searched = query
 		return events, nil
-	}, nil, false, "", rank.DefaultWeights(), 10)
+	}, nil, false, "", rank.DefaultWeights(), 10, "")
 	if !strings.Contains(model.View(), "Type a font name") {
 		t.Fatalf("home prompt missing:\n%s", model.View())
 	}
@@ -264,13 +264,13 @@ func TestHomeModelStartsLiveSearchFromTypedQuery(t *testing.T) {
 		updated, command = model.Update(command())
 		model = updated.(Model)
 	}
-	if !strings.Contains(model.View(), "Inter-Regular.otf") {
+	if !strings.Contains(model.View(), "Quicksand-Regular.otf") {
 		t.Fatalf("search result missing:\n%s", model.View())
 	}
 }
 
 func TestHomeModelKeepsPastedQueryOnOneLine(t *testing.T) {
-	model := sizedModel(t, NewHomeModel(nil, nil, false, "", rank.DefaultWeights(), 10), 40, 12)
+	model := sizedModel(t, NewHomeModel(nil, nil, false, "", rank.DefaultWeights(), 10, ""), 40, 12)
 
 	updated, _ := model.Update(tea.KeyMsg{
 		Type:  tea.KeyRunes,
@@ -284,6 +284,18 @@ func TestHomeModelKeepsPastedQueryOnOneLine(t *testing.T) {
 	}
 	if got := len(strings.Split(model.View(), "\n")); got != 12 {
 		t.Fatalf("rendered lines = %d, want terminal height 12", got)
+	}
+}
+
+func TestHomeModelShowsGitHubConfigurationHint(t *testing.T) {
+	t.Parallel()
+	model := sizedModel(t, NewHomeModel(
+		nil, nil, false, "", rank.DefaultWeights(), 10,
+		"GitHub search is off. Set GITHUB_TOKEN to search more repositories.",
+	), 96, 30)
+	view := model.View()
+	if !strings.Contains(view, "[!] GitHub search is off") || !strings.Contains(view, "GITHUB_TOKEN") {
+		t.Fatalf("GitHub hint missing:\n%s", view)
 	}
 }
 
@@ -329,7 +341,7 @@ func TestLiveModelStreamsProviderEvents(t *testing.T) {
 	events <- provider.Event{Provider: "fixture", Type: provider.EventResult, Result: provider.Result{Filename: "Live.otf", Format: "otf"}}
 	events <- provider.Event{Provider: "fixture", Type: provider.EventStatus, Status: provider.StateDone, Count: 1}
 	close(events)
-	model := NewLiveModel(events, nil, false, "", rank.DefaultWeights(), 10)
+	model := NewLiveModel(events, nil, false, "", "", rank.DefaultWeights(), 10)
 	for command := model.Init(); command != nil; {
 		updated, next := model.Update(command())
 		model = updated.(Model)
@@ -350,7 +362,7 @@ func TestLiveModelHonorsExplicitMaximum(t *testing.T) {
 	}
 	events <- provider.Event{Provider: "fixture", Type: provider.EventStatus, Status: provider.StateDone, Count: 12}
 	close(events)
-	model := NewLiveModel(events, nil, false, "", rank.DefaultWeights(), 5)
+	model := NewLiveModel(events, nil, false, "", "", rank.DefaultWeights(), 5)
 	for command := model.Init(); command != nil; {
 		updated, next := model.Update(command())
 		model = updated.(Model)


### PR DESCRIPTION
**What changed**

- Add safe ZIP, TAR, and TGZ font extraction
- Discover direct fonts through CSS and `@font-face`
- Search bounded GitHub repository trees and release assets
- Add Fontsource and Google Fonts under the `registry` provider
- Add adaptive filename query variants
- Add a versioned source-plugin protocol
- Update CLI, TUI, configuration, README, and documentation

**Why**

Moji previously missed fonts distributed through archives, stylesheets, release assets, and alternate filename conventions. These additions improve direct-file discovery without accepting webpages or bypassing protected downloads.

**Validation**

- `CGO_ENABLED=1 go test -race -count=1 ./...`
- `npm run verify`
- Production documentation build with 51 generated pages
- Workflow artifact verification
- Live no-Kagi font corpus

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands Moji’s direct font discovery pipeline. The main changes are:

- Safe ZIP, TAR, and TGZ archive inspection and archive-member downloads.
- CSS `@font-face`, GitHub tree/release, registry, Kagi/SearXNG, and source-plugin discovery paths.
- Expanded format support, adaptive query variants, ranking updates, and archive-aware result identity.
- CLI, TUI, config, README, docs, and tests updated for the new providers and formats.

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the reviewed changes.

No verified blocking issues were found in the changed discovery, provider, ranking, cache, download, or UI paths.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- T-Rex ran the full Go race test as part of code-execution validation and produced the proof log.
- The proof log records the working directory, the exact command, the Go version, and the complete package output for the run.
- The test completed successfully with exit code 0 and elapsed time of 55 seconds.
- An earlier shell-wrapper attempt failed before executing the test because /bin/sh did not support pipefail; the test was then re-run under bash.

<a href="https://app.greptile.com/trex/runs/14102118/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/archivefont/archive.go | Adds bounded ZIP/TAR/TGZ inspection and extraction with path and size safety checks. |
| internal/provider/discovery.go | Adds HTTPS direct-file, CSS, GitHub blob conversion, and archive-member discovery behind shared validation boundaries. |
| internal/provider/github.go | Expands GitHub discovery to adaptive Code Search plus bounded repository tree and release asset fallback. |
| internal/provider/websearch.go | Runs Kagi/SearXNG web-search backends concurrently and resolves results through direct discovery. |
| internal/provider/registries.go | Adds registry provider composition for Fontsource metadata and Google Fonts stylesheet URLs. |
| internal/provider/plugins.go | Adds versioned source-plugin execution and resolves plugin URLs through the same discovery boundary. |
| internal/download/download.go | Extends downloader validation to safely extract archive members and validate expanded font bytes. |
| internal/rank/rank.go | Updates parsing, adaptive query generation, relevance filtering, and scoring for expanded formats and variable fonts. |
| internal/app/search.go | Wires new providers, adaptive search rounds, provider selection, and TUI hints into application search flow. |
| internal/config/config.go | Adds defaults for expanded formats, registry/plugins/websearch providers, source plugins, and per-provider limits. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant App
participant Aggregator
participant Providers
participant Discovery
participant Downloader

User->>App: Search query and formats
App->>Aggregator: Run selected providers
Aggregator->>Providers: Search adaptive query variants
Providers->>Discovery: Resolve direct URLs, CSS, archives
Discovery-->>Providers: Validated direct font results
Providers-->>Aggregator: Result events
Aggregator-->>App: Unique ranked results
User->>App: Download selection
App->>Downloader: Download result
Downloader->>Discovery: Extract archive member when needed
Downloader-->>User: Saved validated font
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant App
participant Aggregator
participant Providers
participant Discovery
participant Downloader

User->>App: Search query and formats
App->>Aggregator: Run selected providers
Aggregator->>Providers: Search adaptive query variants
Providers->>Discovery: Resolve direct URLs, CSS, archives
Discovery-->>Providers: Validated direct font results
Providers-->>Aggregator: Result events
Aggregator-->>App: Unique ranked results
User->>App: Download selection
App->>Downloader: Download result
Downloader->>Discovery: Extract archive member when needed
Downloader-->>User: Saved validated font
```

</a>

<sub>Reviews (5): Last reviewed commit: ["feat: expand direct font discovery"](https://github.com/microck/moji/commit/c29c25f8b9209e27965fcfce74d26c58484e5128) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43530664)</sub>

<!-- /greptile_comment -->