### PR TITLE
feat: harden font downloads and release verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,5 +39,14 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
+      - name: Test release contract
+        run: npm run test:release
+
+      - name: Verify release archive
+        run: npm run release
+
+      - name: Verify committed native binaries
+        run: git diff --exit-code -- binaries
+
       - name: Verify
         run: npm run verify

--- a/.workflow/search-and-release-reliability-hardening/final-report.md
+++ b/.workflow/search-and-release-reliability-hardening/final-report.md
@@ -1,0 +1,68 @@
+# Final Report: Search and release reliability hardening
+
+## Outcome
+
+Moji now continues through ranked candidates until it reaches the download
+cap or exhausts the pool. Entire-family requests stage and validate one
+provenance-coherent group before moving files. Invalid direct content is
+remembered in a bounded, expiring, crash-safe cache shared across CLI and TUI
+downloads. Ranking uses source reliability only after relevance and quality.
+
+The repository also owns a resumable release command that rebuilds and checks
+all six native targets, forces lifecycle scripts, verifies the exact npm
+archive, and repairs a partially completed npm/tag/GitHub publication only
+when artifact integrity and commit identity still match.
+
+## Accepted Results
+
+- Ranked invalid-first fallback with aggregate errors.
+- Staged family fallback using repository, stylesheet, archive, or direct-URL
+  provenance rather than display hostname.
+- 30-day, 256-entry URL-health cache with atomic replacement and a bounded
+  cross-process update lock.
+- Registry, raw GitHub, GetFonts, arbitrary-host reliability tie-break order.
+- Verify-only and explicitly publishing release modes with CI enforcement.
+- Reproducible 21-font corpus runner and checked TSV evidence.
+
+## Rejected Results
+
+- HTML pages and invalid magic bytes remain rejected.
+- Network, HTTP, policy, cancellation, and filesystem failures do not poison
+  URL health.
+- Archer and Belarius Serif Narrow Regular remain misses rather than being
+  replaced by a page or gated download.
+
+## Conflicts Resolved
+
+- `--max` remains a cap on successful files while the fallback candidate pool
+  stays untruncated.
+- Family grouping remains coherent even when several repositories share a CDN
+  hostname.
+- Source reliability remains separate from `trusted` and `license`.
+- A release retry never tags local bytes that differ from the immutable npm
+  archive and never accepts a conflicting remote tag or GitHub asset.
+
+## Verification Evidence
+
+- `CGO_ENABLED=1 go test -race ./cmd/... ./internal/... ./e2e/...`: 130 tests.
+- `npm run test:release`: 5 tests.
+- `npm run release`: six binaries rebuilt, packed, extracted, and verified.
+- `npm run verify`: Go vet/tests plus production documentation verification.
+- `git diff --exit-code -- binaries`: committed binaries match rebuilt output.
+- `npm run corpus:verify`: 19 of 21 byte-valid direct downloads; 25 invalid
+  candidates rejected and remembered.
+
+## Remaining Risks
+
+- Live font availability is external and can change after the captured corpus.
+- Multi-file filesystem moves cannot be one kernel transaction. Moji validates
+  before moving and rolls back completed moves; if rollback itself fails, the
+  error now identifies possible partial output instead of claiming success.
+
+## Reusable Follow-up
+
+- Run `npm run corpus:verify -- --output-dir <directory>` to regenerate JSON
+  and TSV corpus evidence.
+- Run `npm run release` for a non-publishing archive verification.
+- Run `npm run release:publish` only after committing a version bump and all
+  six rebuilt binaries.

--- a/.workflow/search-and-release-reliability-hardening/final-report.md
+++ b/.workflow/search-and-release-reliability-hardening/final-report.md
@@ -56,8 +56,8 @@ when artifact integrity and commit identity still match.
 
 - Live font availability is external and can change after the captured corpus.
 - Multi-file filesystem moves cannot be one kernel transaction. Moji validates
-  before moving and rolls back completed moves; if rollback itself fails, the
-  error now identifies possible partial output instead of claiming success.
+	before moving and uses no-replace operations so concurrent files are never
+	overwritten. A commit-time collision reports any already-saved family files.
 
 ## Reusable Follow-up
 

--- a/.workflow/search-and-release-reliability-hardening/final-report.md
+++ b/.workflow/search-and-release-reliability-hardening/final-report.md
@@ -56,8 +56,9 @@ when artifact integrity and commit identity still match.
 
 - Live font availability is external and can change after the captured corpus.
 - Multi-file filesystem moves cannot be one kernel transaction. Moji validates
-	before moving and uses no-replace operations so concurrent files are never
-	overwritten. A commit-time collision reports any already-saved family files.
+	before moving, holds a destination transaction lock, and uses no-replace
+	operations. A commit-time collision rolls back files whose identity still
+	matches Moji's committed files and reports any incomplete rollback.
 
 ## Reusable Follow-up
 

--- a/.workflow/search-and-release-reliability-hardening/orchestration.md
+++ b/.workflow/search-and-release-reliability-hardening/orchestration.md
@@ -1,0 +1,42 @@
+# Orchestration: Search and release reliability hardening
+
+## Execution Rules
+
+- Keep the original objective intact.
+- Ask for approval before risky, expensive, external, or destructive actions.
+- Keep immediate blocking work local.
+- Delegate only bounded, disjoint, materially useful packets.
+- Integrate packet results before final verification.
+
+## Branching Rules
+
+- If one candidate fails validation, record the failure and try the next
+  ranked candidate; do not relax validation.
+- If a failure is transient transport or server state, do not persist it as a
+  negative content-health fact.
+- If family fallback cannot remain atomic and predictable, fail before moving
+  completed files into their final destinations.
+- If source reliability conflicts with query relevance, relevance wins.
+- If artifact versions disagree at any release stage, stop before publication.
+- If the corpus exposes only a webpage or gated flow, classify it as a miss.
+
+## Packet Prompts
+
+1. Contracts: specify typed candidate failures, retryability, cache identity,
+   source classes, and release gates before behavior changes.
+2. Downloads: own app/download selection and integration tests; preserve all
+   existing safety invariants.
+3. URL health: own cache schema, TTL/size bounds, and invalid-result penalties.
+4. Ranking: own source classification and precedence tests without changing
+   legal trust semantics.
+5. Release: own a TypeScript runbook/verifier, exact tarball inspection, and
+   dry-run behavior; never publish during implementation.
+6. Docs/CI: wire the shared verifier into CI and document user-visible behavior.
+7. Audit: inspect the integrated diff, run all gates, and repeat the corpus.
+
+## Completion Audit
+
+Map every success criterion to current source, test, command, or corpus output.
+Treat a green narrow test as insufficient proof for cross-platform release
+behavior or full download semantics. Finish only when no required evidence is
+missing and external publication has not occurred without approval.

--- a/.workflow/search-and-release-reliability-hardening/packets/01-contracts.md
+++ b/.workflow/search-and-release-reliability-hardening/packets/01-contracts.md
@@ -1,0 +1,32 @@
+# Packet 01: behavioral contracts
+
+Status: completed
+
+## Download fallback
+
+- `--max` caps successful downloads; it does not cap the candidates Moji may try.
+- Ranked candidates remain ordered. A failed candidate does not hide later candidates.
+- A family request tries one normalized family and source as a unit. It never mixes sources in one family result.
+- Family grouping uses stable repository, stylesheet, archive, or direct-URL provenance rather than a display hostname alone.
+- Family files are validated in staging and become visible only after every selected member validates.
+- If no candidate succeeds, the error names every attempted candidate or family source.
+
+## URL health
+
+- Only a completed response whose bytes fail font validation is a negative URL-health observation.
+- HTTP, network, cancellation, policy, and local filesystem failures do not poison URL health.
+- Health observations expire and the store has a fixed maximum size.
+- Applying health state does not make network requests and does not alter trust or license metadata.
+
+## Source reliability
+
+- Reliability is a ranking heuristic separate from `trusted` and `license`.
+- Query relevance and coherent family completeness remain stronger ordering constraints.
+- At otherwise comparable quality, structured registries and raw GitHub rank above GetFonts and arbitrary web hosts.
+
+## Release gate
+
+- Release verification rebuilds all six native targets and inspects the exact packed tarball.
+- Manifest, JavaScript launcher, and native binary versions must match before publish.
+- Lifecycle scripts are explicitly enabled even when the user's npm configuration disables them.
+- Publishing precedes tag and GitHub release creation. Verification failure performs none of those external mutations.

--- a/.workflow/search-and-release-reliability-hardening/plan.md
+++ b/.workflow/search-and-release-reliability-hardening/plan.md
@@ -1,0 +1,92 @@
+# Search and release reliability hardening
+
+## Goal
+
+Make Moji recover from bad ranked candidates, remember invalid direct URLs,
+rank reliable sources consistently, and make stale-binary npm releases
+impossible through one repository-owned release runbook.
+
+## Success Criteria
+
+- Single-file `moji get` tries ranked candidates until one downloads and
+  validates, then reports an actionable aggregate error only when all fail.
+- Family downloads preserve family/weight selection semantics and never leave
+  partial output without clearly reporting the outcome.
+- Validation failures enter a bounded, expiring negative URL cache used by
+  later searches without adding eager downloads to the search hot path.
+- Equal-relevance results prefer structured registries, then raw GitHub,
+  GetFonts, and arbitrary web hosts, independently of license/trust metadata.
+- A canonical release command rebuilds all six targets, packs the exact npm
+  tarball, extracts it, verifies manifest/native/JS versions, forces lifecycle
+  scripts, and gates npm/tag/GitHub publication on those checks.
+- CI runs the package artifact/version verification needed to prevent the
+  `v0.2.0` stale-binary incident.
+- Contracts, CLI output, documentation, and tests describe the behavior.
+- The 21-font corpus is repeated with direct-result and byte-validation
+  evidence, without accepting pages or bypassing gated sources.
+
+## Current Context
+
+Moji v0.2.1 is the latest corrected release. The prior v0.2.0 package reused
+stale binaries because machine-level `ignore-scripts=true` skipped `prepack`.
+The 21-font corpus found 19 search hits but only 18 byte-valid direct fonts;
+Knockout was invalid, Mrs. Eaves had an invalid result ahead of a valid raw
+GitHub file, and Archer plus Belarius Serif Narrow had no direct source.
+
+## Constraints
+
+- Keep direct HTTPS files or safe archive members as the result contract.
+- Do not weaken magic/structural validation or bypass publisher gates.
+- Keep search latency bounded; do not download every candidate eagerly.
+- Keep source reliability separate from legal trust and license metadata.
+- Preserve Linux, macOS, and Windows support on x64 and arm64.
+- No external publish, tag, release, or merge without explicit approval.
+
+## Risks
+
+- Retry logic could download unwanted extra family members or leave partial
+  files after a later failure.
+- Negative caching could suppress a URL after a transient or repaired failure.
+- Reliability weights could overpower family relevance.
+- Release automation could publish after a partial verification or use the
+  wrong commit/tag target.
+
+## Approval Required
+
+Local implementation, fixtures, dry runs, and read-only corpus searches are
+approved by the goal request. Any real npm publish, GitHub tag/release, merge,
+or destructive cleanup requires a separate explicit approval.
+
+## Work Packets
+
+1. Define fallback, failure aggregation, URL-health, and reliability contracts.
+2. Implement ranked single-file and family-aware download fallback.
+3. Implement bounded negative URL health caching and ranking integration.
+4. Implement source-reliability scoring with regression coverage.
+5. Implement the repository-owned release runbook and artifact verifier.
+6. Add CI enforcement and progressive-disclosure documentation.
+7. Run security review, full verification, and the 21-font corpus.
+
+## Integration Policy
+
+Keep validation in the downloader boundary. Feed its typed failure outcome into
+URL health, then use health and reliability only as ranking inputs. Release
+automation must invoke one verifier shared with CI rather than duplicating
+checks in prose or shell fragments.
+
+## Verification
+
+- Focused unit tests for fallback ordering, aggregate errors, TTL/eviction,
+  source precedence, and family semantics.
+- HTTP integration fixtures with invalid-first/valid-second candidates.
+- Package tarball fixture that proves stale embedded versions fail closed.
+- Linux race suite plus Windows amd64 and macOS arm64 cross-builds.
+- `npm run verify`, production docs build, and workflow artifact verification.
+- Repeat the 21-font corpus and separately report search hits and validated
+  downloads.
+
+## Reusable Artifacts
+
+Keep the release verifier and runbook in the repository for every future
+release. Preserve a concise corpus procedure and expected classifications in
+the workflow results without committing proprietary font files.

--- a/.workflow/search-and-release-reliability-hardening/results/download-fallback.md
+++ b/.workflow/search-and-release-reliability-hardening/results/download-fallback.md
@@ -1,0 +1,10 @@
+# Download fallback result
+
+Status: implemented, focused verification passing
+
+- Added a typed invalid-content failure boundary for safe URL-health recording.
+- Kept the full ranked candidate pool available to `moji get`.
+- Added ranked retry until the requested success count is reached.
+- Added aggregate candidate errors.
+- Added staged, same-source family fallback through `DownloadBatch`.
+- Focused command: `go test ./internal/app ./internal/download`.

--- a/.workflow/search-and-release-reliability-hardening/results/font-corpus.md
+++ b/.workflow/search-and-release-reliability-hardening/results/font-corpus.md
@@ -1,0 +1,50 @@
+# 21-font direct-download corpus
+
+Date: 2026-07-11
+
+Command shape:
+
+```sh
+GITHUB_TOKEN= XDG_CACHE_HOME=<isolated> MOJI_CONFIG=<missing-default-config> \
+  moji get "<font>" --json --no-cache --download-dir <isolated>
+```
+
+The normal default provider set was used. GitHub was tokenless and the locally
+installed Kagi web-search option was available. Each font used an isolated
+destination. A pass required exit code 0 and a downloaded file whose first
+four bytes matched Moji's validator. No result page or gated flow counted. The
+rerunnable command is `npm run corpus:verify`. Pass `--output-dir <directory>`
+to regenerate JSON and TSV evidence. Exact filenames, sizes, SHA-256 hashes,
+and per-query rejection counts from this run are in `font-corpus.tsv`.
+
+| Query | Result | Validated signature |
+| --- | --- | --- |
+| Gotham | pass | TTF |
+| Helvetica Neue | pass | OTF |
+| Avenir | pass | TTF |
+| Futura | pass | OTF |
+| Brandon Grotesque | pass | OTF |
+| Proxima Nova | pass | OTF |
+| Univers | pass | WOFF2 |
+| FF DIN | pass | OTF |
+| Knockout | pass | OTF |
+| Garamond Premier Pro | pass | WOFF2 |
+| Whitney | pass | OTF |
+| Didot | pass | WOFF2 |
+| Neutraface | pass | OTF |
+| Trade Gothic | pass | TTF |
+| Archer | no direct match | - |
+| Akzidenz-Grotesk | pass | TTF |
+| Frutiger | pass | TTF |
+| Graphik | pass | WOFF2 |
+| Minion Pro | pass | OTF |
+| Mrs. Eaves | pass | TTF |
+| Belarius Serif Narrow Regular | no direct match | - |
+
+Summary: 19 of 21 queries produced a byte-valid direct download. The prior
+corpus produced 18 valid downloads, and Knockout now has a valid direct match.
+During this run, 25 other URLs returned invalid font bytes; Moji rejected them,
+recorded them in the bounded health cache, and continued to later candidates.
+The invalid-first fallback itself is covered by controlled HTTP integration
+tests. Archer and Belarius Serif Narrow Regular still had no direct match and
+were not replaced with webpages.

--- a/.workflow/search-and-release-reliability-hardening/results/font-corpus.tsv
+++ b/.workflow/search-and-release-reliability-hardening/results/font-corpus.tsv
@@ -1,0 +1,22 @@
+query	status	filename	format	bytes	sha256	rejected_candidates
+Gotham	pass	Gotham-Light.ttf	ttf	67400	8e4449e45d05f0bdb49f24851e1df94bc98b155237aba8f23b5513806921b494	7
+Helvetica Neue	pass	HelveticaNeue-Regular.otf	otf	676140	0ff3a909e6926ebff57ca8fd00c3c7d30405254ef9a0efb8290099d651d17562	0
+Avenir	pass	Avenir-regular.ttf	ttf	50052	abb5c29efacd5ca357db1d8d2e1f04ccec9bf180ff3c7747ae543fd067a263bc	0
+Futura	pass	futura-bold.otf	otf	17184	339e2354bc71491f3eb56c6426830f5aa9be04be318c62749cfdcfec36b14e03	0
+Brandon Grotesque	pass	BrandonGrotesque-Medium.otf	otf	89536	1f9d6d92a89f1ccfea85b8384cb0861cfb916716923e2a461c96b621fe2d1626	0
+Proxima Nova	pass	ProximaNova-SemiBold.otf	otf	143880	d42dc14b5ce4dd8819b0131c35d841123c2b350c29e0a5b6cc764f239f57e375	0
+Univers	pass	Univers.woff2	woff2	11504	430ca43960d6edba98a7203308728b6a0adb2c5431e35db607979438a333a54f	0
+FF DIN	pass	FF_DIN_Condensed_Black.otf	otf	31808	47f09a242c494a33f0a51ca9f1bdd59e725f2dc1a3432b2feef13327bc0987d2	0
+Knockout	pass	Knockout-HTF69-FullLiteweight.otf	otf	32564	3496f153b8ceabd64f955e6c37f09f0f6c2dea59dcf8947d8f21b7def5d70df0	0
+Garamond Premier Pro	pass	Garamond-Premier-Pro-Bold.woff2	woff2	178944	02208f92e9eed938d1c5ced39335cb58d24d729fcd2eee4b456111393369c950	0
+Whitney	pass	Whitney Book.otf	otf	27108	f31c365fedbe1da89d9aebe2d55dfc373170679221724deac12072fa3a013021	0
+Didot	pass	DidotLTStd-Ornaments.woff2	woff2	9340	adcdbc40216bf3c20b50c8633b04d088041d50f0faf79453fa4d87d2f710b289	0
+Neutraface	pass	NeutrafaceText-Bold.otf	otf	128564	082d214ce085b71dc8780625bdc4f42edd158bdf3b29da272fc216ff9135d588	0
+Trade Gothic	pass	Trade Gothic LT Bold Condensed No. 20 Oblique.ttf	ttf	54416	419e187392233770cd76c412a06fd11810ccd4d181e173ca2132b485a1f25a98	0
+Archer	miss	-	-	-	-	0
+Akzidenz-Grotesk	pass	akzidenz-grotesk-bold.ttf	ttf	47988	0469acfae365bab9e028f9772f32d41f3dc4fdd63165d77624bf54d55eafab44	0
+Frutiger	pass	Frutiger.ttf	ttf	36924	61bc05483ccc3ca099da0b327dc0b554e0b978107d5e21fd141e1419b24412fb	0
+Graphik	pass	Graphik-Regular-Web.woff2	woff2	30997	3c207c3ab1b05e36d6006dd0b18e2eda1fcd104854e27008332177b986d62ce2	18
+Minion Pro	pass	MinionPro-Regular.otf	otf	235436	4777f31d117d3dcd7f1650fd7b7f7035bc56ba046f913ffd4fb7c86b88faa72b	0
+Mrs. Eaves	pass	mrseavesbold-webfont.ttf	ttf	59064	28a37280d6004fce707fbdfc52f554c746d34b9a663fff54857eb3619413cb9d	0
+Belarius Serif Narrow Regular	miss	-	-	-	-	0

--- a/.workflow/search-and-release-reliability-hardening/results/health-and-ranking.md
+++ b/.workflow/search-and-release-reliability-hardening/results/health-and-ranking.md
@@ -1,0 +1,10 @@
+# URL health and reliability ranking result
+
+Status: implemented, focused verification passing
+
+- Invalid-content URLs persist for 30 days in a 256-entry bounded cache.
+- Search and download lookups are local-only and do not fetch candidates.
+- Only typed byte-validation failures are recorded.
+- Structured registries and raw GitHub win quality ties over GetFonts and
+  arbitrary hosts without changing trust or license metadata.
+- Focused command: `go test ./internal/cache ./internal/rank ./internal/app`.

--- a/.workflow/search-and-release-reliability-hardening/results/release-runbook.md
+++ b/.workflow/search-and-release-reliability-hardening/results/release-runbook.md
@@ -1,0 +1,22 @@
+# Release runbook result
+
+Status: complete
+
+Implemented a repository-owned TypeScript release command with verification-only
+default behavior and an explicit publish mode. The command rebuilds all six
+native targets, forces npm lifecycle scripts during packing, extracts the exact
+tarball, verifies manifest, binary target/version, and JavaScript launcher
+versions, then gates npm publish, annotated tag creation, tag push, and GitHub
+release creation behind successful verification.
+
+Publication is resumable. An existing npm version must match the verified
+archive integrity, a remote tag must be annotated and point to the current
+commit, and an existing GitHub asset must contain the same archive bytes.
+
+Verification:
+
+- `npm run test:release`
+- `npm run release`
+- `npm run docs:check`
+
+No package, tag, push, commit, or GitHub release was created.

--- a/.workflow/search-and-release-reliability-hardening/state.json
+++ b/.workflow/search-and-release-reliability-hardening/state.json
@@ -1,0 +1,31 @@
+{
+  "title": "Search and release reliability hardening",
+  "slug": "search-and-release-reliability-hardening",
+  "created_at": "2026-07-11T18:12:30+00:00",
+  "status": "completed",
+  "approval": {
+    "required": false,
+    "granted": true,
+    "notes": "Local implementation and verification approved; external publication remains gated."
+  },
+  "packets": [
+    {"id":"contracts","status":"completed"},
+    {"id":"fallback-downloads","status":"completed"},
+    {"id":"negative-cache","status":"completed"},
+    {"id":"source-reliability","status":"completed"},
+    {"id":"release-runbook","status":"completed"},
+    {"id":"docs-ci","status":"completed"},
+    {"id":"verification-corpus","status":"completed"}
+  ],
+  "verification": {
+    "status": "completed",
+    "checks": [
+      "go-race",
+      "release-tests",
+      "six-target-archive",
+      "committed-binaries",
+      "npm-verify",
+      "font-corpus"
+    ]
+  }
+}

--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ the `websearch` provider automatically uses
 `kagi auth` once. Ordinary web pages are ignored. direct CSS font URLs and
 bounded ZIP or TAR archive members can become results. configured source
 plugins pass through the same HTTPS, format, and download validation boundary.
+Direct binary responses with missing or misleading extensions can also be
+recognized as ZIP, TAR, or compressed TAR archives by signature; webpages and
+interactive download flows remain excluded.
 
 ```bash
 export GITHUB_TOKEN=github_pat_example

--- a/README.md
+++ b/README.md
@@ -99,6 +99,11 @@ downloads use HTTPS by default and stop at 50 MiB. before the final file appears
 temporary path, and renames it atomically. SHA-256 hashes prevent duplicate
 files from being saved twice.
 
+If the first ranked link returns invalid font bytes, `moji get` remembers that
+URL and tries the next candidate. Whole-family downloads validate one coherent
+same-source group in staging, so a broken member cannot leave a partial family
+or mix sources.
+
 search results include source and best-effort license metadata. an `unknown`
 license is not permission to use or redistribute a font. check the font's
 license before shipping it.
@@ -159,6 +164,11 @@ npm run docs:check
 npm run docs:build
 npm run docs:dev
 ```
+
+Before a release, `npm run release` rebuilds and verifies the exact npm archive
+without publishing it. The operator-only `npm run release:publish` runs the
+same gate before npm publication, the annotated tag, and the GitHub release.
+See the [release runbook](docs/release-runbook.md).
 
 the end-to-end suite builds the real binary, searches a controlled HTTP
 provider, downloads a valid fixture font, checks the file on disk, and exercises

--- a/docs/content/docs/explanation/download-safety-and-licensing.mdx
+++ b/docs/content/docs/explanation/download-safety-and-licensing.mdx
@@ -28,6 +28,11 @@ Moji reads the first four bytes and compares them with the selected format:
 
 HTML error pages and mislabeled files fail validation.
 
+During discovery, Moji can recognize ZIP, TAR, and compressed TAR signatures
+when a direct binary response has no useful archive extension. It then applies
+the same entry-count, member-size, and expanded-size limits used for named
+archives. A webpage is never reclassified as a downloadable archive.
+
 When a direct URL returns bytes that fail this validation, Moji records that
 URL in a bounded local health cache for 30 days. Later searches suppress the
 known-bad URL without fetching it again. Network failures, HTTP status errors,

--- a/docs/content/docs/explanation/download-safety-and-licensing.mdx
+++ b/docs/content/docs/explanation/download-safety-and-licensing.mdx
@@ -28,6 +28,12 @@ Moji reads the first four bytes and compares them with the selected format:
 
 HTML error pages and mislabeled files fail validation.
 
+When a direct URL returns bytes that fail this validation, Moji records that
+URL in a bounded local health cache for 30 days. Later searches suppress the
+known-bad URL without fetching it again. Network failures, HTTP status errors,
+redirect policy failures, cancellations, and filesystem errors are not
+recorded because they do not prove that the URL's content is invalid.
+
 ## Filesystem controls
 
 Content is streamed into a temporary file in the destination directory. Only a
@@ -42,6 +48,16 @@ SHA-256:
 
 Error messages state when no completed file was saved, so a failed operation
 does not leave the user guessing about partial state.
+
+`moji get` keeps the ranked candidate pool after choosing the requested
+download count. If the highest-ranked candidate fails, Moji tries later
+candidates until it has the requested number of valid files. If none work, the
+error lists the candidates it tried.
+
+Family downloads are staged as one same-source group. Every selected member
+must validate before any member is moved into the destination. If one source
+fails, Moji discards its staging directory and tries the next coherent family
+source instead of mixing files from different sources.
 
 ## Licensing boundary
 

--- a/docs/content/docs/explanation/ranking-and-families.mdx
+++ b/docs/content/docs/explanation/ranking-and-families.mdx
@@ -31,6 +31,12 @@ The score combines:
 - a variable-font bonus; and
 - a penalty for suspiciously small files.
 
+After relevance and these quality scores tie, Moji uses direct-link
+reliability as a final ordering rule: structured registries, raw GitHub files,
+GetFonts, then arbitrary web hosts. This heuristic predicts whether a result is
+likely to remain a usable direct file. It does not change the `trusted` or
+`license` fields and cannot outrank a more relevant or more complete family.
+
 Ranking weights are configurable because a desktop design workflow and a web
 workflow may value formats differently.
 
@@ -43,6 +49,10 @@ Moji groups by normalized family and source. Family mode starts from the
 highest-ranked result, then selects matching family files from that same
 source. This keeps the set coherent and rewards sources that contain several
 weights.
+
+If a member fails byte validation, the whole staged group is discarded before
+Moji tries the next family source. A completed family never combines weights
+from unrelated repositories or hosts.
 
 ## Ranking is guidance, not proof
 

--- a/docs/content/docs/how-to/manage-config-and-cache.mdx
+++ b/docs/content/docs/how-to/manage-config-and-cache.mdx
@@ -29,7 +29,10 @@ The command prints JSON and redacts a configured GitHub token.
 
 ## Bypass or clear cache
 
-Search results are cached by normalized query, provider, and format set.
+Search results are cached by normalized query, provider, and format set. Moji
+also keeps a separate, bounded URL-health cache for direct links whose bytes
+failed font validation. Health entries expire after 30 days and do not include
+network, HTTP, policy, or filesystem failures.
 
 ```sh
 moji "Inter" --no-cache
@@ -37,4 +40,6 @@ moji cache clear
 ```
 
 Use `--no-cache` when you need a fresh provider response for one invocation.
-Use `cache clear` to remove all saved search responses.
+The safety-oriented URL-health cache still suppresses links already proven to
+return invalid font bytes. Use `moji cache clear` to remove both provider
+responses and URL-health entries.

--- a/docs/content/docs/reference/errors-and-exit-codes.mdx
+++ b/docs/content/docs/reference/errors-and-exit-codes.mdx
@@ -38,6 +38,11 @@ received invalid font content, or found a destination collision. Rejected
 content remains in a temporary file only until cleanup; no completed font is
 placed at the destination.
 
+For a single-font request, Moji continues through the ranked candidates and
+reports an aggregate error only if it cannot reach the requested success count.
+For an entire-family request, each same-source group is staged and either
+completed as a unit or discarded before the next group is tried.
+
 ### Config could not be parsed
 
 Fix the YAML at the reported path or move the file aside to use defaults. Moji

--- a/docs/content/docs/reference/providers.mdx
+++ b/docs/content/docs/reference/providers.mdx
@@ -71,11 +71,11 @@ its bounded query.
 
 Only direct font files are emitted. Direct ZIP, TAR, and compressed TAR results
 are inspected within fixed entry and expanded-size limits. Extensionless or
-mislabeled responses are considered only when the server advertises an archive
-or generic binary content type and the bytes match a supported archive
-signature. HTML pages, download forms, and gated flows remain excluded. Both
-backends run concurrently and merge by direct URL plus archive member. A
-failure in one backend does not discard results from the other.
+mislabeled responses are considered only when the bytes match a supported
+archive signature. Explicit HTML, text, JSON, and XML response types are
+rejected before reading the body. Download forms and gated flows remain
+excluded. Both backends run concurrently and merge by direct URL plus archive
+member. A failure in one backend does not discard results from the other.
 
 ## Source plugins
 

--- a/docs/content/docs/reference/providers.mdx
+++ b/docs/content/docs/reference/providers.mdx
@@ -62,10 +62,18 @@ Kagi authentication is managed by `kagi-cli`; run `kagi auth`. Its backend
 runs one structured search and converts GitHub blob links to HTTPS raw-file
 URLs. Ordinary pages are discarded.
 
-The SearXNG backend runs six bounded queries concurrently: quoted TTF and OTF
+The SearXNG backend runs nine bounded queries concurrently: quoted TTF and OTF
 filenames, a VK-scoped query, an index-of query covering configured formats,
-GitHub title query, and CSS `@font-face` query. Direct ZIP, TAR, and compressed
-TAR results are inspected within fixed entry and expanded-size limits. Both
+GitHub title query, CSS `@font-face` query, and three grouped queries across
+font indexes such as OnlineWebFonts, wFonts, BeFonts, CufonFonts, FontsFree,
+DFonts, FFonts, and FontBolt. Kagi receives the same grouped index clauses in
+its bounded query.
+
+Only direct font files are emitted. Direct ZIP, TAR, and compressed TAR results
+are inspected within fixed entry and expanded-size limits. Extensionless or
+mislabeled responses are considered only when the server advertises an archive
+or generic binary content type and the bytes match a supported archive
+signature. HTML pages, download forms, and gated flows remain excluded. Both
 backends run concurrently and merge by direct URL plus archive member. A
 failure in one backend does not discard results from the other.
 

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -47,6 +47,7 @@ be annotated and point to the current commit. Existing GitHub release assets
 are downloaded and compared with the verified archive; a missing asset is
 uploaded, while different bytes stop the run.
 
-If a rebuilt binary differs from the committed copy, publishing stops. Commit
-the rebuilt artifacts and rerun the command so npm and GitHub describe the same
-source state.
+The generated binaries are intentionally ignored by Git. Before publishing,
+Moji reads the VCS metadata embedded by Go and requires every binary to identify
+the current clean commit. A stale binary, a different revision, or locally
+modified source stops the release before npm, tags, or GitHub are changed.

--- a/docs/release-runbook.md
+++ b/docs/release-runbook.md
@@ -1,0 +1,52 @@
+# Release runbook
+
+Moji has one repository-owned release command. It rebuilds the six npm native
+binaries, packs the exact npm archive, extracts it, and verifies every artifact
+before an irreversible operation can run.
+
+## Verify a release archive
+
+Update and commit the version in `package.json` and `package-lock.json`, then run:
+
+```console
+npm run release
+```
+
+Verification is the default mode. It does not publish a package, create a tag,
+push, or create a GitHub release. The command:
+
+1. Builds Linux, macOS, and Windows binaries for x64 and arm64.
+2. Runs `npm pack` with lifecycle scripts explicitly enabled, even when the
+   user's npm configuration sets `ignore-scripts=true`.
+3. Extracts the generated tarball into a temporary directory.
+4. Confirms the packed manifest version and exact six-target directory set.
+5. Confirms each binary's embedded app version and Go target metadata.
+6. Runs the packed JavaScript launcher and compares its reported version.
+
+CI runs this same command so stale or incorrectly targeted package artifacts
+cannot pass the release gate.
+
+## Publish
+
+The publishing operator needs npm and GitHub CLI authentication. The repository
+must be clean, and the matching `v<version>` tag must not exist.
+
+```console
+npm run release:publish
+```
+
+After verification passes, the command publishes the exact verified tarball,
+creates and pushes an annotated `v<version>` tag, then creates the matching
+latest GitHub release with generated notes and the tarball attached.
+
+The publish path is resumable. If npm publication succeeded but a later tag or
+GitHub operation failed, rerun `npm run release:publish`. Moji compares npm's
+published integrity with the newly verified archive, refuses any mismatch, and
+continues from the first missing tag or release step. Existing remote tags must
+be annotated and point to the current commit. Existing GitHub release assets
+are downloaded and compared with the verified archive; a missing asset is
+uploaded, while different bytes stop the run.
+
+If a rebuilt binary differs from the committed copy, publishing stops. Commit
+the rebuilt artifacts and rerun the command so npm and GitHub describe the same
+source state.

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -27,7 +27,7 @@ func TestMojiBinaryEndToEnd(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		binary += ".exe"
 	}
-	build := exec.Command("go", "build", "-o", binary, "../cmd/moji")
+	build := exec.Command("go", "build", "-ldflags=-X=github.com/microck/moji/internal/app.allowPrivateBuild=e2e", "-o", binary, "../cmd/moji")
 	build.Dir = "."
 	if output, err := build.CombinedOutput(); err != nil {
 		t.Fatalf("build binary: %v\n%s", err, output)

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/charmbracelet/lipgloss v1.1.0
 	github.com/charmbracelet/x/ansi v0.10.1
 	github.com/creack/pty v1.1.24
+	golang.org/x/sys v0.47.0
 	golang.org/x/term v0.45.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -26,6 +27,5 @@ require (
 	github.com/muesli/termenv v0.16.0 // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
-	golang.org/x/sys v0.47.0 // indirect
 	golang.org/x/text v0.3.8 // indirect
 )

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -127,10 +127,7 @@ func (application App) Run(ctx context.Context, args []string) int {
 		results = rank.FilterWeight(results, strings.ToLower(parsed.weight))
 	}
 	results = rank.Results(results, query, strings.ToLower(parsed.weight), current.Ranking)
-	if getMode && intent.WantFamily {
-		results = rank.SelectFamily(results, parsed.max)
-	}
-	if len(results) > parsed.max {
+	if !getMode && len(results) > parsed.max {
 		results = results[:parsed.max]
 	}
 	if parsed.verbose {
@@ -139,7 +136,7 @@ func (application App) Run(ctx context.Context, args []string) int {
 		}
 	}
 	if getMode {
-		return application.runGet(ctx, results, parsed)
+		return application.runGet(ctx, results, parsed, intent.WantFamily)
 	}
 	if parsed.json {
 		return application.writeJSON(results)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -21,6 +21,8 @@ type App struct {
 	Stdout io.Writer
 	Stderr io.Writer
 	Client *http.Client
+
+	allowPrivate bool
 }
 
 type options struct {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"runtime"
 	"strings"
 
 	"github.com/microck/moji/internal/config"
@@ -15,6 +16,7 @@ import (
 )
 
 var Version = "0.2.1"
+var ReleaseMarker = "moji-release-version:development:moji-marker-end"
 
 // allowPrivateBuild is set only on the subprocess binary built by the E2E
 // test. Release builds leave it empty, and no runtime input can change it.
@@ -36,6 +38,7 @@ type options struct {
 }
 
 func (application App) Run(ctx context.Context, args []string) int {
+	runtime.KeepAlive(ReleaseMarker)
 	application.allowPrivate = application.allowPrivate || allowPrivateBuild == "e2e"
 	application.setDefaults()
 	if containsHelp(args) {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -16,6 +16,10 @@ import (
 
 var Version = "0.2.1"
 
+// allowPrivateBuild is set only on the subprocess binary built by the E2E
+// test. Release builds leave it empty, and no runtime input can change it.
+var allowPrivateBuild string
+
 type App struct {
 	Stdin  io.Reader
 	Stdout io.Writer
@@ -32,6 +36,7 @@ type options struct {
 }
 
 func (application App) Run(ctx context.Context, args []string) int {
+	application.allowPrivate = application.allowPrivate || allowPrivateBuild == "e2e"
 	application.setDefaults()
 	if containsHelp(args) {
 		fmt.Fprint(application.Stdout, helpText)

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -218,7 +218,13 @@ func TestRunGetFamilyFallsBackAsACompleteSameSourceGroup(t *testing.T) {
 		}
 	}
 	entries, err := os.ReadDir(destination)
-	if err != nil || len(entries) != 2 {
+	visible := 0
+	for _, entry := range entries {
+		if !strings.HasPrefix(entry.Name(), ".moji-") {
+			visible++
+		}
+	}
+	if err != nil || visible != 2 {
 		t.Fatalf("family destination contains partial or staging files: entries=%v err=%v", entries, err)
 	}
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -176,6 +176,19 @@ func TestInteractiveDownloadRecordsInvalidURLHealth(t *testing.T) {
 	}
 }
 
+func TestArchiveMemberHealthDoesNotSuppressValidSibling(t *testing.T) {
+	t.Parallel()
+	store := cache.Store{Directory: t.TempDir()}
+	bad := provider.Result{URL: "https://example.test/family.zip", ArchiveMember: "Bad.otf"}
+	good := provider.Result{URL: bad.URL, ArchiveMember: "Good.otf"}
+	if err := store.MarkInvalidURL(resultHealthKey(bad)); err != nil {
+		t.Fatal(err)
+	}
+	if invalid, err := store.IsInvalidURL(resultHealthKey(good)); err != nil || invalid {
+		t.Fatalf("valid sibling invalid=%v err=%v", invalid, err)
+	}
+}
+
 func TestRunGetFamilyFallsBackAsACompleteSameSourceGroup(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -36,7 +36,7 @@ func TestRunSearchJSONAndGetDownload(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", filepath.Join(root, "cache"))
 
 	var stdout, stderr bytes.Buffer
-	application := App{Stdout: &stdout, Stderr: &stderr, Client: server.Client()}
+	application := App{Stdout: &stdout, Stderr: &stderr, Client: server.Client(), allowPrivate: true}
 	if code := application.Run(context.Background(), []string{"Example", "--json", "--no-cache"}); code != 0 {
 		t.Fatalf("search code=%d stderr=%s", code, stderr.String())
 	}
@@ -74,7 +74,7 @@ func TestRunGetFallsBackAfterInvalidRankedCandidate(t *testing.T) {
 	defer server.Close()
 	destination := filepath.Join(root, "fonts")
 	var stdout, stderr bytes.Buffer
-	application := App{Stdout: &stdout, Stderr: &stderr, Client: server.Client()}
+	application := App{Stdout: &stdout, Stderr: &stderr, Client: server.Client(), allowPrivate: true}
 	results := []provider.Result{
 		{URL: server.URL + "/best.otf", Filename: "Example-Bold.otf", Format: "otf", Source: "first"},
 		{URL: server.URL + "/fallback.ttf", Filename: "Example-Bold.ttf", Format: "ttf", Source: "second"},
@@ -118,7 +118,7 @@ func TestRunGetKeepsCandidatesBeyondRequestedMaximumForFallback(t *testing.T) {
 	t.Setenv("MOJI_CONFIG", configPath)
 	t.Setenv("XDG_CACHE_HOME", filepath.Join(root, "cache"))
 	var stdout, stderr bytes.Buffer
-	application := App{Stdout: &stdout, Stderr: &stderr, Client: server.Client()}
+	application := App{Stdout: &stdout, Stderr: &stderr, Client: server.Client(), allowPrivate: true}
 
 	if code := application.Run(context.Background(), []string{"get", "Example bold", "--allow-insecure", "--no-cache"}); code != 0 {
 		t.Fatalf("code=%d stderr=%s", code, stderr.String())
@@ -139,7 +139,7 @@ func TestRunGetReportsEveryFailedCandidate(t *testing.T) {
 	}))
 	defer server.Close()
 	var stderr bytes.Buffer
-	application := App{Stdout: &bytes.Buffer{}, Stderr: &stderr, Client: server.Client()}
+	application := App{Stdout: &bytes.Buffer{}, Stderr: &stderr, Client: server.Client(), allowPrivate: true}
 	results := []provider.Result{
 		{URL: server.URL + "/one.otf", Filename: "Example-One.otf", Format: "otf", Source: "one"},
 		{URL: server.URL + "/two.ttf", Filename: "Example-Two.ttf", Format: "ttf", Source: "two"},
@@ -160,7 +160,7 @@ func TestInteractiveDownloadRecordsInvalidURLHealth(t *testing.T) {
 		response.Write([]byte("not a font"))
 	}))
 	defer server.Close()
-	application := App{Client: server.Client()}
+	application := App{Client: server.Client(), allowPrivate: true}
 	downloadFont := application.interactiveDownloader(context.Background(), options{downloadDir: filepath.Join(root, "fonts")})
 	_, err := downloadFont(provider.Result{URL: server.URL, Filename: "Example.otf", Format: "otf"})
 	if err == nil {
@@ -201,7 +201,7 @@ func TestRunGetFamilyFallsBackAsACompleteSameSourceGroup(t *testing.T) {
 	defer server.Close()
 	destination := t.TempDir()
 	var stdout, stderr bytes.Buffer
-	application := App{Stdout: &stdout, Stderr: &stderr, Client: server.Client()}
+	application := App{Stdout: &stdout, Stderr: &stderr, Client: server.Client(), allowPrivate: true}
 	results := []provider.Result{
 		{URL: server.URL + "/broken/Regular.otf", Filename: "Example-Regular.otf", Format: "otf", Source: "broken", Score: 20},
 		{URL: server.URL + "/broken/Bold.otf", Filename: "Example-Bold.otf", Format: "otf", Source: "broken", Score: 19},

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -128,6 +128,22 @@ func TestRunGetKeepsCandidatesBeyondRequestedMaximumForFallback(t *testing.T) {
 	}
 }
 
+func TestFamilyDryRunPreviewsTheFirstDownloadGroup(t *testing.T) {
+	t.Parallel()
+	var stdout, stderr bytes.Buffer
+	application := App{Stdout: &stdout, Stderr: &stderr}
+	results := []provider.Result{
+		{Filename: "Example-Regular.otf", Format: "otf", Source: "singleton", Score: 13},
+		{Filename: "Example-Regular.ttf", Format: "ttf", Source: "family", Score: 12},
+		{Filename: "Example-Bold.ttf", Format: "ttf", Source: "family", Score: 11},
+	}
+
+	code := application.runGet(context.Background(), results, options{dryRun: true, max: 10}, true)
+	if code != 0 || strings.Contains(stdout.String(), "singleton") || strings.Count(stdout.String(), "family") != 2 {
+		t.Fatalf("code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+}
+
 func serverURL(request *http.Request, path string) string {
 	return "http://" + request.Host + path
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -10,6 +10,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/microck/moji/internal/cache"
+	"github.com/microck/moji/internal/provider"
 )
 
 func TestRunSearchJSONAndGetDownload(t *testing.T) {
@@ -53,6 +56,157 @@ func TestRunSearchJSONAndGetDownload(t *testing.T) {
 	}
 	if !bytes.Equal(content, font) || !strings.Contains(stdout.String(), "Downloaded:") {
 		t.Fatalf("download output=%s content=%x", stdout.String(), content)
+	}
+}
+
+func TestRunGetFallsBackAfterInvalidRankedCandidate(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(root, "cache"))
+	invalidRequests := 0
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.URL.Path == "/best.otf" {
+			invalidRequests++
+			response.Write([]byte("not a font"))
+			return
+		}
+		response.Write(append([]byte("\x00\x01\x00\x00"), make([]byte, 32)...))
+	}))
+	defer server.Close()
+	destination := filepath.Join(root, "fonts")
+	var stdout, stderr bytes.Buffer
+	application := App{Stdout: &stdout, Stderr: &stderr, Client: server.Client()}
+	results := []provider.Result{
+		{URL: server.URL + "/best.otf", Filename: "Example-Bold.otf", Format: "otf", Source: "first"},
+		{URL: server.URL + "/fallback.ttf", Filename: "Example-Bold.ttf", Format: "ttf", Source: "second"},
+	}
+
+	if code := application.runGet(context.Background(), results, options{max: 1, downloadDir: destination}, false); code != 0 {
+		t.Fatalf("code=%d stderr=%s", code, stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(destination, "Example-Bold.ttf")); err != nil {
+		t.Fatalf("fallback was not downloaded: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(destination, "Example-Bold.otf")); !os.IsNotExist(err) {
+		t.Fatalf("invalid candidate was saved: %v", err)
+	}
+	if code := application.runGet(context.Background(), results, options{max: 1, downloadDir: destination}, false); code != 0 {
+		t.Fatalf("second code=%d stderr=%s", code, stderr.String())
+	}
+	if invalidRequests != 1 {
+		t.Fatalf("known-invalid URL was requested %d times, want once", invalidRequests)
+	}
+}
+
+func TestRunGetKeepsCandidatesBeyondRequestedMaximumForFallback(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/invalid/Example-Bold.otf":
+			response.Write([]byte("not a font"))
+		case "/valid/Example-Bold.ttf":
+			response.Write(append([]byte("\x00\x01\x00\x00"), make([]byte, 32)...))
+		default:
+			fmt.Fprintf(response, `{"items":[{"name":"Example-Bold.otf","html_url":%q,"repository":{"full_name":"bad/fonts"}},{"name":"Example-Bold.ttf","html_url":%q,"repository":{"full_name":"good/fonts"}}]}`, serverURL(request, "/invalid/Example-Bold.otf"), serverURL(request, "/valid/Example-Bold.ttf"))
+		}
+	}))
+	defer server.Close()
+	root := t.TempDir()
+	configPath := filepath.Join(root, "config.yaml")
+	configBody := fmt.Sprintf("download_dir: %s\nsearch_timeout_seconds: 2\ncache_ttl_seconds: 60\ndefault_formats: [otf, ttf]\nproviders:\n  github:\n    enabled: false\n  getfonts:\n    enabled: true\n    instance: %s\n  registry:\n    enabled: false\n  websearch:\n    enabled: false\n", filepath.Join(root, "fonts"), server.URL)
+	if err := os.WriteFile(configPath, []byte(configBody), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("MOJI_CONFIG", configPath)
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(root, "cache"))
+	var stdout, stderr bytes.Buffer
+	application := App{Stdout: &stdout, Stderr: &stderr, Client: server.Client()}
+
+	if code := application.Run(context.Background(), []string{"get", "Example bold", "--allow-insecure", "--no-cache"}); code != 0 {
+		t.Fatalf("code=%d stderr=%s", code, stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(root, "fonts", "Example-Bold.ttf")); err != nil {
+		t.Fatalf("candidate beyond max=1 was not used: %v", err)
+	}
+}
+
+func serverURL(request *http.Request, path string) string {
+	return "http://" + request.Host + path
+}
+
+func TestRunGetReportsEveryFailedCandidate(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		response.Write([]byte("not a font"))
+	}))
+	defer server.Close()
+	var stderr bytes.Buffer
+	application := App{Stdout: &bytes.Buffer{}, Stderr: &stderr, Client: server.Client()}
+	results := []provider.Result{
+		{URL: server.URL + "/one.otf", Filename: "Example-One.otf", Format: "otf", Source: "one"},
+		{URL: server.URL + "/two.ttf", Filename: "Example-Two.ttf", Format: "ttf", Source: "two"},
+	}
+
+	if code := application.runGet(context.Background(), results, options{max: 1, downloadDir: t.TempDir()}, false); code != 1 {
+		t.Fatalf("code=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "Example-One.otf") || !strings.Contains(stderr.String(), "Example-Two.ttf") {
+		t.Fatalf("aggregate error omitted a candidate: %s", stderr.String())
+	}
+}
+
+func TestInteractiveDownloadRecordsInvalidURLHealth(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("XDG_CACHE_HOME", filepath.Join(root, "cache"))
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		response.Write([]byte("not a font"))
+	}))
+	defer server.Close()
+	application := App{Client: server.Client()}
+	downloadFont := application.interactiveDownloader(context.Background(), options{downloadDir: filepath.Join(root, "fonts")})
+	_, err := downloadFont(provider.Result{URL: server.URL, Filename: "Example.otf", Format: "otf"})
+	if err == nil {
+		t.Fatal("interactive invalid download error = nil")
+	}
+	directory, directoryErr := cache.DefaultDirectory()
+	if directoryErr != nil {
+		t.Fatal(directoryErr)
+	}
+	invalid, healthErr := (cache.Store{Directory: directory}).IsInvalidURL(server.URL)
+	if healthErr != nil || !invalid {
+		t.Fatalf("invalid=%v err=%v, want TUI failure recorded", invalid, healthErr)
+	}
+}
+
+func TestRunGetFamilyFallsBackAsACompleteSameSourceGroup(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if strings.HasPrefix(request.URL.Path, "/broken/") && strings.Contains(request.URL.Path, "Bold") {
+			response.Write([]byte("not a font"))
+			return
+		}
+		response.Write(append(append([]byte("OTTO"), []byte(request.URL.Path)...), make([]byte, 32)...))
+	}))
+	defer server.Close()
+	destination := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	application := App{Stdout: &stdout, Stderr: &stderr, Client: server.Client()}
+	results := []provider.Result{
+		{URL: server.URL + "/broken/Regular.otf", Filename: "Example-Regular.otf", Format: "otf", Source: "broken", Score: 20},
+		{URL: server.URL + "/broken/Bold.otf", Filename: "Example-Bold.otf", Format: "otf", Source: "broken", Score: 19},
+		{URL: server.URL + "/healthy/Regular.otf", Filename: "Example-Regular.otf", Format: "otf", Source: "healthy", Score: 18},
+		{URL: server.URL + "/healthy/Bold.otf", Filename: "Example-Bold.otf", Format: "otf", Source: "healthy", Score: 17},
+	}
+
+	if code := application.runGet(context.Background(), results, options{max: 10, downloadDir: destination}, true); code != 0 {
+		t.Fatalf("code=%d stderr=%s", code, stderr.String())
+	}
+	for _, name := range []string{"Example-Regular.otf", "Example-Bold.otf"} {
+		if _, err := os.Stat(filepath.Join(destination, name)); err != nil {
+			t.Fatalf("healthy family member %s missing: %v", name, err)
+		}
+	}
+	entries, err := os.ReadDir(destination)
+	if err != nil || len(entries) != 2 {
+		t.Fatalf("family destination contains partial or staging files: entries=%v err=%v", entries, err)
 	}
 }
 

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -47,7 +47,7 @@ func (application App) runGet(ctx context.Context, results []provider.Result, pa
 	failures := make([]error, 0)
 	for _, result := range results {
 		if healthAvailable {
-			if invalid, err := health.IsInvalidURL(result.URL); err == nil && invalid {
+			if invalid, err := health.IsInvalidURL(resultHealthKey(result)); err == nil && invalid {
 				failures = append(failures, fmt.Errorf("%s from %s: skipped because this URL previously returned invalid font content", result.Filename, result.Source))
 				continue
 			}
@@ -55,7 +55,7 @@ func (application App) runGet(ctx context.Context, results []provider.Result, pa
 		file, err := downloader.Download(ctx, result, expandHome(parsed.downloadDir))
 		if err != nil {
 			if healthAvailable && download.IsInvalidContent(err) {
-				_ = health.MarkInvalidURL(result.URL)
+				_ = health.MarkInvalidURL(resultHealthKey(result))
 			}
 			failures = append(failures, fmt.Errorf("%s from %s: %w", result.Filename, result.Source, err))
 			continue
@@ -81,7 +81,7 @@ func (application App) runGetFamily(ctx context.Context, downloader download.Dow
 		knownInvalid := ""
 		if healthAvailable {
 			for _, candidate := range candidates {
-				if invalid, err := health.IsInvalidURL(candidate.URL); err == nil && invalid {
+				if invalid, err := health.IsInvalidURL(resultHealthKey(candidate)); err == nil && invalid {
 					knownInvalid = candidate.Filename
 					break
 				}
@@ -96,7 +96,7 @@ func (application App) runGetFamily(ctx context.Context, downloader download.Dow
 			return application.writeDownloadedFiles(files, parsed.json)
 		}
 		if healthAvailable && download.IsInvalidContent(err) {
-			_ = health.MarkInvalidURL(download.InvalidContentURL(err))
+			_ = health.MarkInvalidURL(download.InvalidContentKey(err))
 		}
 		failures = append(failures, fmt.Errorf("%s from %s: %w", group.FamilyName, group.Source, err))
 	}
@@ -109,6 +109,13 @@ func urlHealthStore() (cache.Store, bool) {
 		return cache.Store{}, false
 	}
 	return cache.Store{Directory: directory}, true
+}
+
+func resultHealthKey(result provider.Result) string {
+	if result.ArchiveMember != "" {
+		return result.URL + "\x00" + result.ArchiveMember
+	}
+	return result.URL
 }
 
 func (application App) writeDownloadedFiles(files []download.File, jsonOutput bool) int {

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -38,7 +38,7 @@ func (application App) runGet(ctx context.Context, results []provider.Result, pa
 		application.writeTable(preview)
 		return 0
 	}
-	downloader := download.Downloader{Client: application.Client, AllowInsecure: parsed.allowInsecure}
+	downloader := download.Downloader{Client: application.Client, AllowInsecure: parsed.allowInsecure, AllowPrivate: application.allowPrivate}
 	health, healthAvailable := urlHealthStore()
 	if family {
 		return application.runGetFamily(ctx, downloader, health, healthAvailable, results, maximum, parsed)

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -13,30 +13,106 @@ import (
 	"github.com/microck/moji/internal/config"
 	"github.com/microck/moji/internal/download"
 	"github.com/microck/moji/internal/provider"
+	"github.com/microck/moji/internal/rank"
 )
 
-func (application App) runGet(ctx context.Context, results []provider.Result, parsed options) int {
+func (application App) runGet(ctx context.Context, results []provider.Result, parsed options, family bool) int {
 	if len(results) == 0 {
 		return application.fail(errors.New("no fonts matched the query and filters. Try another name or remove --weight or --format"), 1)
 	}
+	maximum := parsed.max
+	if maximum <= 0 {
+		maximum = 1
+	}
 	if parsed.dryRun {
+		preview := results
+		if family {
+			preview = rank.SelectFamily(results, maximum)
+		} else if len(preview) > maximum {
+			preview = preview[:maximum]
+		}
 		if parsed.json {
-			return application.writeJSON(results)
+			return application.writeJSON(preview)
 		}
 		fmt.Fprintln(application.Stdout, "Would download:")
-		application.writeTable(results)
+		application.writeTable(preview)
 		return 0
 	}
 	downloader := download.Downloader{Client: application.Client, AllowInsecure: parsed.allowInsecure}
-	files := make([]download.File, 0, len(results))
+	health, healthAvailable := urlHealthStore()
+	if family {
+		return application.runGetFamily(ctx, downloader, health, healthAvailable, results, maximum, parsed)
+	}
+	files := make([]download.File, 0, maximum)
+	failures := make([]error, 0)
 	for _, result := range results {
+		if healthAvailable {
+			if invalid, err := health.IsInvalidURL(result.URL); err == nil && invalid {
+				failures = append(failures, fmt.Errorf("%s from %s: skipped because this URL previously returned invalid font content", result.Filename, result.Source))
+				continue
+			}
+		}
 		file, err := downloader.Download(ctx, result, expandHome(parsed.downloadDir))
 		if err != nil {
-			return application.fail(fmt.Errorf("%s was not downloaded: %w", result.Filename, err), 1)
+			if healthAvailable && download.IsInvalidContent(err) {
+				_ = health.MarkInvalidURL(result.URL)
+			}
+			failures = append(failures, fmt.Errorf("%s from %s: %w", result.Filename, result.Source, err))
+			continue
 		}
 		files = append(files, file)
+		if len(files) == maximum {
+			break
+		}
 	}
-	if parsed.json {
+	if len(files) == 0 {
+		return application.fail(fmt.Errorf("none of %d ranked candidates could be downloaded: %w", len(results), errors.Join(failures...)), 1)
+	}
+	return application.writeDownloadedFiles(files, parsed.json)
+}
+
+func (application App) runGetFamily(ctx context.Context, downloader download.Downloader, health cache.Store, healthAvailable bool, results []provider.Result, maximum int, parsed options) int {
+	failures := make([]error, 0)
+	for _, group := range rank.Groups(results) {
+		candidates := group.Files
+		if len(candidates) > maximum {
+			candidates = candidates[:maximum]
+		}
+		knownInvalid := ""
+		if healthAvailable {
+			for _, candidate := range candidates {
+				if invalid, err := health.IsInvalidURL(candidate.URL); err == nil && invalid {
+					knownInvalid = candidate.Filename
+					break
+				}
+			}
+		}
+		if knownInvalid != "" {
+			failures = append(failures, fmt.Errorf("%s from %s: skipped because %s previously returned invalid font content", group.FamilyName, group.Source, knownInvalid))
+			continue
+		}
+		files, err := downloader.DownloadBatch(ctx, candidates, expandHome(parsed.downloadDir))
+		if err == nil {
+			return application.writeDownloadedFiles(files, parsed.json)
+		}
+		if healthAvailable && download.IsInvalidContent(err) {
+			_ = health.MarkInvalidURL(download.InvalidContentURL(err))
+		}
+		failures = append(failures, fmt.Errorf("%s from %s: %w", group.FamilyName, group.Source, err))
+	}
+	return application.fail(fmt.Errorf("no complete font family could be downloaded: %w", errors.Join(failures...)), 1)
+}
+
+func urlHealthStore() (cache.Store, bool) {
+	directory, err := cache.DefaultDirectory()
+	if err != nil {
+		return cache.Store{}, false
+	}
+	return cache.Store{Directory: directory}, true
+}
+
+func (application App) writeDownloadedFiles(files []download.File, jsonOutput bool) int {
+	if jsonOutput {
 		return application.writeJSON(files)
 	}
 	for _, file := range files {

--- a/internal/app/search.go
+++ b/internal/app/search.go
@@ -150,7 +150,7 @@ func (application App) runHome(ctx context.Context, current config.Config, forma
 }
 
 func (application App) interactiveDownloader(ctx context.Context, parsed options) tui.DownloadFunc {
-	downloader := download.Downloader{Client: application.Client, AllowInsecure: parsed.allowInsecure}
+	downloader := download.Downloader{Client: application.Client, AllowInsecure: parsed.allowInsecure, AllowPrivate: application.allowPrivate}
 	health, healthAvailable := urlHealthStore()
 	return func(result provider.Result) (string, error) {
 		file, err := downloader.Download(ctx, result, expandHome(parsed.downloadDir))

--- a/internal/app/search.go
+++ b/internal/app/search.go
@@ -96,7 +96,7 @@ func (application App) searchEvents(ctx context.Context, current config.Config, 
 		defer cancel()
 		forward := func(searchQuery string) (relevantCount, completedCount int) {
 			for event := range aggregate.Search(searchCtx, searchQuery, formats) {
-				if event.Type == provider.EventResult && invalidURLs[event.Result.URL] {
+				if event.Type == provider.EventResult && invalidURLs[resultHealthKey(event.Result)] {
 					continue
 				}
 				if event.Type == provider.EventResult && rank.Relevance(event.Result, searchQuery) > 0 {
@@ -155,7 +155,7 @@ func (application App) interactiveDownloader(ctx context.Context, parsed options
 	return func(result provider.Result) (string, error) {
 		file, err := downloader.Download(ctx, result, expandHome(parsed.downloadDir))
 		if err != nil && healthAvailable && download.IsInvalidContent(err) {
-			_ = health.MarkInvalidURL(result.URL)
+			_ = health.MarkInvalidURL(resultHealthKey(result))
 		}
 		return file.Path, err
 	}

--- a/internal/app/search.go
+++ b/internal/app/search.go
@@ -61,6 +61,7 @@ func (application App) searchEvents(ctx context.Context, current config.Config, 
 		return nil, 0, err
 	}
 	store := cache.Store{Directory: cacheDirectory, TTL: time.Duration(current.CacheTTLSeconds) * time.Second}
+	invalidURLs, _ := store.InvalidURLs()
 	available := map[string]provider.Provider{
 		"getfonts": provider.GetFonts{Client: application.Client, Endpoint: current.Providers["getfonts"].Instance},
 		"registry": provider.RegistrySearch{
@@ -95,6 +96,9 @@ func (application App) searchEvents(ctx context.Context, current config.Config, 
 		defer cancel()
 		forward := func(searchQuery string) (relevantCount, completedCount int) {
 			for event := range aggregate.Search(searchCtx, searchQuery, formats) {
+				if event.Type == provider.EventResult && invalidURLs[event.Result.URL] {
+					continue
+				}
 				if event.Type == provider.EventResult && rank.Relevance(event.Result, searchQuery) > 0 {
 					relevantCount++
 				}
@@ -147,8 +151,12 @@ func (application App) runHome(ctx context.Context, current config.Config, forma
 
 func (application App) interactiveDownloader(ctx context.Context, parsed options) tui.DownloadFunc {
 	downloader := download.Downloader{Client: application.Client, AllowInsecure: parsed.allowInsecure}
+	health, healthAvailable := urlHealthStore()
 	return func(result provider.Result) (string, error) {
 		file, err := downloader.Download(ctx, result, expandHome(parsed.downloadDir))
+		if err != nil && healthAvailable && download.IsInvalidContent(err) {
+			_ = health.MarkInvalidURL(result.URL)
+		}
 		return file.Path, err
 	}
 }

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -10,19 +10,41 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/microck/moji/internal/provider"
 )
 
 type entry struct {
-	FetchedAt time.Time         `json:"fetched_at"`
-	Results   []provider.Result `json:"results"`
+	FetchedAt    time.Time         `json:"fetched_at"`
+	Results      []provider.Result `json:"results"`
+	FamilyGroups []string          `json:"family_groups,omitempty"`
 }
+
+const (
+	urlHealthFilename       = "url-health.json"
+	defaultHealthTTL        = 30 * 24 * time.Hour
+	defaultMaxHealthEntries = 256
+	urlHealthLockTimeout    = 2 * time.Second
+)
+
+type urlHealthEntry struct {
+	InvalidAt time.Time `json:"invalid_at"`
+}
+
+type urlHealthFile struct {
+	Invalid map[string]urlHealthEntry `json:"invalid"`
+}
+
+var urlHealthMu sync.Mutex
+
 type Store struct {
-	Directory string
-	TTL       time.Duration
-	Now       func() time.Time
+	Directory        string
+	TTL              time.Duration
+	HealthTTL        time.Duration
+	MaxHealthEntries int
+	Now              func() time.Time
 }
 
 type CachedProvider struct {
@@ -78,7 +100,7 @@ func DefaultDirectory() (string, error) {
 func (store Store) key(query, source string, formats []string) string {
 	ordered := append([]string(nil), formats...)
 	sort.Strings(ordered)
-	digest := sha256.Sum256([]byte("v2\x00" + strings.ToLower(strings.TrimSpace(query)) + "\x00" + source + "\x00" + strings.Join(ordered, ",")))
+	digest := sha256.Sum256([]byte("v3\x00" + strings.ToLower(strings.TrimSpace(query)) + "\x00" + source + "\x00" + strings.Join(ordered, ",")))
 	return hex.EncodeToString(digest[:]) + ".json"
 }
 
@@ -101,6 +123,11 @@ func (store Store) Get(query, source string, formats []string) ([]provider.Resul
 	if store.TTL <= 0 || now().Sub(cached.FetchedAt) > store.TTL {
 		return nil, false, nil
 	}
+	for index := range cached.Results {
+		if index < len(cached.FamilyGroups) {
+			cached.Results[index].FamilyGroup = cached.FamilyGroups[index]
+		}
+	}
 	return cached.Results, true, nil
 }
 
@@ -112,11 +139,171 @@ func (store Store) Put(query, source string, formats []string, results []provide
 	if store.Now != nil {
 		now = store.Now
 	}
-	content, err := json.Marshal(entry{FetchedAt: now(), Results: results})
+	familyGroups := make([]string, len(results))
+	for index := range results {
+		familyGroups[index] = results[index].FamilyGroup
+	}
+	content, err := json.Marshal(entry{FetchedAt: now(), Results: results, FamilyGroups: familyGroups})
 	if err != nil {
 		return err
 	}
 	return os.WriteFile(filepath.Join(store.Directory, store.key(query, source, formats)), content, 0o600)
+}
+
+// MarkInvalidURL records a URL only after the caller has proven that its
+// response is not valid font content. Transport, server, and filesystem
+// failures must not call this method because those failures can be transient.
+func (store Store) MarkInvalidURL(value string) error {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return errors.New("invalid URL health entry cannot be empty")
+	}
+
+	urlHealthMu.Lock()
+	defer urlHealthMu.Unlock()
+	release, err := lockURLHealth(store.Directory)
+	if err != nil {
+		return err
+	}
+	defer release()
+
+	health, err := store.readURLHealth()
+	if err != nil {
+		return err
+	}
+	now := store.now()
+	health.Invalid[value] = urlHealthEntry{InvalidAt: now}
+	store.pruneURLHealth(health, now)
+	return store.writeURLHealth(health)
+}
+
+// IsInvalidURL is a local-only lookup. It never validates or fetches the URL,
+// so ranking can suppress known-bad candidates without adding network work.
+func (store Store) IsInvalidURL(value string) (bool, error) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return false, nil
+	}
+
+	invalid, err := store.InvalidURLs()
+	return invalid[value], err
+}
+
+// InvalidURLs returns one in-memory snapshot for a search operation. Callers
+// can check every streamed result without rereading the cache file per result.
+func (store Store) InvalidURLs() (map[string]bool, error) {
+	urlHealthMu.Lock()
+	defer urlHealthMu.Unlock()
+	health, err := store.readURLHealth()
+	if err != nil {
+		return nil, err
+	}
+	now := store.now()
+	invalid := make(map[string]bool, len(health.Invalid))
+	for value, entry := range health.Invalid {
+		if now.Sub(entry.InvalidAt) <= store.healthTTL() {
+			invalid[value] = true
+		}
+	}
+	return invalid, nil
+}
+
+func (store Store) readURLHealth() (urlHealthFile, error) {
+	health := urlHealthFile{Invalid: make(map[string]urlHealthEntry)}
+	content, err := os.ReadFile(filepath.Join(store.Directory, urlHealthFilename))
+	if errors.Is(err, os.ErrNotExist) {
+		return health, nil
+	}
+	if err != nil {
+		return health, err
+	}
+	if err := json.Unmarshal(content, &health); err != nil {
+		return health, err
+	}
+	if health.Invalid == nil {
+		health.Invalid = make(map[string]urlHealthEntry)
+	}
+	return health, nil
+}
+
+func (store Store) writeURLHealth(health urlHealthFile) error {
+	if err := os.MkdirAll(store.Directory, 0o700); err != nil {
+		return err
+	}
+	content, err := json.Marshal(health)
+	if err != nil {
+		return err
+	}
+	temporary, err := os.CreateTemp(store.Directory, ".url-health-*.tmp")
+	if err != nil {
+		return err
+	}
+	temporaryPath := temporary.Name()
+	defer os.Remove(temporaryPath)
+	if err := temporary.Chmod(0o600); err != nil {
+		temporary.Close()
+		return err
+	}
+	if _, err := temporary.Write(content); err != nil {
+		temporary.Close()
+		return err
+	}
+	if err := temporary.Close(); err != nil {
+		return err
+	}
+	return replaceFile(temporaryPath, filepath.Join(store.Directory, urlHealthFilename))
+}
+
+func (store Store) pruneURLHealth(health urlHealthFile, now time.Time) {
+	ttl := store.healthTTL()
+	for value, entry := range health.Invalid {
+		if now.Sub(entry.InvalidAt) > ttl {
+			delete(health.Invalid, value)
+		}
+	}
+
+	maximum := store.maxHealthEntries()
+	if len(health.Invalid) <= maximum {
+		return
+	}
+	type candidate struct {
+		url       string
+		invalidAt time.Time
+	}
+	ordered := make([]candidate, 0, len(health.Invalid))
+	for value, entry := range health.Invalid {
+		ordered = append(ordered, candidate{url: value, invalidAt: entry.InvalidAt})
+	}
+	sort.Slice(ordered, func(i, j int) bool {
+		if ordered[i].invalidAt.Equal(ordered[j].invalidAt) {
+			return ordered[i].url < ordered[j].url
+		}
+		return ordered[i].invalidAt.Before(ordered[j].invalidAt)
+	})
+	for _, entry := range ordered[:len(ordered)-maximum] {
+		delete(health.Invalid, entry.url)
+	}
+}
+
+func (store Store) now() time.Time {
+	if store.Now != nil {
+		return store.Now()
+	}
+	return time.Now()
+}
+
+func (store Store) healthTTL() time.Duration {
+	if store.HealthTTL > 0 {
+		return store.HealthTTL
+	}
+	return defaultHealthTTL
+}
+
+func (store Store) maxHealthEntries() int {
+	if store.MaxHealthEntries > 0 {
+		return store.MaxHealthEntries
+	}
+	return defaultMaxHealthEntries
 }
 
 func (store Store) Clear() error {

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,6 +1,10 @@
 package cache
 
 import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -11,17 +15,115 @@ func TestStoreHonorsTTLAndFormatIndependentOrder(t *testing.T) {
 	t.Parallel()
 	now := time.Unix(1000, 0)
 	store := Store{Directory: t.TempDir(), TTL: time.Hour, Now: func() time.Time { return now }}
-	want := []provider.Result{{Filename: "Example.otf"}}
+	want := []provider.Result{{Filename: "Example.otf", FamilyGroup: "github.com/example/fonts"}}
 	if err := store.Put("Example", "fixture", []string{"ttf", "otf"}, want); err != nil {
 		t.Fatal(err)
 	}
 	got, hit, err := store.Get("example", "fixture", []string{"otf", "ttf"})
-	if err != nil || !hit || got[0].Filename != want[0].Filename {
+	if err != nil || !hit || got[0].Filename != want[0].Filename || got[0].FamilyGroup != want[0].FamilyGroup {
 		t.Fatalf("got=%#v hit=%v err=%v", got, hit, err)
 	}
 	now = now.Add(2 * time.Hour)
 	_, hit, err = store.Get("example", "fixture", []string{"otf", "ttf"})
 	if err != nil || hit {
 		t.Fatalf("expired hit=%v err=%v", hit, err)
+	}
+}
+
+func TestStoreUsesCurrentCacheSchemaKey(t *testing.T) {
+	t.Parallel()
+	store := Store{Directory: t.TempDir()}
+	current := store.key("Example", "fixture", []string{"otf"})
+	legacyDigest := sha256.Sum256([]byte("v2\x00example\x00fixture\x00otf"))
+	legacy := hex.EncodeToString(legacyDigest[:]) + ".json"
+	if current == legacy {
+		t.Fatal("current result cache key still accepts pre-FamilyGroup entries")
+	}
+}
+
+func TestStorePersistsInvalidURLHealthUntilTTL(t *testing.T) {
+	t.Parallel()
+	now := time.Unix(1000, 0)
+	directory := t.TempDir()
+	store := Store{
+		Directory:        directory,
+		HealthTTL:        time.Hour,
+		MaxHealthEntries: 10,
+		Now:              func() time.Time { return now },
+	}
+
+	if err := store.MarkInvalidURL("https://example.com/not-a-font.ttf"); err != nil {
+		t.Fatal(err)
+	}
+
+	reopened := store
+	if invalid, err := reopened.IsInvalidURL("https://example.com/not-a-font.ttf"); err != nil || !invalid {
+		t.Fatalf("invalid=%v err=%v, want persisted invalid URL", invalid, err)
+	}
+
+	now = now.Add(2 * time.Hour)
+	if invalid, err := reopened.IsInvalidURL("https://example.com/not-a-font.ttf"); err != nil || invalid {
+		t.Fatalf("invalid=%v err=%v, want expired URL health", invalid, err)
+	}
+}
+
+func TestStoreBoundsInvalidURLHealthByMostRecentFailure(t *testing.T) {
+	t.Parallel()
+	now := time.Unix(1000, 0)
+	store := Store{
+		Directory:        t.TempDir(),
+		HealthTTL:        time.Hour,
+		MaxHealthEntries: 2,
+		Now:              func() time.Time { return now },
+	}
+
+	for _, url := range []string{"https://example.com/old.ttf", "https://example.com/middle.ttf", "https://example.com/new.ttf"} {
+		if err := store.MarkInvalidURL(url); err != nil {
+			t.Fatal(err)
+		}
+		now = now.Add(time.Minute)
+	}
+
+	for url, want := range map[string]bool{
+		"https://example.com/old.ttf":    false,
+		"https://example.com/middle.ttf": true,
+		"https://example.com/new.ttf":    true,
+	} {
+		if invalid, err := store.IsInvalidURL(url); err != nil || invalid != want {
+			t.Errorf("IsInvalidURL(%q) = %v, %v; want %v, nil", url, invalid, err, want)
+		}
+	}
+}
+
+func TestStoreDoesNotRecordEmptyInvalidURL(t *testing.T) {
+	t.Parallel()
+	store := Store{Directory: t.TempDir(), HealthTTL: time.Hour, MaxHealthEntries: 10}
+	if err := store.MarkInvalidURL("  "); err == nil {
+		t.Fatal("MarkInvalidURL(empty) error = nil")
+	}
+}
+
+func TestStoreClearRemovesSearchAndURLHealthCaches(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	store := Store{Directory: directory, TTL: time.Hour, HealthTTL: time.Hour, MaxHealthEntries: 10}
+	if err := store.Put("Example", "fixture", []string{"otf"}, []provider.Result{{Filename: "Example.otf"}}); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.MarkInvalidURL("https://example.com/invalid.otf"); err != nil {
+		t.Fatal(err)
+	}
+	if err := store.Clear(); err != nil {
+		t.Fatal(err)
+	}
+	entries, err := os.ReadDir(directory)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("cache directory contains %v after Clear", entries)
+	}
+	if _, err := os.Stat(filepath.Join(directory, urlHealthFilename)); !os.IsNotExist(err) {
+		t.Fatalf("health cache stat error = %v, want not exist", err)
 	}
 }

--- a/internal/cache/url_health_lock_unix.go
+++ b/internal/cache/url_health_lock_unix.go
@@ -1,0 +1,46 @@
+//go:build !windows
+
+package cache
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func lockURLHealth(directory string) (func(), error) {
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		return nil, err
+	}
+	file, err := os.OpenFile(filepath.Join(directory, ".url-health.lock"), os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	deadline := time.Now().Add(urlHealthLockTimeout)
+	for {
+		err = unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+		if err == nil {
+			return func() {
+				_ = unix.Flock(int(file.Fd()), unix.LOCK_UN)
+				_ = file.Close()
+			}, nil
+		}
+		if !errors.Is(err, syscall.EWOULDBLOCK) && !errors.Is(err, syscall.EAGAIN) {
+			file.Close()
+			return nil, err
+		}
+		if time.Now().After(deadline) {
+			file.Close()
+			return nil, errors.New("timed out waiting for another Moji process to update URL health")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func replaceFile(temporaryPath, finalPath string) error {
+	return os.Rename(temporaryPath, finalPath)
+}

--- a/internal/cache/url_health_lock_windows.go
+++ b/internal/cache/url_health_lock_windows.go
@@ -1,0 +1,46 @@
+//go:build windows
+
+package cache
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockURLHealth(directory string) (func(), error) {
+	if err := os.MkdirAll(directory, 0o700); err != nil {
+		return nil, err
+	}
+	file, err := os.OpenFile(filepath.Join(directory, ".url-health.lock"), os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	overlapped := new(windows.Overlapped)
+	deadline := time.Now().Add(urlHealthLockTimeout)
+	for {
+		err = windows.LockFileEx(windows.Handle(file.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, overlapped)
+		if err == nil {
+			return func() {
+				_ = windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, overlapped)
+				_ = file.Close()
+			}, nil
+		}
+		if !errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+			file.Close()
+			return nil, err
+		}
+		if time.Now().After(deadline) {
+			file.Close()
+			return nil, errors.New("timed out waiting for another Moji process to update URL health")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func replaceFile(temporaryPath, finalPath string) error {
+	return windows.Rename(temporaryPath, finalPath)
+}

--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -33,6 +33,11 @@ type File struct {
 	Existing bool
 }
 
+type batchMove struct {
+	from string
+	to   string
+}
+
 // InvalidContentError marks a URL that returned bytes which cannot be the
 // advertised font. Callers may remember this failure without treating network
 // or local filesystem errors as permanent URL failures.
@@ -206,10 +211,14 @@ func (d Downloader) DownloadBatch(ctx context.Context, results []provider.Result
 			staged = append(staged, file)
 		}
 	}
+	release, err := lockDownloadDirectory(destination)
+	if err != nil {
+		return nil, fmt.Errorf("Moji couldn't lock %s for a family download: %w. No family files were saved", destination, err)
+	}
+	defer release()
 
 	files := make([]File, len(staged))
-	type move struct{ from, to string }
-	moves := make([]move, 0, len(staged))
+	moves := make([]batchMove, 0, len(staged))
 	for index, file := range staged {
 		finalPath := filepath.Join(destination, filepath.Base(file.Path))
 		if duplicatePath, found, findErr := findDuplicate(destination, file.SHA256); findErr != nil {
@@ -229,15 +238,49 @@ func (d Downloader) DownloadBatch(ctx context.Context, results []provider.Result
 			return nil, fmt.Errorf("Moji couldn't inspect %s: %w. No family files were saved", finalPath, readErr)
 		}
 		files[index] = File{Path: finalPath, SHA256: file.SHA256}
-		moves = append(moves, move{from: file.Path, to: finalPath})
+		moves = append(moves, batchMove{from: file.Path, to: finalPath})
 	}
 
-	for index, operation := range moves {
-		if moveErr := moveNoReplace(operation.from, operation.to); moveErr != nil {
-			return nil, fmt.Errorf("Moji couldn't finish the family download at %s without overwriting a concurrent file: %w. %d validated family files were already saved and were left untouched", operation.to, moveErr, index)
-		}
+	if err := commitBatchMoves(moves); err != nil {
+		return nil, err
 	}
 	return files, nil
+}
+
+func commitBatchMoves(moves []batchMove) error {
+	type committedMove struct {
+		batchMove
+		identity os.FileInfo
+	}
+	committed := make([]committedMove, 0, len(moves))
+	for _, operation := range moves {
+		if err := moveNoReplace(operation.from, operation.to); err != nil {
+			rollbackFailures := make([]error, 0)
+			for index := len(committed) - 1; index >= 0; index-- {
+				current, statErr := os.Stat(committed[index].to)
+				if errors.Is(statErr, os.ErrNotExist) {
+					continue
+				}
+				if statErr != nil || !os.SameFile(committed[index].identity, current) {
+					rollbackFailures = append(rollbackFailures, fmt.Errorf("%s changed before rollback", committed[index].to))
+					continue
+				}
+				if removeErr := os.Remove(committed[index].to); removeErr != nil {
+					rollbackFailures = append(rollbackFailures, fmt.Errorf("remove %s: %w", committed[index].to, removeErr))
+				}
+			}
+			if len(rollbackFailures) > 0 {
+				return fmt.Errorf("Moji couldn't finish the family download at %s without overwriting a concurrent file: %w. Rollback was incomplete: %v", operation.to, err, errors.Join(rollbackFailures...))
+			}
+			return fmt.Errorf("Moji couldn't finish the family download at %s without overwriting a concurrent file: %w. Earlier family moves were rolled back", operation.to, err)
+		}
+		identity, statErr := os.Stat(operation.to)
+		if statErr != nil {
+			return fmt.Errorf("Moji couldn't verify the committed family file %s: %w", operation.to, statErr)
+		}
+		committed = append(committed, committedMove{batchMove: operation, identity: identity})
+	}
+	return nil
 }
 
 func findDuplicate(directory, digest string) (string, bool, error) {
@@ -246,7 +289,7 @@ func findDuplicate(directory, digest string) (string, bool, error) {
 		return "", false, err
 	}
 	for _, entry := range entries {
-		if entry.IsDir() || strings.HasSuffix(entry.Name(), ".tmp") {
+		if entry.IsDir() || strings.HasSuffix(entry.Name(), ".tmp") || strings.HasPrefix(entry.Name(), ".moji-") {
 			continue
 		}
 		path := filepath.Join(directory, entry.Name())

--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/microck/moji/internal/archivefont"
 	"github.com/microck/moji/internal/provider"
+	"github.com/microck/moji/internal/safehttp"
 )
 
 const DefaultMaxSize int64 = 50 << 20
@@ -25,6 +26,9 @@ type Downloader struct {
 	Client        *http.Client
 	MaxSize       int64
 	AllowInsecure bool
+	// AllowPrivate is only for trusted local test fixtures. The application
+	// never exposes it through configuration or CLI flags.
+	AllowPrivate bool
 }
 
 type File struct {
@@ -79,11 +83,7 @@ func (d Downloader) Download(ctx context.Context, result provider.Result, destin
 	if parsed.Scheme != "https" && !(parsed.Scheme == "http" && d.AllowInsecure) {
 		return File{}, errors.New("the download uses insecure HTTP, so Moji blocked it before saving a file. Choose another result or use --allow-insecure only if you trust this source")
 	}
-	client := d.Client
-	if client == nil {
-		client = &http.Client{}
-	}
-	clientCopy := *client
+	clientCopy := safehttp.Constrain(d.Client, d.AllowPrivate)
 	originalRedirect := clientCopy.CheckRedirect
 	clientCopy.CheckRedirect = func(request *http.Request, via []*http.Request) error {
 		if request.URL.Scheme != "https" && !(request.URL.Scheme == "http" && d.AllowInsecure) {
@@ -97,7 +97,7 @@ func (d Downloader) Download(ctx context.Context, result provider.Result, destin
 		}
 		return nil
 	}
-	client = &clientCopy
+	client := &clientCopy
 	limit := d.MaxSize
 	if limit <= 0 {
 		limit = DefaultMaxSize

--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -38,6 +38,11 @@ type batchMove struct {
 	to   string
 }
 
+type committedBatchMove struct {
+	batchMove
+	identity os.FileInfo
+}
+
 // InvalidContentError marks a URL that returned bytes which cannot be the
 // advertised font. Callers may remember this failure without treating network
 // or local filesystem errors as permanent URL failures.
@@ -248,39 +253,46 @@ func (d Downloader) DownloadBatch(ctx context.Context, results []provider.Result
 }
 
 func commitBatchMoves(moves []batchMove) error {
-	type committedMove struct {
-		batchMove
-		identity os.FileInfo
-	}
-	committed := make([]committedMove, 0, len(moves))
+	committed := make([]committedBatchMove, 0, len(moves))
 	for _, operation := range moves {
+		identity, statErr := os.Stat(operation.from)
+		if statErr != nil {
+			return fmt.Errorf("Moji couldn't identify the staged family file %s: %w", operation.from, statErr)
+		}
 		if err := moveNoReplace(operation.from, operation.to); err != nil {
-			rollbackFailures := make([]error, 0)
-			for index := len(committed) - 1; index >= 0; index-- {
-				current, statErr := os.Stat(committed[index].to)
-				if errors.Is(statErr, os.ErrNotExist) {
-					continue
-				}
-				if statErr != nil || !os.SameFile(committed[index].identity, current) {
-					rollbackFailures = append(rollbackFailures, fmt.Errorf("%s changed before rollback", committed[index].to))
-					continue
-				}
-				if removeErr := os.Remove(committed[index].to); removeErr != nil {
-					rollbackFailures = append(rollbackFailures, fmt.Errorf("remove %s: %w", committed[index].to, removeErr))
-				}
-			}
-			if len(rollbackFailures) > 0 {
-				return fmt.Errorf("Moji couldn't finish the family download at %s without overwriting a concurrent file: %w. Rollback was incomplete: %v", operation.to, err, errors.Join(rollbackFailures...))
+			if rollbackErr := rollbackBatchMoves(committed); rollbackErr != nil {
+				return fmt.Errorf("Moji couldn't finish the family download at %s without overwriting a concurrent file: %w. Rollback was incomplete: %v", operation.to, err, rollbackErr)
 			}
 			return fmt.Errorf("Moji couldn't finish the family download at %s without overwriting a concurrent file: %w. Earlier family moves were rolled back", operation.to, err)
 		}
-		identity, statErr := os.Stat(operation.to)
-		if statErr != nil {
-			return fmt.Errorf("Moji couldn't verify the committed family file %s: %w", operation.to, statErr)
+		current, statErr := os.Stat(operation.to)
+		if statErr != nil || !os.SameFile(identity, current) {
+			if rollbackErr := rollbackBatchMoves(committed); rollbackErr != nil {
+				return fmt.Errorf("Moji couldn't verify ownership of %s after moving it. Earlier rollback was incomplete: %v", operation.to, rollbackErr)
+			}
+			return fmt.Errorf("Moji couldn't verify ownership of %s after moving it. Earlier family moves were rolled back and the changed path was left untouched", operation.to)
 		}
-		committed = append(committed, committedMove{batchMove: operation, identity: identity})
+		committed = append(committed, committedBatchMove{batchMove: operation, identity: identity})
 	}
 	return nil
+}
+
+func rollbackBatchMoves(committed []committedBatchMove) error {
+	failures := make([]error, 0)
+	for index := len(committed) - 1; index >= 0; index-- {
+		current, err := os.Stat(committed[index].to)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil || !os.SameFile(committed[index].identity, current) {
+			failures = append(failures, fmt.Errorf("%s changed before rollback", committed[index].to))
+			continue
+		}
+		if err := os.Remove(committed[index].to); err != nil {
+			failures = append(failures, fmt.Errorf("remove %s: %w", committed[index].to, err))
+		}
+	}
+	return errors.Join(failures...)
 }
 
 func findDuplicate(directory, digest string) (string, bool, error) {

--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -257,7 +257,10 @@ func commitBatchMoves(moves []batchMove) error {
 	for _, operation := range moves {
 		identity, statErr := os.Stat(operation.from)
 		if statErr != nil {
-			return fmt.Errorf("Moji couldn't identify the staged family file %s: %w", operation.from, statErr)
+			if rollbackErr := rollbackBatchMoves(committed); rollbackErr != nil {
+				return fmt.Errorf("Moji couldn't identify the staged family file %s: %w. Rollback was incomplete: %v", operation.from, statErr, rollbackErr)
+			}
+			return fmt.Errorf("Moji couldn't identify the staged family file %s: %w. Earlier family moves were rolled back", operation.from, statErr)
 		}
 		if err := moveNoReplace(operation.from, operation.to); err != nil {
 			if rollbackErr := rollbackBatchMoves(committed); rollbackErr != nil {

--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -33,6 +33,30 @@ type File struct {
 	Existing bool
 }
 
+// InvalidContentError marks a URL that returned bytes which cannot be the
+// advertised font. Callers may remember this failure without treating network
+// or local filesystem errors as permanent URL failures.
+type InvalidContentError struct {
+	URL string
+	Err error
+}
+
+func (failure InvalidContentError) Error() string { return failure.Err.Error() }
+func (failure InvalidContentError) Unwrap() error { return failure.Err }
+
+func IsInvalidContent(err error) bool {
+	var failure InvalidContentError
+	return errors.As(err, &failure)
+}
+
+func InvalidContentURL(err error) string {
+	var failure InvalidContentError
+	if errors.As(err, &failure) {
+		return failure.URL
+	}
+	return ""
+}
+
 func (d Downloader) Download(ctx context.Context, result provider.Result, destination string) (File, error) {
 	parsed, err := url.Parse(result.URL)
 	if err != nil {
@@ -90,7 +114,7 @@ func (d Downloader) Download(ctx context.Context, result provider.Result, destin
 		}
 		member, extractErr := archivefont.Extract(archive, result.ArchiveFormat, result.ArchiveMember, archivefont.DefaultLimits())
 		if extractErr != nil {
-			return File{}, fmt.Errorf("Moji couldn't safely extract %s: %w. No file was saved", result.ArchiveMember, extractErr)
+			return File{}, InvalidContentError{URL: result.URL, Err: fmt.Errorf("Moji couldn't safely extract %s: %w. No file was saved", result.ArchiveMember, extractErr)}
 		}
 		contentReader = bytes.NewReader(member)
 	}
@@ -124,7 +148,7 @@ func (d Downloader) Download(ctx context.Context, result provider.Result, destin
 		return File{}, fmt.Errorf("Moji couldn't validate the temporary download: %w. No font was saved; try again", err)
 	}
 	if err := ValidateMagic(result.Format, bytes); err != nil {
-		return File{}, err
+		return File{}, InvalidContentError{URL: result.URL, Err: err}
 	}
 	digest := hex.EncodeToString(hash.Sum(nil))
 	finalPath := filepath.Join(destination, filename)
@@ -144,6 +168,76 @@ func (d Downloader) Download(ctx context.Context, result provider.Result, destin
 		return File{}, fmt.Errorf("Moji couldn't move the validated font to %s: %w. No completed font was saved; check the directory permissions", finalPath, err)
 	}
 	return File{Path: finalPath, SHA256: digest}, nil
+}
+
+// DownloadBatch validates every file in an isolated staging directory before
+// exposing any of them in destination. This keeps family downloads coherent:
+// one bad member cannot leave a partially downloaded family behind.
+func (d Downloader) DownloadBatch(ctx context.Context, results []provider.Result, destination string) ([]File, error) {
+	if err := os.MkdirAll(destination, 0o755); err != nil {
+		return nil, fmt.Errorf("Moji couldn't create the download directory %s: %w. Check the directory permissions, then try again", destination, err)
+	}
+	staging, err := os.MkdirTemp(destination, ".moji-family-*")
+	if err != nil {
+		return nil, fmt.Errorf("Moji couldn't create a family staging directory in %s: %w. No font was saved", destination, err)
+	}
+	defer os.RemoveAll(staging)
+
+	staged := make([]File, 0, len(results))
+	stagedPaths := make(map[string]bool, len(results))
+	for _, result := range results {
+		file, downloadErr := d.Download(ctx, result, staging)
+		if downloadErr != nil {
+			return nil, downloadErr
+		}
+		if !stagedPaths[file.Path] {
+			stagedPaths[file.Path] = true
+			staged = append(staged, file)
+		}
+	}
+
+	files := make([]File, len(staged))
+	type move struct{ from, to string }
+	moves := make([]move, 0, len(staged))
+	for index, file := range staged {
+		finalPath := filepath.Join(destination, filepath.Base(file.Path))
+		if duplicatePath, found, findErr := findDuplicate(destination, file.SHA256); findErr != nil {
+			return nil, fmt.Errorf("Moji couldn't inspect existing files in %s: %w. No family files were saved", destination, findErr)
+		} else if found {
+			files[index] = File{Path: duplicatePath, SHA256: file.SHA256, Existing: true}
+			continue
+		}
+		if existing, readErr := os.ReadFile(finalPath); readErr == nil {
+			hash := sha256.Sum256(existing)
+			if hex.EncodeToString(hash[:]) != file.SHA256 {
+				return nil, fmt.Errorf("%s already contains a different file. No family files were saved; move or rename it, then try again", finalPath)
+			}
+			files[index] = File{Path: finalPath, SHA256: file.SHA256, Existing: true}
+			continue
+		} else if !errors.Is(readErr, os.ErrNotExist) {
+			return nil, fmt.Errorf("Moji couldn't inspect %s: %w. No family files were saved", finalPath, readErr)
+		}
+		files[index] = File{Path: finalPath, SHA256: file.SHA256}
+		moves = append(moves, move{from: file.Path, to: finalPath})
+	}
+
+	moved := make([]move, 0, len(moves))
+	for _, operation := range moves {
+		if moveErr := os.Rename(operation.from, operation.to); moveErr != nil {
+			rollbackFailures := make([]error, 0)
+			for index := len(moved) - 1; index >= 0; index-- {
+				if rollbackErr := os.Rename(moved[index].to, moved[index].from); rollbackErr != nil {
+					rollbackFailures = append(rollbackFailures, fmt.Errorf("restore %s: %w", moved[index].to, rollbackErr))
+				}
+			}
+			if len(rollbackFailures) > 0 {
+				return nil, fmt.Errorf("Moji couldn't finish the family download at %s: %w. Rollback also failed, so the destination may contain part of the family: %v", operation.to, moveErr, errors.Join(rollbackFailures...))
+			}
+			return nil, fmt.Errorf("Moji couldn't finish the family download at %s: %w. Completed moves were rolled back", operation.to, moveErr)
+		}
+		moved = append(moved, operation)
+	}
+	return files, nil
 }
 
 func findDuplicate(directory, digest string) (string, bool, error) {

--- a/internal/download/download.go
+++ b/internal/download/download.go
@@ -37,8 +37,9 @@ type File struct {
 // advertised font. Callers may remember this failure without treating network
 // or local filesystem errors as permanent URL failures.
 type InvalidContentError struct {
-	URL string
-	Err error
+	URL           string
+	ArchiveMember string
+	Err           error
 }
 
 func (failure InvalidContentError) Error() string { return failure.Err.Error() }
@@ -49,9 +50,12 @@ func IsInvalidContent(err error) bool {
 	return errors.As(err, &failure)
 }
 
-func InvalidContentURL(err error) string {
+func InvalidContentKey(err error) string {
 	var failure InvalidContentError
 	if errors.As(err, &failure) {
+		if failure.ArchiveMember != "" {
+			return failure.URL + "\x00" + failure.ArchiveMember
+		}
 		return failure.URL
 	}
 	return ""
@@ -114,7 +118,7 @@ func (d Downloader) Download(ctx context.Context, result provider.Result, destin
 		}
 		member, extractErr := archivefont.Extract(archive, result.ArchiveFormat, result.ArchiveMember, archivefont.DefaultLimits())
 		if extractErr != nil {
-			return File{}, InvalidContentError{URL: result.URL, Err: fmt.Errorf("Moji couldn't safely extract %s: %w. No file was saved", result.ArchiveMember, extractErr)}
+			return File{}, InvalidContentError{URL: result.URL, ArchiveMember: result.ArchiveMember, Err: fmt.Errorf("Moji couldn't safely extract %s: %w. No file was saved", result.ArchiveMember, extractErr)}
 		}
 		contentReader = bytes.NewReader(member)
 	}
@@ -148,7 +152,7 @@ func (d Downloader) Download(ctx context.Context, result provider.Result, destin
 		return File{}, fmt.Errorf("Moji couldn't validate the temporary download: %w. No font was saved; try again", err)
 	}
 	if err := ValidateMagic(result.Format, bytes); err != nil {
-		return File{}, InvalidContentError{URL: result.URL, Err: err}
+		return File{}, InvalidContentError{URL: result.URL, ArchiveMember: result.ArchiveMember, Err: err}
 	}
 	digest := hex.EncodeToString(hash.Sum(nil))
 	finalPath := filepath.Join(destination, filename)
@@ -164,7 +168,14 @@ func (d Downloader) Download(ctx context.Context, result provider.Result, destin
 		}
 		return File{}, fmt.Errorf("%s already contains a different file. Move or rename it, then try again", finalPath)
 	}
-	if err := os.Rename(temporaryPath, finalPath); err != nil {
+	if err := moveNoReplace(temporaryPath, finalPath); err != nil {
+		if existing, readErr := os.ReadFile(finalPath); readErr == nil {
+			existingHash := sha256.Sum256(existing)
+			if hex.EncodeToString(existingHash[:]) == digest {
+				return File{Path: finalPath, SHA256: digest, Existing: true}, nil
+			}
+			return File{}, fmt.Errorf("%s was created by another process with different content. Moji did not overwrite it", finalPath)
+		}
 		return File{}, fmt.Errorf("Moji couldn't move the validated font to %s: %w. No completed font was saved; check the directory permissions", finalPath, err)
 	}
 	return File{Path: finalPath, SHA256: digest}, nil
@@ -221,21 +232,10 @@ func (d Downloader) DownloadBatch(ctx context.Context, results []provider.Result
 		moves = append(moves, move{from: file.Path, to: finalPath})
 	}
 
-	moved := make([]move, 0, len(moves))
-	for _, operation := range moves {
-		if moveErr := os.Rename(operation.from, operation.to); moveErr != nil {
-			rollbackFailures := make([]error, 0)
-			for index := len(moved) - 1; index >= 0; index-- {
-				if rollbackErr := os.Rename(moved[index].to, moved[index].from); rollbackErr != nil {
-					rollbackFailures = append(rollbackFailures, fmt.Errorf("restore %s: %w", moved[index].to, rollbackErr))
-				}
-			}
-			if len(rollbackFailures) > 0 {
-				return nil, fmt.Errorf("Moji couldn't finish the family download at %s: %w. Rollback also failed, so the destination may contain part of the family: %v", operation.to, moveErr, errors.Join(rollbackFailures...))
-			}
-			return nil, fmt.Errorf("Moji couldn't finish the family download at %s: %w. Completed moves were rolled back", operation.to, moveErr)
+	for index, operation := range moves {
+		if moveErr := moveNoReplace(operation.from, operation.to); moveErr != nil {
+			return nil, fmt.Errorf("Moji couldn't finish the family download at %s without overwriting a concurrent file: %w. %d validated family files were already saved and were left untouched", operation.to, moveErr, index)
 		}
-		moved = append(moved, operation)
 	}
 	return files, nil
 }

--- a/internal/download/download_test.go
+++ b/internal/download/download_test.go
@@ -40,6 +40,21 @@ func TestDownloadExtractsAndValidatesArchiveMember(t *testing.T) {
 	}
 }
 
+func TestDownloadClassifiesMalformedArchiveAsInvalidContent(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		response.Write([]byte("not a zip archive"))
+	}))
+	defer server.Close()
+	_, err := (Downloader{Client: server.Client()}).Download(context.Background(), provider.Result{
+		URL: server.URL, Filename: "Example-Regular.otf", Format: "otf",
+		ArchiveFormat: "zip", ArchiveMember: "Example-Regular.otf",
+	}, t.TempDir())
+	if err == nil || !IsInvalidContent(err) || InvalidContentURL(err) != server.URL {
+		t.Fatalf("malformed archive classification = %v", err)
+	}
+}
+
 func TestValidateLegacyFontFormats(t *testing.T) {
 	t.Parallel()
 	pfb := []byte{0x80, 0x01, 0x04, 0x00, 0x00, 0x00, 'f', 'o', 'n', 't', 0x80, 0x03}
@@ -96,12 +111,44 @@ func TestDownloadRejectsInvalidContentWithoutResidue(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected invalid magic error")
 	}
+	if !IsInvalidContent(err) {
+		t.Fatalf("invalid font content must be classifiable for URL health caching: %v", err)
+	}
 	if !strings.Contains(err.Error(), "No file was saved") || !strings.Contains(err.Error(), "try another source") {
 		t.Fatalf("error does not explain recovery: %v", err)
 	}
 	entries, readErr := os.ReadDir(destination)
 	if readErr != nil || len(entries) != 0 {
 		t.Fatalf("temporary file left behind: %v, %v", entries, readErr)
+	}
+}
+
+func TestDownloadBatchLeavesDestinationUnchangedWhenAnyFontIsInvalid(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.URL.Path == "/valid.otf" {
+			response.Write(append([]byte("OTTO"), make([]byte, 32)...))
+			return
+		}
+		response.Write([]byte("not a font"))
+	}))
+	defer server.Close()
+	destination := t.TempDir()
+	marker := filepath.Join(destination, "keep.txt")
+	if err := os.WriteFile(marker, []byte("unchanged"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := (Downloader{Client: server.Client()}).DownloadBatch(context.Background(), []provider.Result{
+		{URL: server.URL + "/valid.otf", Filename: "Family-Regular.otf", Format: "otf"},
+		{URL: server.URL + "/invalid.otf", Filename: "Family-Bold.otf", Format: "otf"},
+	}, destination)
+	if err == nil || !IsInvalidContent(err) {
+		t.Fatalf("expected classifiable invalid-content failure, got %v", err)
+	}
+	entries, readErr := os.ReadDir(destination)
+	if readErr != nil || len(entries) != 1 || entries[0].Name() != "keep.txt" {
+		t.Fatalf("family failure changed destination: entries=%v err=%v", entries, readErr)
 	}
 }
 

--- a/internal/download/download_test.go
+++ b/internal/download/download_test.go
@@ -280,3 +280,28 @@ func TestCommitBatchMovesRollsBackAfterLaterCollision(t *testing.T) {
 		t.Fatalf("concurrent file=%q err=%v", content, readErr)
 	}
 }
+
+func TestRollbackBatchMovesPreservesReplacedFile(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	original := filepath.Join(directory, "original.otf")
+	destination := filepath.Join(directory, "destination.otf")
+	if err := os.WriteFile(original, []byte("original"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	identity, err := os.Stat(original)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(destination, []byte("replacement"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err = rollbackBatchMoves([]committedBatchMove{{batchMove: batchMove{to: destination}, identity: identity}})
+	if err == nil {
+		t.Fatal("rollback accepted a replacement file as its own")
+	}
+	content, readErr := os.ReadFile(destination)
+	if readErr != nil || string(content) != "replacement" {
+		t.Fatalf("replacement=%q err=%v", content, readErr)
+	}
+}

--- a/internal/download/download_test.go
+++ b/internal/download/download_test.go
@@ -50,7 +50,7 @@ func TestDownloadClassifiesMalformedArchiveAsInvalidContent(t *testing.T) {
 		URL: server.URL, Filename: "Example-Regular.otf", Format: "otf",
 		ArchiveFormat: "zip", ArchiveMember: "Example-Regular.otf",
 	}, t.TempDir())
-	if err == nil || !IsInvalidContent(err) || InvalidContentURL(err) != server.URL {
+	if err == nil || !IsInvalidContent(err) || InvalidContentKey(err) != server.URL+"\x00Example-Regular.otf" {
 		t.Fatalf("malformed archive classification = %v", err)
 	}
 }
@@ -231,5 +231,25 @@ func TestDownloadRejectsHTTPSDowngradeRedirect(t *testing.T) {
 	_, err := (Downloader{Client: secure.Client()}).Download(context.Background(), provider.Result{URL: secure.URL, Filename: "font.otf", Format: "otf"}, t.TempDir())
 	if err == nil {
 		t.Fatal("expected HTTPS downgrade redirect to be rejected")
+	}
+}
+
+func TestMoveNoReplacePreservesConcurrentDestination(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	source := filepath.Join(directory, "source.otf")
+	destination := filepath.Join(directory, "destination.otf")
+	if err := os.WriteFile(source, []byte("source"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(destination, []byte("concurrent"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := moveNoReplace(source, destination); err == nil {
+		t.Fatal("moveNoReplace overwrote an existing destination")
+	}
+	content, err := os.ReadFile(destination)
+	if err != nil || string(content) != "concurrent" {
+		t.Fatalf("destination=%q err=%v", content, err)
 	}
 }

--- a/internal/download/download_test.go
+++ b/internal/download/download_test.go
@@ -27,7 +27,7 @@ func TestDownloadExtractsAndValidatesArchiveMember(t *testing.T) {
 	}))
 	defer server.Close()
 	destination := t.TempDir()
-	file, err := (Downloader{Client: server.Client()}).Download(context.Background(), provider.Result{
+	file, err := (Downloader{Client: server.Client(), AllowPrivate: true}).Download(context.Background(), provider.Result{
 		Filename: "Example-Regular.otf", Format: "otf", URL: server.URL, Source: "fixture",
 		ArchiveFormat: "zip", ArchiveMember: "Family/Example-Regular.otf",
 	}, destination)
@@ -46,7 +46,7 @@ func TestDownloadClassifiesMalformedArchiveAsInvalidContent(t *testing.T) {
 		response.Write([]byte("not a zip archive"))
 	}))
 	defer server.Close()
-	_, err := (Downloader{Client: server.Client()}).Download(context.Background(), provider.Result{
+	_, err := (Downloader{Client: server.Client(), AllowPrivate: true}).Download(context.Background(), provider.Result{
 		URL: server.URL, Filename: "Example-Regular.otf", Format: "otf",
 		ArchiveFormat: "zip", ArchiveMember: "Example-Regular.otf",
 	}, t.TempDir())
@@ -84,7 +84,7 @@ func TestDownloadValidatesAndDeduplicates(t *testing.T) {
 	}))
 	defer server.Close()
 	destination := t.TempDir()
-	d := Downloader{Client: server.Client()}
+	d := Downloader{Client: server.Client(), AllowPrivate: true}
 	result := provider.Result{URL: server.URL, Source: "fixture", Filename: "../Example.otf", Format: "otf"}
 	first, err := d.Download(context.Background(), result, destination)
 	if err != nil {
@@ -107,7 +107,7 @@ func TestDownloadRejectsInvalidContentWithoutResidue(t *testing.T) {
 	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) { response.Write([]byte("html response")) }))
 	defer server.Close()
 	destination := t.TempDir()
-	_, err := (Downloader{Client: server.Client()}).Download(context.Background(), provider.Result{URL: server.URL, Filename: "bad.ttf", Format: "ttf"}, destination)
+	_, err := (Downloader{Client: server.Client(), AllowPrivate: true}).Download(context.Background(), provider.Result{URL: server.URL, Filename: "bad.ttf", Format: "ttf"}, destination)
 	if err == nil {
 		t.Fatal("expected invalid magic error")
 	}
@@ -139,7 +139,7 @@ func TestDownloadBatchLeavesDestinationUnchangedWhenAnyFontIsInvalid(t *testing.
 		t.Fatal(err)
 	}
 
-	_, err := (Downloader{Client: server.Client()}).DownloadBatch(context.Background(), []provider.Result{
+	_, err := (Downloader{Client: server.Client(), AllowPrivate: true}).DownloadBatch(context.Background(), []provider.Result{
 		{URL: server.URL + "/valid.otf", Filename: "Family-Regular.otf", Format: "otf"},
 		{URL: server.URL + "/invalid.otf", Filename: "Family-Bold.otf", Format: "otf"},
 	}, destination)
@@ -163,6 +163,18 @@ func TestDownloadRejectsInsecureHTTP(t *testing.T) {
 	}
 }
 
+func TestDownloadRejectsPrivateNetworkDestinations(t *testing.T) {
+	t.Parallel()
+	for _, rawURL := range []string{"https://127.0.0.1/font.ttf", "https://localhost/font.ttf"} {
+		_, err := (Downloader{}).Download(context.Background(), provider.Result{
+			URL: rawURL, Source: "fixture", Filename: "font.ttf", Format: "ttf",
+		}, t.TempDir())
+		if err == nil || !strings.Contains(err.Error(), "non-public address") {
+			t.Fatalf("url=%s err=%v", rawURL, err)
+		}
+	}
+}
+
 func TestDownloadDeduplicatesSameBytesAcrossFilenames(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
@@ -170,7 +182,7 @@ func TestDownloadDeduplicatesSameBytesAcrossFilenames(t *testing.T) {
 	}))
 	defer server.Close()
 	destination := t.TempDir()
-	downloader := Downloader{Client: server.Client()}
+	downloader := Downloader{Client: server.Client(), AllowPrivate: true}
 	first, err := downloader.Download(context.Background(), provider.Result{URL: server.URL, Filename: "First.otf", Format: "otf"}, destination)
 	if err != nil {
 		t.Fatal(err)
@@ -195,7 +207,7 @@ func TestDownloadCapsRedirectsAtFive(t *testing.T) {
 		http.Redirect(response, request, "/next", http.StatusFound)
 	}))
 	defer server.Close()
-	_, err := (Downloader{Client: server.Client()}).Download(context.Background(), provider.Result{URL: server.URL, Filename: "font.otf", Format: "otf"}, t.TempDir())
+	_, err := (Downloader{Client: server.Client(), AllowPrivate: true}).Download(context.Background(), provider.Result{URL: server.URL, Filename: "font.otf", Format: "otf"}, t.TempDir())
 	if err == nil || redirects != 5 {
 		t.Fatalf("redirects=%d err=%v", redirects, err)
 	}
@@ -208,7 +220,7 @@ func TestDownloadRejectsBodyOverMaximumSize(t *testing.T) {
 	}))
 	defer server.Close()
 	destination := t.TempDir()
-	_, err := (Downloader{Client: server.Client(), MaxSize: 16}).Download(context.Background(), provider.Result{URL: server.URL, Filename: "large.otf", Format: "otf"}, destination)
+	_, err := (Downloader{Client: server.Client(), MaxSize: 16, AllowPrivate: true}).Download(context.Background(), provider.Result{URL: server.URL, Filename: "large.otf", Format: "otf"}, destination)
 	if err == nil {
 		t.Fatal("expected maximum-size error")
 	}
@@ -228,7 +240,7 @@ func TestDownloadRejectsHTTPSDowngradeRedirect(t *testing.T) {
 		http.Redirect(response, request, insecure.URL+"/font.otf", http.StatusFound)
 	}))
 	defer secure.Close()
-	_, err := (Downloader{Client: secure.Client()}).Download(context.Background(), provider.Result{URL: secure.URL, Filename: "font.otf", Format: "otf"}, t.TempDir())
+	_, err := (Downloader{Client: secure.Client(), AllowPrivate: true}).Download(context.Background(), provider.Result{URL: secure.URL, Filename: "font.otf", Format: "otf"}, t.TempDir())
 	if err == nil {
 		t.Fatal("expected HTTPS downgrade redirect to be rejected")
 	}

--- a/internal/download/download_test.go
+++ b/internal/download/download_test.go
@@ -281,6 +281,26 @@ func TestCommitBatchMovesRollsBackAfterLaterCollision(t *testing.T) {
 	}
 }
 
+func TestCommitBatchMovesRollsBackWhenLaterSourceDisappears(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	firstSource := filepath.Join(directory, "first-source.otf")
+	firstDestination := filepath.Join(directory, "first.otf")
+	if err := os.WriteFile(firstSource, []byte("first"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := commitBatchMoves([]batchMove{
+		{from: firstSource, to: firstDestination},
+		{from: filepath.Join(directory, "missing.otf"), to: filepath.Join(directory, "second.otf")},
+	})
+	if err == nil {
+		t.Fatal("expected missing staged source error")
+	}
+	if _, statErr := os.Stat(firstDestination); !os.IsNotExist(statErr) {
+		t.Fatalf("first family file was not rolled back: %v", statErr)
+	}
+}
+
 func TestRollbackBatchMovesPreservesReplacedFile(t *testing.T) {
 	t.Parallel()
 	directory := t.TempDir()

--- a/internal/download/download_test.go
+++ b/internal/download/download_test.go
@@ -253,3 +253,30 @@ func TestMoveNoReplacePreservesConcurrentDestination(t *testing.T) {
 		t.Fatalf("destination=%q err=%v", content, err)
 	}
 }
+
+func TestCommitBatchMovesRollsBackAfterLaterCollision(t *testing.T) {
+	t.Parallel()
+	directory := t.TempDir()
+	firstSource := filepath.Join(directory, "first-source.otf")
+	secondSource := filepath.Join(directory, "second-source.otf")
+	firstDestination := filepath.Join(directory, "first.otf")
+	secondDestination := filepath.Join(directory, "second.otf")
+	for path, content := range map[string]string{
+		firstSource: "first", secondSource: "second", secondDestination: "concurrent",
+	} {
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			t.Fatal(err)
+		}
+	}
+	err := commitBatchMoves([]batchMove{{from: firstSource, to: firstDestination}, {from: secondSource, to: secondDestination}})
+	if err == nil {
+		t.Fatal("expected second move collision")
+	}
+	if _, statErr := os.Stat(firstDestination); !os.IsNotExist(statErr) {
+		t.Fatalf("first family file was not rolled back: %v", statErr)
+	}
+	content, readErr := os.ReadFile(secondDestination)
+	if readErr != nil || string(content) != "concurrent" {
+		t.Fatalf("concurrent file=%q err=%v", content, readErr)
+	}
+}

--- a/internal/download/move_no_replace_unix.go
+++ b/internal/download/move_no_replace_unix.go
@@ -1,0 +1,13 @@
+//go:build !windows
+
+package download
+
+import "os"
+
+func moveNoReplace(source, destination string) error {
+	if err := os.Link(source, destination); err != nil {
+		return err
+	}
+	_ = os.Remove(source)
+	return nil
+}

--- a/internal/download/move_no_replace_windows.go
+++ b/internal/download/move_no_replace_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package download
+
+import (
+	"golang.org/x/sys/windows"
+)
+
+func moveNoReplace(source, destination string) error {
+	from, err := windows.UTF16PtrFromString(source)
+	if err != nil {
+		return err
+	}
+	to, err := windows.UTF16PtrFromString(destination)
+	if err != nil {
+		return err
+	}
+	return windows.MoveFileEx(from, to, windows.MOVEFILE_WRITE_THROUGH)
+}

--- a/internal/download/transaction_lock_unix.go
+++ b/internal/download/transaction_lock_unix.go
@@ -1,0 +1,39 @@
+//go:build !windows
+
+package download
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func lockDownloadDirectory(directory string) (func(), error) {
+	file, err := os.OpenFile(filepath.Join(directory, ".moji-download.lock"), os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		err = unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+		if err == nil {
+			return func() {
+				_ = unix.Flock(int(file.Fd()), unix.LOCK_UN)
+				_ = file.Close()
+			}, nil
+		}
+		if !errors.Is(err, syscall.EWOULDBLOCK) && !errors.Is(err, syscall.EAGAIN) {
+			file.Close()
+			return nil, err
+		}
+		if time.Now().After(deadline) {
+			file.Close()
+			return nil, errors.New("timed out waiting for another Moji family download")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/internal/download/transaction_lock_windows.go
+++ b/internal/download/transaction_lock_windows.go
@@ -1,0 +1,39 @@
+//go:build windows
+
+package download
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"time"
+
+	"golang.org/x/sys/windows"
+)
+
+func lockDownloadDirectory(directory string) (func(), error) {
+	file, err := os.OpenFile(filepath.Join(directory, ".moji-download.lock"), os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, err
+	}
+	overlapped := new(windows.Overlapped)
+	deadline := time.Now().Add(2 * time.Second)
+	for {
+		err = windows.LockFileEx(windows.Handle(file.Fd()), windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY, 0, 1, 0, overlapped)
+		if err == nil {
+			return func() {
+				_ = windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, overlapped)
+				_ = file.Close()
+			}, nil
+		}
+		if !errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+			file.Close()
+			return nil, err
+		}
+		if time.Now().After(deadline) {
+			file.Close()
+			return nil, errors.New("timed out waiting for another Moji family download")
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}

--- a/internal/provider/discovery.go
+++ b/internal/provider/discovery.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 
 	"github.com/microck/moji/internal/archivefont"
+	"github.com/microck/moji/internal/safehttp"
 )
 
 const maxDiscoveryContainerSize int64 = 50 << 20
@@ -21,6 +22,10 @@ const maxDiscoveryContainerSize int64 = 50 << 20
 const maxDiscoveryStylesheetSize int64 = 2 << 20
 
 var cssSource = regexp.MustCompile(`(?i)url\(\s*['"]?([^'")\s]+)['"]?\s*\)\s*(?:format\(\s*['"]?([a-z0-9-]+)['"]?\s*\))?`)
+
+// privateDiscoveryContextKey lets package tests reach local TLS servers. No
+// production caller can opt out of the public-address check through the API.
+type privateDiscoveryContextKey struct{}
 
 func resolveDiscoveredURL(ctx context.Context, client *http.Client, rawURL, query string, allowed map[string]bool) ([]Result, error) {
 	parsed, err := url.Parse(rawURL)
@@ -75,9 +80,12 @@ func resolveDiscoveredURL(ctx context.Context, client *http.Client, rawURL, quer
 			return nil, nil
 		}
 	} else {
-		content, err = fetchDiscoveryContent(ctx, client, rawURL, maxDiscoveryContainerSize)
+		content, _, err = fetchDiscoveryContentWithType(ctx, client, rawURL, maxDiscoveryContainerSize, true)
 		if err != nil {
 			return nil, err
+		}
+		if content == nil {
+			return nil, nil
 		}
 	}
 	members, err := archivefont.Inspect(content, archiveFormat, allowed, archivefont.DefaultLimits())
@@ -127,10 +135,8 @@ func fetchDiscoveryContent(ctx context.Context, client *http.Client, rawURL stri
 }
 
 func fetchDiscoveryContentWithType(ctx context.Context, client *http.Client, rawURL string, maximum int64, requireBinary bool) ([]byte, string, error) {
-	if client == nil {
-		client = &http.Client{}
-	}
-	clientCopy := *client
+	allowPrivate, _ := ctx.Value(privateDiscoveryContextKey{}).(bool)
+	clientCopy := safehttp.Constrain(client, allowPrivate)
 	originalRedirect := clientCopy.CheckRedirect
 	clientCopy.CheckRedirect = func(request *http.Request, via []*http.Request) error {
 		if request.URL.Scheme != "https" {
@@ -160,7 +166,7 @@ func fetchDiscoveryContentWithType(ctx context.Context, client *http.Client, raw
 		return nil, "", errors.New("discovery response exceeds the size limit")
 	}
 	contentType := response.Header.Get("Content-Type")
-	if requireBinary && !directBinaryContentType(contentType) {
+	if requireBinary && pageContentType(contentType) {
 		return nil, contentType, nil
 	}
 	content, err := io.ReadAll(io.LimitReader(response.Body, maximum+1))
@@ -173,13 +179,20 @@ func fetchDiscoveryContentWithType(ctx context.Context, client *http.Client, raw
 	return content, contentType, nil
 }
 
-func directBinaryContentType(value string) bool {
+func pageContentType(value string) bool {
+	if strings.TrimSpace(value) == "" {
+		return false
+	}
 	mediaType, _, err := mime.ParseMediaType(value)
 	if err != nil {
 		return false
 	}
-	switch strings.ToLower(mediaType) {
-	case "application/octet-stream", "application/zip", "application/x-zip-compressed", "application/x-tar", "application/gzip", "application/x-gzip":
+	mediaType = strings.ToLower(mediaType)
+	if strings.HasPrefix(mediaType, "text/") {
+		return true
+	}
+	switch mediaType {
+	case "application/json", "application/ld+json", "application/xhtml+xml", "application/xml":
 		return true
 	default:
 		return false

--- a/internal/provider/discovery.go
+++ b/internal/provider/discovery.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"io"
@@ -36,7 +37,7 @@ func resolveDiscoveredURL(ctx context.Context, client *http.Client, rawURL, quer
 	if allowed[format] {
 		return []Result{{
 			Name: query, Filename: filename, Format: format, Source: parsed.Host,
-			URL: rawURL, Trusted: false, License: "unknown",
+			URL: rawURL, Trusted: false, License: "unknown", FamilyGroup: directFamilyGroup(parsed),
 		}}, nil
 	}
 	if format == "css" {
@@ -55,7 +56,7 @@ func resolveDiscoveredURL(ctx context.Context, client *http.Client, rawURL, quer
 			if resolved.Scheme == "https" && resolved.Host != "" && allowed[fontFormat] {
 				results = append(results, Result{
 					Name: query, Filename: discoveredFilename(resolved.Path, query, fontFormat), Format: fontFormat,
-					Source: resolved.Host, URL: resolved.String(), Trusted: false, License: "unknown",
+					Source: resolved.Host, URL: resolved.String(), Trusted: false, License: "unknown", FamilyGroup: discoveredFamilyGroup("css", rawURL),
 				})
 			}
 		}
@@ -78,10 +79,25 @@ func resolveDiscoveredURL(ctx context.Context, client *http.Client, rawURL, quer
 		results = append(results, Result{
 			Name: query, Filename: filepath.Base(member.Path), Format: member.Format,
 			SizeBytes: member.Size, Source: parsed.Host, URL: rawURL,
-			Trusted: false, License: "unknown", ArchiveFormat: archiveFormat, ArchiveMember: member.Path,
+			Trusted: false, License: "unknown", ArchiveFormat: archiveFormat, ArchiveMember: member.Path, FamilyGroup: discoveredFamilyGroup("archive", rawURL),
 		})
 	}
 	return results, nil
+}
+
+func directFamilyGroup(parsed *url.URL) string {
+	if strings.EqualFold(parsed.Hostname(), "raw.githubusercontent.com") {
+		parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+		if len(parts) >= 2 {
+			return "github.com/" + parts[0] + "/" + parts[1]
+		}
+	}
+	return discoveredFamilyGroup("url", parsed.String())
+}
+
+func discoveredFamilyGroup(kind, value string) string {
+	digest := sha256.Sum256([]byte(value))
+	return fmt.Sprintf("%s:%x", kind, digest)
 }
 
 func discoveredFilename(pathValue, query, format string) string {

--- a/internal/provider/discovery.go
+++ b/internal/provider/discovery.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"net/url"
 	"path/filepath"
@@ -63,12 +64,21 @@ func resolveDiscoveredURL(ctx context.Context, client *http.Client, rawURL, quer
 		return results, nil
 	}
 	archiveFormat := discoveredArchiveFormat(parsed.Path)
+	var content []byte
 	if archiveFormat == "" {
-		return nil, nil
-	}
-	content, err := fetchDiscoveryContent(ctx, client, rawURL, maxDiscoveryContainerSize)
-	if err != nil {
-		return nil, err
+		content, _, err = fetchDiscoveryContentWithType(ctx, client, rawURL, maxDiscoveryContainerSize, true)
+		if err != nil {
+			return nil, err
+		}
+		archiveFormat = sniffArchiveFormat(content)
+		if archiveFormat == "" {
+			return nil, nil
+		}
+	} else {
+		content, err = fetchDiscoveryContent(ctx, client, rawURL, maxDiscoveryContainerSize)
+		if err != nil {
+			return nil, err
+		}
 	}
 	members, err := archivefont.Inspect(content, archiveFormat, allowed, archivefont.DefaultLimits())
 	if err != nil {
@@ -112,6 +122,11 @@ func discoveredFilename(pathValue, query, format string) string {
 }
 
 func fetchDiscoveryContent(ctx context.Context, client *http.Client, rawURL string, maximum int64) ([]byte, error) {
+	content, _, err := fetchDiscoveryContentWithType(ctx, client, rawURL, maximum, false)
+	return content, err
+}
+
+func fetchDiscoveryContentWithType(ctx context.Context, client *http.Client, rawURL string, maximum int64, requireBinary bool) ([]byte, string, error) {
 	if client == nil {
 		client = &http.Client{}
 	}
@@ -131,27 +146,58 @@ func fetchDiscoveryContent(ctx context.Context, client *http.Client, rawURL stri
 	}
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	response, err := clientCopy.Do(request)
 	if err != nil {
-		return nil, fmt.Errorf("%w: discovery request: %v", ErrUnavailable, err)
+		return nil, "", fmt.Errorf("%w: discovery request: %v", ErrUnavailable, err)
 	}
 	defer response.Body.Close()
 	if response.StatusCode < 200 || response.StatusCode >= 300 {
-		return nil, nil
+		return nil, "", nil
 	}
 	if response.ContentLength > maximum {
-		return nil, errors.New("discovery response exceeds the size limit")
+		return nil, "", errors.New("discovery response exceeds the size limit")
+	}
+	contentType := response.Header.Get("Content-Type")
+	if requireBinary && !directBinaryContentType(contentType) {
+		return nil, contentType, nil
 	}
 	content, err := io.ReadAll(io.LimitReader(response.Body, maximum+1))
 	if err != nil {
-		return nil, err
+		return nil, "", err
 	}
 	if int64(len(content)) > maximum {
-		return nil, errors.New("discovery response exceeds the size limit")
+		return nil, "", errors.New("discovery response exceeds the size limit")
 	}
-	return content, nil
+	return content, contentType, nil
+}
+
+func directBinaryContentType(value string) bool {
+	mediaType, _, err := mime.ParseMediaType(value)
+	if err != nil {
+		return false
+	}
+	switch strings.ToLower(mediaType) {
+	case "application/octet-stream", "application/zip", "application/x-zip-compressed", "application/x-tar", "application/gzip", "application/x-gzip":
+		return true
+	default:
+		return false
+	}
+}
+
+func sniffArchiveFormat(content []byte) string {
+	if len(content) >= 4 && content[0] == 'P' && content[1] == 'K' &&
+		((content[2] == 3 && content[3] == 4) || (content[2] == 5 && content[3] == 6) || (content[2] == 7 && content[3] == 8)) {
+		return "zip"
+	}
+	if len(content) >= 2 && content[0] == 0x1f && content[1] == 0x8b {
+		return "tgz"
+	}
+	if len(content) >= 262 && string(content[257:262]) == "ustar" {
+		return "tar"
+	}
+	return ""
 }
 
 func cssFontFormat(pathValue, declared string) string {

--- a/internal/provider/discovery_test.go
+++ b/internal/provider/discovery_test.go
@@ -24,7 +24,7 @@ func TestResolveDiscoveredArchiveMembers(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(results) != 1 || results[0].ArchiveMember != "Family/Example-Bold.otf" || results[0].Filename != "Example-Bold.otf" {
+	if len(results) != 1 || results[0].ArchiveMember != "Family/Example-Bold.otf" || results[0].Filename != "Example-Bold.otf" || results[0].FamilyGroup == "" || results[0].FamilyGroup == server.URL+"/family.zip" {
 		t.Fatalf("results = %#v", results)
 	}
 }
@@ -39,7 +39,7 @@ func TestResolveDiscoveredStylesheetFonts(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(results) != 1 || results[0].URL != server.URL+"/fonts/Example.woff2" {
+	if len(results) != 1 || results[0].URL != server.URL+"/fonts/Example.woff2" || results[0].FamilyGroup == "" || results[0].FamilyGroup == server.URL+"/css/family.css" {
 		t.Fatalf("results = %#v", results)
 	}
 }
@@ -79,7 +79,7 @@ func TestResolveDiscoveredURLConvertsGitHubBlobToRaw(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(results) != 1 || results[0].URL != "https://raw.githubusercontent.com/acme/fonts/main/Example.otf" {
+	if len(results) != 1 || results[0].URL != "https://raw.githubusercontent.com/acme/fonts/main/Example.otf" || results[0].FamilyGroup != "github.com/acme/fonts" {
 		t.Fatalf("results = %#v", results)
 	}
 }

--- a/internal/provider/discovery_test.go
+++ b/internal/provider/discovery_test.go
@@ -6,8 +6,13 @@ import (
 	"context"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 )
+
+func localDiscoveryContext() context.Context {
+	return context.WithValue(context.Background(), privateDiscoveryContextKey{}, true)
+}
 
 func TestResolveDiscoveredArchiveMembers(t *testing.T) {
 	t.Parallel()
@@ -20,7 +25,7 @@ func TestResolveDiscoveredArchiveMembers(t *testing.T) {
 		response.Write(archive.Bytes())
 	}))
 	defer server.Close()
-	results, err := resolveDiscoveredURL(context.Background(), server.Client(), server.URL+"/family.zip", "Example", map[string]bool{"otf": true})
+	results, err := resolveDiscoveredURL(localDiscoveryContext(), server.Client(), server.URL+"/family.zip", "Example", map[string]bool{"otf": true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -41,7 +46,7 @@ func TestResolveDiscoveredArchiveByContentWhenExtensionIsMissing(t *testing.T) {
 		response.Write(archive.Bytes())
 	}))
 	defer server.Close()
-	results, err := resolveDiscoveredURL(context.Background(), server.Client(), server.URL+"/download?id=family", "Example", map[string]bool{"otf": true})
+	results, err := resolveDiscoveredURL(localDiscoveryContext(), server.Client(), server.URL+"/download?id=family", "Example", map[string]bool{"otf": true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,8 +62,47 @@ func TestResolveDiscoveredURLDoesNotTreatHTMLPageAsDownload(t *testing.T) {
 		response.Write([]byte("<html>PK\\x03\\x04 download</html>"))
 	}))
 	defer server.Close()
-	results, err := resolveDiscoveredURL(context.Background(), server.Client(), server.URL+"/font-page", "Example", map[string]bool{"otf": true})
+	results, err := resolveDiscoveredURL(localDiscoveryContext(), server.Client(), server.URL+"/font-page", "Example", map[string]bool{"otf": true})
 	if err != nil || len(results) != 0 {
+		t.Fatalf("results=%#v err=%v", results, err)
+	}
+}
+
+func TestResolveDiscoveredURLRejectsHTMLWithArchiveSuffix(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		response.Header().Set("Content-Type", "text/html")
+		response.Write([]byte("<html>not an archive</html>"))
+	}))
+	defer server.Close()
+	results, err := resolveDiscoveredURL(localDiscoveryContext(), server.Client(), server.URL+"/font.zip", "Example", map[string]bool{"otf": true})
+	if err != nil || len(results) != 0 {
+		t.Fatalf("results=%#v err=%v", results, err)
+	}
+}
+
+func TestDiscoveryBlocksPrivateNetworkDestinations(t *testing.T) {
+	t.Parallel()
+	results, err := resolveDiscoveredURL(context.Background(), http.DefaultClient, "https://127.0.0.1/font-download", "Example", map[string]bool{"otf": true})
+	if err == nil || len(results) != 0 || !strings.Contains(err.Error(), "non-public address") {
+		t.Fatalf("results=%#v err=%v", results, err)
+	}
+}
+
+func TestResolveDiscoveredArchiveAcceptsNonstandardDownloadContentType(t *testing.T) {
+	t.Parallel()
+	var archive bytes.Buffer
+	writer := zip.NewWriter(&archive)
+	font, _ := writer.Create("Example-Regular.otf")
+	font.Write([]byte("OTTOfont"))
+	writer.Close()
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		response.Header().Set("Content-Type", "application/force-download")
+		response.Write(archive.Bytes())
+	}))
+	defer server.Close()
+	results, err := resolveDiscoveredURL(localDiscoveryContext(), server.Client(), server.URL+"/download", "Example", map[string]bool{"otf": true})
+	if err != nil || len(results) != 1 || results[0].ArchiveFormat != "zip" {
 		t.Fatalf("results=%#v err=%v", results, err)
 	}
 }
@@ -91,7 +135,7 @@ func TestResolveDiscoveredStylesheetFonts(t *testing.T) {
 		response.Write([]byte(`@font-face { src: url("../fonts/Example.woff2") format("woff2"); }`))
 	}))
 	defer server.Close()
-	results, err := resolveDiscoveredURL(context.Background(), server.Client(), server.URL+"/css/family.css", "Example", map[string]bool{"woff2": true})
+	results, err := resolveDiscoveredURL(localDiscoveryContext(), server.Client(), server.URL+"/css/family.css", "Example", map[string]bool{"woff2": true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -106,7 +150,7 @@ func TestResolveDiscoveredStylesheetUsesDeclaredFormatWithoutExtension(t *testin
 		response.Write([]byte(`@font-face { src: url("/font?id=example") format("woff2"); }`))
 	}))
 	defer server.Close()
-	results, err := resolveDiscoveredURL(context.Background(), server.Client(), server.URL+"/family.css", "Example", map[string]bool{"woff2": true})
+	results, err := resolveDiscoveredURL(localDiscoveryContext(), server.Client(), server.URL+"/family.css", "Example", map[string]bool{"woff2": true})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -125,7 +169,7 @@ func TestDiscoveryRejectsInsecureRedirect(t *testing.T) {
 		http.Redirect(response, request, insecure.URL+"/Example.woff2", http.StatusFound)
 	}))
 	defer secure.Close()
-	if _, err := fetchDiscoveryContent(context.Background(), secure.Client(), secure.URL+"/family.css", 1024); err == nil {
+	if _, err := fetchDiscoveryContent(localDiscoveryContext(), secure.Client(), secure.URL+"/family.css", 1024); err == nil {
 		t.Fatal("expected insecure redirect rejection")
 	}
 }

--- a/internal/provider/discovery_test.go
+++ b/internal/provider/discovery_test.go
@@ -29,6 +29,62 @@ func TestResolveDiscoveredArchiveMembers(t *testing.T) {
 	}
 }
 
+func TestResolveDiscoveredArchiveByContentWhenExtensionIsMissing(t *testing.T) {
+	t.Parallel()
+	var archive bytes.Buffer
+	writer := zip.NewWriter(&archive)
+	font, _ := writer.Create("Family/Example-Regular.otf")
+	font.Write([]byte("OTTOfont"))
+	writer.Close()
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		response.Header().Set("Content-Type", "application/octet-stream")
+		response.Write(archive.Bytes())
+	}))
+	defer server.Close()
+	results, err := resolveDiscoveredURL(context.Background(), server.Client(), server.URL+"/download?id=family", "Example", map[string]bool{"otf": true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(results) != 1 || results[0].ArchiveFormat != "zip" || results[0].ArchiveMember != "Family/Example-Regular.otf" {
+		t.Fatalf("results = %#v", results)
+	}
+}
+
+func TestResolveDiscoveredURLDoesNotTreatHTMLPageAsDownload(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		response.Header().Set("Content-Type", "text/html")
+		response.Write([]byte("<html>PK\\x03\\x04 download</html>"))
+	}))
+	defer server.Close()
+	results, err := resolveDiscoveredURL(context.Background(), server.Client(), server.URL+"/font-page", "Example", map[string]bool{"otf": true})
+	if err != nil || len(results) != 0 {
+		t.Fatalf("results=%#v err=%v", results, err)
+	}
+}
+
+func TestSniffArchiveFormatRecognizesSupportedSignatures(t *testing.T) {
+	t.Parallel()
+	tarContent := make([]byte, 262)
+	copy(tarContent[257:], "ustar")
+	for name, test := range map[string]struct {
+		content []byte
+		want    string
+	}{
+		"zip":  {content: []byte{'P', 'K', 3, 4}, want: "zip"},
+		"tgz":  {content: []byte{0x1f, 0x8b, 8, 0}, want: "tgz"},
+		"tar":  {content: tarContent, want: "tar"},
+		"html": {content: []byte("<html>"), want: ""},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := sniffArchiveFormat(test.content); got != test.want {
+				t.Fatalf("sniffArchiveFormat() = %q, want %q", got, test.want)
+			}
+		})
+	}
+}
+
 func TestResolveDiscoveredStylesheetFonts(t *testing.T) {
 	t.Parallel()
 	server := httptest.NewTLSServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {

--- a/internal/provider/github.go
+++ b/internal/provider/github.go
@@ -169,6 +169,7 @@ func (source GitHub) searchRepositories(ctx context.Context, client *http.Client
 				}
 				for _, result := range results {
 					result.Source = "github.com/" + repository.FullName
+					result.FamilyGroup = result.Source
 					if result.SizeBytes == 0 && result.ArchiveMember == "" {
 						result.SizeBytes = asset.Size
 					}

--- a/internal/provider/github_test.go
+++ b/internal/provider/github_test.go
@@ -287,7 +287,7 @@ func TestWebSearchPreservesEveryArchiveMember(t *testing.T) {
 	defer server.Close()
 
 	out := make(chan Event, 12)
-	if err := (WebSearch{Client: server.Client(), Instance: server.URL}).Search(context.Background(), "Example", []string{"otf"}, out); err != nil {
+	if err := (WebSearch{Client: server.Client(), Instance: server.URL}).Search(localDiscoveryContext(), "Example", []string{"otf"}, out); err != nil {
 		t.Fatal(err)
 	}
 	close(out)

--- a/internal/provider/github_test.go
+++ b/internal/provider/github_test.go
@@ -255,8 +255,8 @@ func TestWebSearchOnlyReturnsDirectFontLinks(t *testing.T) {
 	if len(out) != 1 || (<-out).Result.Filename != "Example.woff2" {
 		t.Fatal("direct font result was not extracted")
 	}
-	if requests.Load() != 6 {
-		t.Fatalf("requests = %d, want 6", requests.Load())
+	if requests.Load() != 9 {
+		t.Fatalf("requests = %d, want 9", requests.Load())
 	}
 }
 
@@ -306,6 +306,9 @@ func TestWebSearchQueriesCoverDorkVariants(t *testing.T) {
 		`"Proxima Nova" "index of" .otf OR .ttf OR .dfont OR .zip OR .tar.gz`,
 		`intitle:"Proxima Nova" github`,
 		`"Proxima Nova" "@font-face" filetype:css`,
+		`("Proxima Nova.ttf" OR "Proxima Nova.otf") (site:onlinewebfonts.com OR site:wfonts.com OR site:befonts.com OR site:cufonfonts.com)`,
+		`("Proxima Nova.ttf" OR "Proxima Nova.otf") (site:freefontsfamily.org OR site:fontsfree.net OR site:dfonts.org OR site:font.download)`,
+		`("Proxima Nova.ttf" OR "Proxima Nova.otf") (site:ffonts.net OR site:dafontfree.co OR site:fontshub.pro OR site:fontbolt.com)`,
 	}
 	if len(queries) != len(want) {
 		t.Fatalf("queries = %#v", queries)

--- a/internal/provider/kagi.go
+++ b/internal/provider/kagi.go
@@ -22,7 +22,8 @@ func (source KagiCLI) Search(ctx context.Context, query string, formats []string
 	if executable == "" {
 		executable = "kagi"
 	}
-	command := exec.CommandContext(ctx, executable, "search", "--format", "json", "--error-format", "json", "--limit", "20", query+" font "+strings.Join(kagiQueryFormats(formats), " ")+" zip css")
+	searchQuery := "(" + query + " font " + strings.Join(kagiQueryFormats(formats), " ") + " zip css) OR (" + strings.Join(fontIndexQueries(query), " OR ") + ")"
+	command := exec.CommandContext(ctx, executable, "search", "--format", "json", "--error-format", "json", "--limit", "20", searchQuery)
 	content, err := command.Output()
 	if err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {

--- a/internal/provider/kagi_test.go
+++ b/internal/provider/kagi_test.go
@@ -15,7 +15,7 @@ func TestWebSearchUsesInstalledKagiBackend(t *testing.T) {
 	executable := filepath.Join(t.TempDir(), "kagi")
 	script := `#!/bin/sh
 case "$*" in
-  *"search --format json --error-format json --limit 20 Basier Narrow font otf zip css"*)
+  *"search --format json --error-format json --limit 20 (Basier Narrow font otf zip css) OR"*)
     printf '%s' '{"data":[{"url":"https://github.com/example/fonts/blob/main/BasierNarrow-Regular.otf","title":"Basier Narrow font"},{"url":"https://example.test/fonts/basier-narrow","title":"web page"}]}'
     ;;
   *) exit 2 ;;

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -67,6 +67,7 @@ type Result struct {
 	Variable      bool    `json:"variable,omitempty" yaml:"variable,omitempty"`
 	ArchiveFormat string  `json:"archive_format,omitempty" yaml:"archive_format,omitempty"`
 	ArchiveMember string  `json:"archive_member,omitempty" yaml:"archive_member,omitempty"`
+	FamilyGroup   string  `json:"-" yaml:"-"`
 	Score         float64 `json:"score,omitempty" yaml:"score,omitempty"`
 }
 

--- a/internal/provider/websearch.go
+++ b/internal/provider/websearch.go
@@ -154,6 +154,26 @@ func webSearchQueries(query string, formats []string) []string {
 		"intitle:"+quoted+" github",
 		quoted+" \"@font-face\" filetype:css",
 	)
+	queries = append(queries, fontIndexQueries(query)...)
+	return queries
+}
+
+var fontIndexSiteGroups = [][]string{
+	{"onlinewebfonts.com", "wfonts.com", "befonts.com", "cufonfonts.com"},
+	{"freefontsfamily.org", "fontsfree.net", "dfonts.org", "font.download"},
+	{"ffonts.net", "dafontfree.co", "fontshub.pro", "fontbolt.com"},
+}
+
+func fontIndexQueries(query string) []string {
+	filename := fmt.Sprintf("(%q OR %q)", query+".ttf", query+".otf")
+	queries := make([]string, 0, len(fontIndexSiteGroups))
+	for _, sites := range fontIndexSiteGroups {
+		clauses := make([]string, 0, len(sites))
+		for _, site := range sites {
+			clauses = append(clauses, "site:"+site)
+		}
+		queries = append(queries, filename+" ("+strings.Join(clauses, " OR ")+")")
+	}
 	return queries
 }
 

--- a/internal/rank/rank.go
+++ b/internal/rank/rank.go
@@ -473,20 +473,13 @@ func familyGroupOf(result provider.Result) string {
 }
 
 func SelectFamily(results []provider.Result, maximum int) []provider.Result {
-	if len(results) == 0 {
+	groups := Groups(results)
+	if len(groups) == 0 || maximum <= 0 {
 		return nil
 	}
-	best := results[0]
-	bestFamily := ParseFilename(best.Filename).Family
-	bestGroup := familyGroupOf(best)
-	selected := make([]provider.Result, 0, maximum)
-	for _, result := range results {
-		if familyGroupOf(result) == bestGroup && ParseFilename(result.Filename).Family == bestFamily {
-			selected = append(selected, result)
-			if len(selected) == maximum {
-				break
-			}
-		}
+	selected := groups[0].Files
+	if len(selected) > maximum {
+		selected = selected[:maximum]
 	}
 	return selected
 }

--- a/internal/rank/rank.go
+++ b/internal/rank/rank.go
@@ -400,30 +400,69 @@ type ResultGroup struct {
 	Formats    []string
 	BestFormat string
 	FileCount  int
+	familyRank int
+	styles     []string
+	variable   bool
 }
 
 func Groups(results []provider.Result) []ResultGroup {
 	indices := make(map[string]int)
+	familyRanks := make(map[string]int)
 	groups := make([]ResultGroup, 0)
 	for _, result := range results {
 		tags := ParseFilename(result.Filename)
 		key := tags.Family + "\x00" + familyGroupOf(result)
 		index, exists := indices[key]
 		if !exists {
+			familyRank, ranked := familyRanks[tags.Family]
+			if !ranked {
+				familyRank = len(familyRanks)
+				familyRanks[tags.Family] = familyRank
+			}
 			index = len(groups)
 			indices[key] = index
-			groups = append(groups, ResultGroup{FamilyName: tags.Family, Source: result.Source})
+			groups = append(groups, ResultGroup{FamilyName: tags.Family, Source: result.Source, familyRank: familyRank})
 		}
 		group := &groups[index]
 		group.Files = append(group.Files, result)
 		group.FileCount++
 		group.Weights = appendUnique(group.Weights, result.Weight)
 		group.Formats = appendUnique(group.Formats, result.Format)
+		style := result.Weight
+		if style == "" {
+			style = tags.Weight
+		}
+		if tags.Italic {
+			style += ":italic"
+		}
+		group.styles = appendUnique(group.styles, style)
+		group.variable = group.variable || result.Variable || tags.Variable
 		if formatValue(result.Format) > formatValue(group.BestFormat) {
 			group.BestFormat = result.Format
 		}
 	}
+	sort.SliceStable(groups, func(i, j int) bool {
+		if groups[i].familyRank != groups[j].familyRank {
+			return groups[i].familyRank < groups[j].familyRank
+		}
+		leftCoverage, rightCoverage := familyCoverage(groups[i]), familyCoverage(groups[j])
+		if leftCoverage != rightCoverage {
+			return leftCoverage > rightCoverage
+		}
+		if groups[i].FileCount != groups[j].FileCount {
+			return groups[i].FileCount > groups[j].FileCount
+		}
+		return groups[i].Files[0].Score > groups[j].Files[0].Score
+	})
 	return groups
+}
+
+func familyCoverage(group ResultGroup) int {
+	coverage := len(group.styles)
+	if group.variable && coverage < 2 {
+		return 2
+	}
+	return coverage
 }
 
 func familyGroupOf(result provider.Result) string {

--- a/internal/rank/rank.go
+++ b/internal/rank/rank.go
@@ -2,6 +2,7 @@ package rank
 
 import (
 	"math"
+	"net/url"
 	"path/filepath"
 	"regexp"
 	"sort"
@@ -191,7 +192,7 @@ func Results(results []provider.Result, query, wantedWeight string, weights Weig
 		if tags.Variable {
 			ranked[i].Variable = true
 		}
-		key := tags.Family + "\x00" + ranked[i].Source
+		key := tags.Family + "\x00" + familyGroupOf(ranked[i])
 		if familySizes[key] == nil {
 			familySizes[key] = make(map[string]struct{})
 		}
@@ -203,7 +204,7 @@ func Results(results []provider.Result, query, wantedWeight string, weights Weig
 		tags := ParseFilename(ranked[i].Filename)
 		formatRank := map[string]float64{"otf": 3, "ttf": 2, "dfont": 1.5, "pfb": 1, "woff2": 0.75, "woff": 0.5, "pfm": 0.1}[ranked[i].Format]
 		score := weights.Format * formatRank
-		score += weights.FamilySize * math.Log2(1+float64(len(familySizes[tags.Family+"\x00"+ranked[i].Source])))
+		score += weights.FamilySize * math.Log2(1+float64(len(familySizes[tags.Family+"\x00"+familyGroupOf(ranked[i])])))
 		if ranked[i].Trusted {
 			score += weights.Trusted
 		}
@@ -227,6 +228,11 @@ func Results(results []provider.Result, query, wantedWeight string, weights Weig
 		if ranked[i].Score != ranked[j].Score {
 			return ranked[i].Score > ranked[j].Score
 		}
+		leftReliability := sourceReliability(ranked[i])
+		rightReliability := sourceReliability(ranked[j])
+		if leftReliability != rightReliability {
+			return leftReliability > rightReliability
+		}
 		if ranked[i].Filename != ranked[j].Filename {
 			return ranked[i].Filename < ranked[j].Filename
 		}
@@ -236,6 +242,33 @@ func Results(results []provider.Result, query, wantedWeight string, weights Weig
 		return ranked[i].URL < ranked[j].URL
 	})
 	return ranked
+}
+
+// sourceReliability describes how consistently a source identifies a direct
+// font file. It is deliberately independent from trust and license metadata:
+// a reliable direct URL is not evidence that its contents are licensed or
+// safe. Results uses this only after relevance and quality are tied.
+func sourceReliability(result provider.Result) int {
+	source := strings.ToLower(result.Source)
+	switch {
+	case source == "fontsource.org", source == "fonts.google.com":
+		return 4
+	case isRawGitHubURL(result.URL):
+		return 3
+	case strings.HasPrefix(source, "getfonts.cc/") || source == "getfonts.cc":
+		return 2
+	default:
+		return 1
+	}
+}
+
+func isRawGitHubURL(value string) bool {
+	parsed, err := url.Parse(value)
+	if err != nil {
+		return false
+	}
+	host := strings.ToLower(parsed.Hostname())
+	return host == "raw.githubusercontent.com" || host == "github.com" && strings.Contains(parsed.Path, "/raw/")
 }
 
 func Relevance(result provider.Result, query string) int {
@@ -374,7 +407,7 @@ func Groups(results []provider.Result) []ResultGroup {
 	groups := make([]ResultGroup, 0)
 	for _, result := range results {
 		tags := ParseFilename(result.Filename)
-		key := tags.Family + "\x00" + result.Source
+		key := tags.Family + "\x00" + familyGroupOf(result)
 		index, exists := indices[key]
 		if !exists {
 			index = len(groups)
@@ -393,15 +426,23 @@ func Groups(results []provider.Result) []ResultGroup {
 	return groups
 }
 
+func familyGroupOf(result provider.Result) string {
+	if result.FamilyGroup != "" {
+		return result.FamilyGroup
+	}
+	return result.Source
+}
+
 func SelectFamily(results []provider.Result, maximum int) []provider.Result {
 	if len(results) == 0 {
 		return nil
 	}
 	best := results[0]
 	bestFamily := ParseFilename(best.Filename).Family
+	bestGroup := familyGroupOf(best)
 	selected := make([]provider.Result, 0, maximum)
 	for _, result := range results {
-		if result.Source == best.Source && ParseFilename(result.Filename).Family == bestFamily {
+		if familyGroupOf(result) == bestGroup && ParseFilename(result.Filename).Family == bestFamily {
 			selected = append(selected, result)
 			if len(selected) == maximum {
 				break

--- a/internal/rank/rank_test.go
+++ b/internal/rank/rank_test.go
@@ -266,6 +266,10 @@ func TestGroupsPreferBroaderFamilyCoverageOverSingletonFormat(t *testing.T) {
 	if len(groups) != 2 || groups[0].Source != "family" {
 		t.Fatalf("groups = %#v, want broader family first", groups)
 	}
+	selected := SelectFamily(results, 10)
+	if len(selected) != 2 || selected[0].Source != "family" || selected[1].Source != "family" {
+		t.Fatalf("selected = %#v, want the same broader family used by downloads", selected)
+	}
 }
 
 func TestGroupsTreatVariableFontAsCompleteFamily(t *testing.T) {

--- a/internal/rank/rank_test.go
+++ b/internal/rank/rank_test.go
@@ -254,3 +254,28 @@ func TestGroupsDoNotMixSameHostResultsFromDifferentRepositories(t *testing.T) {
 		t.Fatalf("selected = %#v, want one repository only", selected)
 	}
 }
+
+func TestGroupsPreferBroaderFamilyCoverageOverSingletonFormat(t *testing.T) {
+	t.Parallel()
+	results := []provider.Result{
+		{Filename: "Example-Regular.otf", Format: "otf", Source: "singleton", Score: 13},
+		{Filename: "Example-Regular.ttf", Format: "ttf", Source: "family", Score: 12},
+		{Filename: "Example-Bold.ttf", Format: "ttf", Source: "family", Score: 11},
+	}
+	groups := Groups(results)
+	if len(groups) != 2 || groups[0].Source != "family" {
+		t.Fatalf("groups = %#v, want broader family first", groups)
+	}
+}
+
+func TestGroupsTreatVariableFontAsCompleteFamily(t *testing.T) {
+	t.Parallel()
+	results := []provider.Result{
+		{Filename: "Example-Regular.otf", Source: "static", Score: 20},
+		{Filename: "Example[wght].ttf", Source: "variable", Variable: true, Score: 10},
+	}
+	groups := Groups(results)
+	if groups[0].Source != "variable" {
+		t.Fatalf("groups = %#v, want variable family first", groups)
+	}
+}

--- a/internal/rank/rank_test.go
+++ b/internal/rank/rank_test.go
@@ -96,6 +96,59 @@ func TestRankPrefersRelevantFamilyOverQuality(t *testing.T) {
 	}
 }
 
+func TestRankUsesSourceReliabilityOnlyAsQualityTieBreaker(t *testing.T) {
+	t.Parallel()
+
+	results := []provider.Result{
+		{Filename: "Example-Regular.otf", Format: "otf", Source: "downloads.example.com", URL: "https://downloads.example.com/Example-Regular.otf"},
+		{Filename: "Example-Regular.otf", Format: "otf", Source: "getfonts.cc/example", URL: "https://getfonts.cc/example/Example-Regular.otf"},
+		{Filename: "Example-Regular.otf", Format: "otf", Source: "github.com/example/fonts", URL: "https://raw.githubusercontent.com/example/fonts/main/Example-Regular.otf"},
+		{Filename: "Example-Regular.otf", Format: "otf", Source: "fontsource.org", URL: "https://cdn.jsdelivr.net/fontsource/example/Example-Regular.otf"},
+	}
+
+	ranked := Results(results, "Example", "", DefaultWeights())
+	want := []string{"fontsource.org", "github.com/example/fonts", "getfonts.cc/example", "downloads.example.com"}
+	for index, source := range want {
+		if ranked[index].Source != source {
+			t.Fatalf("ranked[%d].Source = %q, want %q; ranked=%#v", index, ranked[index].Source, source, ranked)
+		}
+	}
+}
+
+func TestRankSourceReliabilityDoesNotOverrideRelevance(t *testing.T) {
+	t.Parallel()
+	results := []provider.Result{
+		{Filename: "Example-Sans-Regular.woff", Format: "woff", Source: "downloads.example.com"},
+		{Filename: "Example-Regular.otf", Format: "otf", Source: "fontsource.org"},
+	}
+
+	if got := Results(results, "Example Sans", "", DefaultWeights())[0].Source; got != "downloads.example.com" {
+		t.Fatalf("best source = %q, want more relevant arbitrary host", got)
+	}
+}
+
+func TestRankSourceReliabilityDoesNotOverrideFamilyCompleteness(t *testing.T) {
+	t.Parallel()
+	results := []provider.Result{
+		{Filename: "Example-Regular.otf", Format: "otf", Weight: "regular", Source: "downloads.example.com"},
+		{Filename: "Example-Bold.otf", Format: "otf", Weight: "bold", Source: "downloads.example.com"},
+		{Filename: "Example-Regular.otf", Format: "otf", Weight: "regular", Source: "fontsource.org"},
+	}
+
+	if got := Results(results, "Example", "", DefaultWeights())[0].Source; got != "downloads.example.com" {
+		t.Fatalf("best source = %q, want source with complete family", got)
+	}
+}
+
+func TestSourceReliabilityIsIndependentFromTrustAndLicense(t *testing.T) {
+	t.Parallel()
+	structured := provider.Result{Source: "fonts.google.com", Trusted: false, License: ""}
+	arbitrary := provider.Result{Source: "downloads.example.com", Trusted: true, License: "OFL-1.1"}
+	if sourceReliability(structured) <= sourceReliability(arbitrary) {
+		t.Fatalf("structured reliability must not derive from Trusted or License")
+	}
+}
+
 func TestRankKeepsOneCharacterSearchCorrection(t *testing.T) {
 	t.Parallel()
 	results := []provider.Result{{Filename: "Bariol Serif.ttf", Source: "search"}}
@@ -184,5 +237,20 @@ func TestGroupsAndFamilySelectionStayWithinBestSource(t *testing.T) {
 	selected := SelectFamily(results, 10)
 	if len(selected) != 2 || selected[1].Source != "best" {
 		t.Fatalf("selected = %#v", selected)
+	}
+}
+
+func TestGroupsDoNotMixSameHostResultsFromDifferentRepositories(t *testing.T) {
+	t.Parallel()
+	results := []provider.Result{
+		{Filename: "Example-Regular.otf", Source: "raw.githubusercontent.com", FamilyGroup: "github.com/one/fonts"},
+		{Filename: "Example-Bold.otf", Source: "raw.githubusercontent.com", FamilyGroup: "github.com/two/fonts"},
+	}
+	groups := Groups(results)
+	if len(groups) != 2 {
+		t.Fatalf("groups = %#v, want separate repository groups", groups)
+	}
+	if selected := SelectFamily(results, 10); len(selected) != 1 {
+		t.Fatalf("selected = %#v, want one repository only", selected)
 	}
 }

--- a/internal/safehttp/client.go
+++ b/internal/safehttp/client.go
@@ -22,6 +22,7 @@ var specialUsePrefixes = []netip.Prefix{
 	netip.MustParsePrefix("64:ff9b:1::/48"),
 	netip.MustParsePrefix("100::/64"),
 	netip.MustParsePrefix("2001::/23"),
+	netip.MustParsePrefix("2001:db8::/32"),
 	netip.MustParsePrefix("2002::/16"),
 	netip.MustParsePrefix("3fff::/20"),
 	netip.MustParsePrefix("fec0::/10"),

--- a/internal/safehttp/client.go
+++ b/internal/safehttp/client.go
@@ -1,0 +1,99 @@
+package safehttp
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"net/netip"
+)
+
+var specialUsePrefixes = []netip.Prefix{
+	netip.MustParsePrefix("0.0.0.0/8"),
+	netip.MustParsePrefix("100.64.0.0/10"),
+	netip.MustParsePrefix("192.0.0.0/24"),
+	netip.MustParsePrefix("192.0.2.0/24"),
+	netip.MustParsePrefix("192.88.99.0/24"),
+	netip.MustParsePrefix("198.18.0.0/15"),
+	netip.MustParsePrefix("198.51.100.0/24"),
+	netip.MustParsePrefix("203.0.113.0/24"),
+	netip.MustParsePrefix("240.0.0.0/4"),
+	netip.MustParsePrefix("64:ff9b::/96"),
+	netip.MustParsePrefix("64:ff9b:1::/48"),
+	netip.MustParsePrefix("100::/64"),
+	netip.MustParsePrefix("2001::/23"),
+	netip.MustParsePrefix("2002::/16"),
+	netip.MustParsePrefix("3fff::/20"),
+	netip.MustParsePrefix("fec0::/10"),
+}
+
+// Constrain clones client and pins every connection to a DNS address that was
+// checked as public. Custom TLS dial hooks are cleared because they otherwise
+// bypass DialContext for HTTPS requests.
+func Constrain(client *http.Client, allowPrivate bool) http.Client {
+	if client == nil {
+		client = &http.Client{}
+	}
+	clone := *client
+	if allowPrivate {
+		return clone
+	}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	if configured, ok := client.Transport.(*http.Transport); ok {
+		transport = configured.Clone()
+	}
+	transport.Proxy = nil
+	transport.DialContext = dialPublicAddress
+	transport.DialTLSContext = nil
+	transport.DialTLS = nil
+	clone.Transport = transport
+	return clone
+}
+
+func dialPublicAddress(ctx context.Context, network, address string) (net.Conn, error) {
+	host, port, err := net.SplitHostPort(address)
+	if err != nil {
+		return nil, err
+	}
+	addresses, err := net.DefaultResolver.LookupIPAddr(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+	if len(addresses) == 0 {
+		return nil, fmt.Errorf("%s resolved to no addresses", host)
+	}
+	for _, address := range addresses {
+		if !publicIP(address.IP) {
+			return nil, fmt.Errorf("blocked non-public address for %s", host)
+		}
+	}
+	dialer := &net.Dialer{}
+	var firstError error
+	for _, address := range addresses {
+		connection, dialErr := dialer.DialContext(ctx, network, net.JoinHostPort(address.IP.String(), port))
+		if dialErr == nil {
+			return connection, nil
+		}
+		if firstError == nil {
+			firstError = dialErr
+		}
+	}
+	return nil, firstError
+}
+
+func publicIP(address net.IP) bool {
+	parsed, ok := netip.AddrFromSlice(address)
+	if !ok {
+		return false
+	}
+	parsed = parsed.Unmap()
+	if !parsed.IsGlobalUnicast() || parsed.IsPrivate() || parsed.IsLoopback() || parsed.IsLinkLocalUnicast() || parsed.IsMulticast() {
+		return false
+	}
+	for _, prefix := range specialUsePrefixes {
+		if prefix.Contains(parsed) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/safehttp/client_test.go
+++ b/internal/safehttp/client_test.go
@@ -25,7 +25,7 @@ func TestPublicIPRejectsSpecialUseNetworks(t *testing.T) {
 	t.Parallel()
 	for _, address := range []string{
 		"100.64.0.1", "192.0.2.1", "198.18.0.1", "198.51.100.1", "203.0.113.1", "240.0.0.1",
-		"64:ff9b::1", "64:ff9b:1::1", "100::1", "2001::1", "2002::1", "3fff::1", "fec0::1",
+		"64:ff9b::1", "64:ff9b:1::1", "100::1", "2001::1", "2001:db8::1", "2002::1", "3fff::1", "fec0::1",
 	} {
 		if publicIP(net.ParseIP(address)) {
 			t.Errorf("special-use address %s was treated as public", address)

--- a/internal/safehttp/client_test.go
+++ b/internal/safehttp/client_test.go
@@ -1,0 +1,77 @@
+package safehttp
+
+import (
+	"context"
+	"crypto/tls"
+	"net"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+func TestConstrainedTransportBlocksPrivateDestinations(t *testing.T) {
+	t.Parallel()
+	client := Constrain(nil, false)
+	transport := client.Transport.(*http.Transport)
+	for _, destination := range []string{"127.0.0.1:443", "localhost:443"} {
+		_, err := transport.DialContext(context.Background(), "tcp", destination)
+		if err == nil || !strings.Contains(err.Error(), "non-public address") {
+			t.Fatalf("destination=%s err=%v", destination, err)
+		}
+	}
+}
+
+func TestPublicIPRejectsSpecialUseNetworks(t *testing.T) {
+	t.Parallel()
+	for _, address := range []string{
+		"100.64.0.1", "192.0.2.1", "198.18.0.1", "198.51.100.1", "203.0.113.1", "240.0.0.1",
+		"64:ff9b::1", "64:ff9b:1::1", "100::1", "2001::1", "2002::1", "3fff::1", "fec0::1",
+	} {
+		if publicIP(net.ParseIP(address)) {
+			t.Errorf("special-use address %s was treated as public", address)
+		}
+	}
+}
+
+func TestPublicIPAcceptsGloballyReachableAddresses(t *testing.T) {
+	t.Parallel()
+	for _, address := range []string{"1.1.1.1", "8.8.8.8", "2606:4700:4700::1111", "2001:4860:4860::8888"} {
+		if !publicIP(net.ParseIP(address)) {
+			t.Errorf("globally reachable address %s was rejected", address)
+		}
+	}
+}
+
+func TestConstrainedTransportClearsCustomTLSDialers(t *testing.T) {
+	t.Parallel()
+	called := false
+	configured := http.DefaultTransport.(*http.Transport).Clone()
+	configured.DialTLSContext = func(context.Context, string, string) (net.Conn, error) {
+		called = true
+		return nil, nil
+	}
+	configured.DialTLS = func(string, string) (net.Conn, error) {
+		called = true
+		return nil, nil
+	}
+	client := Constrain(&http.Client{Transport: configured}, false)
+	transport := client.Transport.(*http.Transport)
+	if transport.DialTLSContext != nil || transport.DialTLS != nil {
+		t.Fatal("custom TLS dialer survived the public-address constraint")
+	}
+	_, err := transport.DialContext(context.Background(), "tcp", "127.0.0.1:443")
+	if err == nil || called {
+		t.Fatalf("err=%v custom TLS dialer called=%t", err, called)
+	}
+}
+
+func TestConstrainKeepsTLSConfiguration(t *testing.T) {
+	t.Parallel()
+	configured := http.DefaultTransport.(*http.Transport).Clone()
+	configured.TLSClientConfig = &tls.Config{ServerName: "fonts.example"}
+	client := Constrain(&http.Client{Transport: configured}, false)
+	transport := client.Transport.(*http.Transport)
+	if transport.TLSClientConfig == configured.TLSClientConfig || transport.TLSClientConfig.ServerName != "fonts.example" {
+		t.Fatal("TLS configuration was not safely cloned")
+	}
+}

--- a/package.json
+++ b/package.json
@@ -34,6 +34,10 @@
     "docs:check": "npm run check --workspace @microck/moji-docs",
     "docs:dev": "npm run dev --workspace @microck/moji-docs",
     "prepack": "npm run build:binaries",
+    "release": "tsx scripts/release.ts --verify",
+    "release:publish": "tsx scripts/release.ts --publish",
+    "test:release": "node --import tsx --test scripts/release.test.ts",
+    "corpus:verify": "tsx scripts/font-corpus.ts",
     "verify": "go vet ./cmd/... ./internal/... ./e2e/... && go test ./cmd/... ./internal/... ./e2e/... && npm run docs:check && npm run docs:build"
   },
   "devDependencies": {

--- a/scripts/build-binaries.ts
+++ b/scripts/build-binaries.ts
@@ -12,7 +12,12 @@ const targets = [
 ] as const;
 
 const packageManifest = JSON.parse(await readFile('package.json', 'utf8')) as { version: string };
-const linkFlags = `-s -w -X github.com/microck/moji/internal/app.Version=${packageManifest.version}`;
+const linkFlags = [
+  '-s',
+  '-w',
+  `-X github.com/microck/moji/internal/app.Version=${packageManifest.version}`,
+  `-X github.com/microck/moji/internal/app.ReleaseMarker=moji-release-version:${packageManifest.version}:moji-marker-end`,
+].join(' ');
 
 async function build(platform: string, nodeArchitecture: string, goArchitecture: string) {
   const directory = resolve('binaries', `${platform}-${nodeArchitecture}`);

--- a/scripts/font-corpus.ts
+++ b/scripts/font-corpus.ts
@@ -1,0 +1,158 @@
+import { createHash } from 'node:crypto';
+import { mkdir, mkdtemp, readFile, rm, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { basename, join, resolve } from 'node:path';
+import { spawn } from 'node:child_process';
+
+const fonts = [
+  'Gotham',
+  'Helvetica Neue',
+  'Avenir',
+  'Futura',
+  'Brandon Grotesque',
+  'Proxima Nova',
+  'Univers',
+  'FF DIN',
+  'Knockout',
+  'Garamond Premier Pro',
+  'Whitney',
+  'Didot',
+  'Neutraface',
+  'Trade Gothic',
+  'Archer',
+  'Akzidenz-Grotesk',
+  'Frutiger',
+  'Graphik',
+  'Minion Pro',
+  'Mrs. Eaves',
+  'Belarius Serif Narrow Regular',
+] as const;
+
+const expectedMisses = new Set(['Archer', 'Belarius Serif Narrow Regular']);
+
+type CommandResult = { code: number; stdout: string; stderr: string };
+type DownloadFile = { Path: string; SHA256: string; Existing: boolean };
+
+function run(command: string, args: readonly string[], environment: NodeJS.ProcessEnv): Promise<CommandResult> {
+  return new Promise((resolveRun, rejectRun) => {
+    const child = spawn(command, args, { env: environment, stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk: Buffer) => (stdout += chunk.toString()));
+    child.stderr.on('data', (chunk: Buffer) => (stderr += chunk.toString()));
+    child.once('error', rejectRun);
+    child.once('exit', (code) => resolveRun({ code: code ?? 1, stdout, stderr }));
+  });
+}
+
+function signature(content: Buffer): string | null {
+  const magic = content.subarray(0, 4).toString('hex');
+  if (magic === '4f54544f') return 'otf';
+  if (magic === '00010000') return 'ttf';
+  if (magic === '774f4646') return 'woff';
+  if (magic === '774f4632') return 'woff2';
+  return null;
+}
+
+async function invalidURLCount(cacheRoot: string): Promise<number> {
+  try {
+    const content = JSON.parse(await readFile(join(cacheRoot, 'moji', 'url-health.json'), 'utf8')) as {
+      invalid?: Record<string, unknown>;
+    };
+    return Object.keys(content.invalid ?? {}).length;
+  } catch {
+    return 0;
+  }
+}
+
+async function main(): Promise<void> {
+	const argumentsList = process.argv.slice(2);
+	const binaryArgument = argumentsList[0]?.startsWith('--') ? undefined : argumentsList.shift();
+	const outputIndex = argumentsList.indexOf('--output-dir');
+	const outputDirectory = outputIndex >= 0 ? argumentsList[outputIndex + 1] : undefined;
+	if (outputIndex >= 0 && !outputDirectory) throw new Error('--output-dir requires a path');
+	const unknown = argumentsList.filter((argument, index) => index !== outputIndex && index !== outputIndex + 1);
+	if (unknown.length > 0) throw new Error(`unknown corpus argument: ${unknown.join(', ')}`);
+  const binary = resolve(binaryArgument ?? join('binaries', `${process.platform}-${process.arch}`, process.platform === 'win32' ? 'moji.exe' : 'moji'));
+  const root = await mkdtemp(join(tmpdir(), 'moji-font-corpus-'));
+	try {
+  const cacheRoot = join(root, 'cache');
+  const environment = {
+    ...process.env,
+    GITHUB_TOKEN: '',
+    MOJI_CONFIG: join(root, 'missing-config.yaml'),
+    XDG_CACHE_HOME: cacheRoot,
+  };
+  const results = [];
+	const kagiCheck = await run('kagi', ['--version'], environment).catch(() => ({ code: 1 }));
+
+  for (const font of fonts) {
+    const beforeInvalid = await invalidURLCount(cacheRoot);
+    const destination = join(root, 'downloads', font.replaceAll(/[^a-z0-9]+/gi, '_'));
+    const command = await run(binary, ['get', font, '--json', '--no-cache', '--download-dir', destination], environment);
+    const afterInvalid = await invalidURLCount(cacheRoot);
+    if (command.code !== 0) {
+      results.push({ query: font, status: 'miss', exitCode: command.code, error: command.stderr.trim() });
+      console.error(`MISS ${font}: ${command.stderr.trim()}`);
+      continue;
+    }
+
+    const [download] = JSON.parse(command.stdout) as DownloadFile[];
+    if (!download?.Path) throw new Error(`${font} returned success without a download path`);
+    const content = await readFile(download.Path);
+    const format = signature(content);
+    if (format === null) throw new Error(`${font} returned bytes outside the direct-font contract`);
+    const metadata = await stat(download.Path);
+    results.push({
+      query: font,
+      status: 'pass',
+      filename: basename(download.Path),
+      format,
+      bytes: metadata.size,
+      sha256: createHash('sha256').update(content).digest('hex'),
+      rejectedCandidates: Math.max(0, afterInvalid - beforeInvalid),
+    });
+    console.error(`PASS ${font}: ${basename(download.Path)} (${format})`);
+  }
+
+	const unexpected = results.filter((result) => result.status === 'miss' && !expectedMisses.has(result.query));
+  const report = {
+    generatedAt: new Date().toISOString(),
+    binary,
+    githubAuthenticated: false,
+		kagiAvailable: kagiCheck.code === 0,
+    passed: results.filter(({ status }) => status === 'pass').length,
+    total: fonts.length,
+    results,
+  };
+	if (outputDirectory) {
+		await mkdir(outputDirectory, { recursive: true });
+		await writeFile(join(outputDirectory, 'font-corpus.json'), `${JSON.stringify(report, null, 2)}\n`);
+		const header = 'query\tstatus\tfilename\tformat\tbytes\tsha256\trejected_candidates';
+		const rows = results.map((result) => {
+			const clean = (value: unknown) => String(value ?? '-').replaceAll(/[\t\r\n]/g, ' ');
+			return [
+				result.query,
+				result.status,
+				'filename' in result ? result.filename : '-',
+				'format' in result ? result.format : '-',
+				'bytes' in result ? result.bytes : '-',
+				'sha256' in result ? result.sha256 : '-',
+				'rejectedCandidates' in result ? result.rejectedCandidates : 0,
+			].map(clean).join('\t');
+		});
+		await writeFile(join(outputDirectory, 'font-corpus.tsv'), `${[header, ...rows].join('\n')}\n`);
+	}
+  console.log(JSON.stringify(report, null, 2));
+  if (unexpected.length > 0) {
+    throw new Error(`corpus changed unexpectedly for: ${unexpected.map(({ query }) => query).join(', ')}`);
+  }
+	} finally {
+		await rm(root, { recursive: true, force: true });
+	}
+}
+
+main().catch((error: unknown) => {
+  console.error(error instanceof Error ? `font-corpus: ${error.message}` : error);
+  process.exitCode = 1;
+});

--- a/scripts/release.test.ts
+++ b/scripts/release.test.ts
@@ -3,7 +3,7 @@ import { test } from 'node:test';
 
 import {
   archiveIntegrity,
-  binaryContainsExactVersion,
+  binaryContainsVersionMarker,
 	isMissingReleaseError,
   parseBuildMetadata,
 	parseRemoteAnnotatedTag,
@@ -32,11 +32,14 @@ test('requires the complete six-target release matrix', () => {
   );
 });
 
-test('finds only an exact printable embedded version', () => {
-  const binary = Buffer.from(['prefix', 'dependency-v0.2.1', 'v0.2.1', '0.2.1', 'suffix'].join('\0'));
+test('finds the unique version marker inside concatenated Go string data', () => {
+  const binary = Buffer.from('prefixtime0.2.1falsemoji-release-version:0.2.1:moji-marker-endsuffix');
 
-  assert.equal(binaryContainsExactVersion(binary, '0.2.1'), true);
-  assert.equal(binaryContainsExactVersion(binary, '0.2.2'), false);
+  assert.equal(binaryContainsVersionMarker(binary, '0.2.1'), true);
+  assert.equal(binaryContainsVersionMarker(binary, '0.2.2'), false);
+	assert.equal(binaryContainsVersionMarker(Buffer.from('dependency-v0.2.1'), '0.2.1'), false);
+	assert.equal(binaryContainsVersionMarker(Buffer.from('moji-release-version:0.2.10:moji-marker-end'), '0.2.1'), false);
+	assert.equal(binaryContainsVersionMarker(Buffer.from('moji-release-version:0.2.1-beta:moji-marker-end'), '0.2.1'), false);
 });
 
 test('reads the target architecture from Go build metadata', () => {

--- a/scripts/release.test.ts
+++ b/scripts/release.test.ts
@@ -1,0 +1,74 @@
+import assert from 'node:assert/strict';
+import { test } from 'node:test';
+
+import {
+  archiveIntegrity,
+  binaryContainsExactVersion,
+  parseBuildMetadata,
+	parseRemoteAnnotatedTag,
+  shouldPublishPackage,
+  validateTargets,
+} from './release.ts';
+
+test('requires the complete six-target release matrix', () => {
+  assert.doesNotThrow(() =>
+    validateTargets([
+      'linux-x64',
+      'linux-arm64',
+      'darwin-x64',
+      'darwin-arm64',
+      'win32-x64',
+      'win32-arm64',
+    ]),
+  );
+
+  assert.throws(
+    () => validateTargets(['linux-x64', 'linux-arm64']),
+    /release archive must contain exactly 6 native targets/,
+  );
+});
+
+test('finds only an exact printable embedded version', () => {
+  const binary = Buffer.from(['prefix', 'dependency-v0.2.1', 'v0.2.1', '0.2.1', 'suffix'].join('\0'));
+
+  assert.equal(binaryContainsExactVersion(binary, '0.2.1'), true);
+  assert.equal(binaryContainsExactVersion(binary, '0.2.2'), false);
+});
+
+test('reads the target architecture from Go build metadata', () => {
+  const metadata = parseBuildMetadata(`
+package/moji: go1.25.0
+\tpath\tgithub.com/microck/moji/cmd/moji
+\tbuild\tCGO_ENABLED=0
+\tbuild\tGOARCH=arm64
+\tbuild\tGOOS=windows
+`);
+
+  assert.deepEqual(metadata, { goos: 'windows', goarch: 'arm64' });
+});
+
+test('resumes after npm publication only when the verified archive is identical', () => {
+	const integrity = archiveIntegrity(Buffer.from('verified archive'));
+	assert.equal(shouldPublishPackage(null, integrity), true);
+	assert.equal(shouldPublishPackage(integrity, integrity), false);
+	assert.throws(() => shouldPublishPackage(archiveIntegrity(Buffer.from('other archive')), integrity), /different archive bytes/);
+});
+
+test('resumes from a matching remote annotated tag and rejects unsafe tags', () => {
+	const commit = '1111111111111111111111111111111111111111';
+	const tagObject = '2222222222222222222222222222222222222222';
+	assert.equal(parseRemoteAnnotatedTag('', 'v1.2.3', commit), 'missing');
+	assert.equal(
+		parseRemoteAnnotatedTag(
+			`${tagObject}\trefs/tags/v1.2.3\n${commit}\trefs/tags/v1.2.3^{}\n`,
+			'v1.2.3',
+			commit,
+		),
+		'matching',
+	);
+	assert.throws(() => parseRemoteAnnotatedTag(`${commit}\trefs/tags/v1.2.3\n`, 'v1.2.3', commit), /not an annotated tag/);
+	assert.throws(
+		() => parseRemoteAnnotatedTag(`${tagObject}\trefs/tags/v1.2.3\n${tagObject}\trefs/tags/v1.2.3^{}\n`, 'v1.2.3', commit),
+		/not current commit/,
+	);
+});

--- a/scripts/release.test.ts
+++ b/scripts/release.test.ts
@@ -8,6 +8,9 @@ import {
   parseBuildMetadata,
 	parseRemoteAnnotatedTag,
   shouldPublishPackage,
+	validateBuildSource,
+	validateArtifactIntegrity,
+	validatePublishState,
   validateTargets,
 } from './release.ts';
 
@@ -43,9 +46,35 @@ package/moji: go1.25.0
 \tbuild\tCGO_ENABLED=0
 \tbuild\tGOARCH=arm64
 \tbuild\tGOOS=windows
+\tbuild\tvcs.revision=1111111111111111111111111111111111111111
+\tbuild\tvcs.modified=false
 `);
 
-  assert.deepEqual(metadata, { goos: 'windows', goarch: 'arm64' });
+	assert.deepEqual(metadata, {
+		goos: 'windows',
+		goarch: 'arm64',
+		revision: '1111111111111111111111111111111111111111',
+		modified: false,
+	});
+	assert.doesNotThrow(() => validateBuildSource(metadata, metadata.revision!));
+	assert.throws(() => validateBuildSource({ ...metadata, modified: true }, metadata.revision!), /local modifications/);
+	assert.throws(() => validateBuildSource(metadata, '2222222222222222222222222222222222222222'), /expected clean commit/);
+});
+
+test('requires release inputs and HEAD to remain unchanged after verification', () => {
+	const head = '1111111111111111111111111111111111111111';
+	assert.doesNotThrow(() => validatePublishState('', `${head}\n`, head));
+	assert.throws(() => validatePublishState(' M README.md\n', head, head), /release inputs changed/);
+	assert.throws(
+		() => validatePublishState('', '2222222222222222222222222222222222222222', head),
+		/HEAD changed during verification/,
+	);
+});
+
+test('rejects a release archive that changes after verification', () => {
+	const expected = archiveIntegrity(Buffer.from('verified'));
+	assert.doesNotThrow(() => validateArtifactIntegrity(expected, expected));
+	assert.throws(() => validateArtifactIntegrity(archiveIntegrity(Buffer.from('changed')), expected), /archive changed/);
 });
 
 test('resumes after npm publication only when the verified archive is identical', () => {

--- a/scripts/release.test.ts
+++ b/scripts/release.test.ts
@@ -4,6 +4,7 @@ import { test } from 'node:test';
 import {
   archiveIntegrity,
   binaryContainsExactVersion,
+	isMissingReleaseError,
   parseBuildMetadata,
 	parseRemoteAnnotatedTag,
   shouldPublishPackage,
@@ -71,4 +72,11 @@ test('resumes from a matching remote annotated tag and rejects unsafe tags', () 
 		() => parseRemoteAnnotatedTag(`${tagObject}\trefs/tags/v1.2.3\n${tagObject}\trefs/tags/v1.2.3^{}\n`, 'v1.2.3', commit),
 		/not current commit/,
 	);
+});
+
+test('classifies only explicit GitHub release 404s as missing', () => {
+	assert.equal(isMissingReleaseError('release not found'), true);
+	assert.equal(isMissingReleaseError('gh: Not Found (HTTP 404)'), true);
+	assert.equal(isMissingReleaseError('HTTP 503 Service Unavailable'), false);
+	assert.equal(isMissingReleaseError('authentication required'), false);
 });

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -1,0 +1,303 @@
+import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { mkdir, mkdtemp, readFile, readdir, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { basename, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const targets = [
+  { directory: 'linux-x64', executable: 'moji', goos: 'linux', goarch: 'amd64' },
+  { directory: 'linux-arm64', executable: 'moji', goos: 'linux', goarch: 'arm64' },
+  { directory: 'darwin-x64', executable: 'moji', goos: 'darwin', goarch: 'amd64' },
+  { directory: 'darwin-arm64', executable: 'moji', goos: 'darwin', goarch: 'arm64' },
+  { directory: 'win32-x64', executable: 'moji.exe', goos: 'windows', goarch: 'amd64' },
+  { directory: 'win32-arm64', executable: 'moji.exe', goos: 'windows', goarch: 'arm64' },
+] as const;
+
+type BuildMetadata = { goos: string; goarch: string };
+type PackageManifest = { name: string; version: string };
+type TagPreflight = { tag: string; head: string; remote: 'missing' | 'matching'; localTarget: string | null };
+type ReleasePreflight = 'missing-release' | 'missing-asset' | 'matching';
+
+export function validateTargets(directories: readonly string[]): void {
+  const expected = targets.map(({ directory }) => directory).sort();
+  const actual = [...directories].sort();
+  if (actual.length !== expected.length || actual.some((directory, index) => directory !== expected[index])) {
+    throw new Error(
+      `release archive must contain exactly 6 native targets (${expected.join(', ')}); found ${actual.join(', ')}`,
+    );
+  }
+}
+
+// Go stores string constants as printable byte runs. Requiring a whole run avoids
+// accepting dependency versions such as "module-v0.2.1" as the app version.
+export function binaryContainsExactVersion(binary: Buffer, version: string): boolean {
+  let start = 0;
+  for (let index = 0; index <= binary.length; index += 1) {
+    const byte = binary[index];
+    const printable = byte !== undefined && byte >= 0x20 && byte <= 0x7e;
+    if (printable) continue;
+    if (index > start && binary.toString('ascii', start, index) === version) return true;
+    start = index + 1;
+  }
+  return false;
+}
+
+export function parseBuildMetadata(output: string): BuildMetadata {
+  const goos = output.match(/^\s*build\s+GOOS=(\S+)$/m)?.[1];
+  const goarch = output.match(/^\s*build\s+GOARCH=(\S+)$/m)?.[1];
+  if (!goos || !goarch) throw new Error('native binary is missing GOOS/GOARCH build metadata');
+  return { goos, goarch };
+}
+
+export function archiveIntegrity(content: Buffer): string {
+  return `sha512-${createHash('sha512').update(content).digest('base64')}`;
+}
+
+export function shouldPublishPackage(existingIntegrity: string | null, localIntegrity: string): boolean {
+  if (existingIntegrity === null) return true;
+  if (existingIntegrity !== localIntegrity) {
+    throw new Error('the npm version already exists with different archive bytes; refusing to tag this commit');
+  }
+  return false;
+}
+
+export function parseRemoteAnnotatedTag(output: string, tag: string, expectedCommit: string): 'missing' | 'matching' {
+	const references = new Map(
+		output.trim().split('\n').filter(Boolean).map((line) => {
+			const [hash, reference] = line.split(/\s+/, 2);
+			return [reference, hash] as const;
+		}),
+	);
+	const reference = `refs/tags/${tag}`;
+	if (!references.has(reference)) return 'missing';
+	const peeled = references.get(`${reference}^{}`);
+	if (!peeled) throw new Error(`origin/${tag} exists but is not an annotated tag`);
+	if (peeled !== expectedCommit) throw new Error(`origin/${tag} points to ${peeled}, not current commit ${expectedCommit}`);
+	return 'matching';
+}
+
+async function run(
+  command: string,
+  args: readonly string[],
+  options: { cwd?: string; capture?: boolean } = {},
+): Promise<string> {
+  console.log(`> ${command} ${args.join(' ')}`);
+  return await new Promise<string>((resolveRun, rejectRun) => {
+    const capture = options.capture ?? false;
+    const child = spawn(command, args, {
+      cwd: options.cwd,
+      stdio: capture ? ['ignore', 'pipe', 'inherit'] : 'inherit',
+    });
+    let stdout = '';
+    if (capture) child.stdout?.on('data', (chunk: Buffer) => (stdout += chunk.toString()));
+    child.once('error', rejectRun);
+    child.once('exit', (code) => {
+      if (code === 0) resolveRun(stdout);
+      else rejectRun(new Error(`${command} exited with code ${code}`));
+    });
+  });
+}
+
+async function readManifest(path: string): Promise<PackageManifest> {
+  const manifest = JSON.parse(await readFile(path, 'utf8')) as Partial<PackageManifest>;
+  if (!manifest.name || !manifest.version) throw new Error(`${path} must contain package name and version`);
+  return manifest as PackageManifest;
+}
+
+async function verifyArchive(archive: string, extractionRoot: string, expected: PackageManifest): Promise<void> {
+  await run('tar', ['-xzf', archive, '-C', extractionRoot]);
+  const packageRoot = join(extractionRoot, 'package');
+  const packed = await readManifest(join(packageRoot, 'package.json'));
+  if (packed.name !== expected.name || packed.version !== expected.version) {
+    throw new Error(
+      `packed manifest is ${packed.name}@${packed.version}; expected ${expected.name}@${expected.version}`,
+    );
+  }
+
+  const binaryRoot = join(packageRoot, 'binaries');
+  validateTargets(await readdir(binaryRoot));
+  for (const target of targets) {
+    const binaryPath = join(binaryRoot, target.directory, target.executable);
+    const binary = await readFile(binaryPath);
+    if (!binaryContainsExactVersion(binary, expected.version)) {
+      throw new Error(`${target.directory} binary does not contain exact app version ${expected.version}`);
+    }
+
+    const metadata = parseBuildMetadata(await run('go', ['version', '-m', binaryPath], { capture: true }));
+    if (metadata.goos !== target.goos || metadata.goarch !== target.goarch) {
+      throw new Error(
+        `${target.directory} contains ${metadata.goos}/${metadata.goarch}; expected ${target.goos}/${target.goarch}`,
+      );
+    }
+  }
+
+  const launcherVersion = (
+    await run(process.execPath, ['bin/moji.js', '--version'], { cwd: packageRoot, capture: true })
+  ).trim();
+  if (launcherVersion !== expected.version) {
+    throw new Error(`packed JS launcher reported ${launcherVersion}; expected ${expected.version}`);
+  }
+}
+
+async function assertPublishPreconditions(): Promise<void> {
+  const status = await run('git', ['status', '--porcelain'], { capture: true });
+  if (status.trim()) throw new Error('refusing to publish from a dirty worktree; commit the verified release first');
+
+	await run('npm', ['whoami'], { capture: true });
+	await run('gh', ['auth', 'status']);
+}
+
+async function registryIntegrity(name: string, version: string): Promise<string | null> {
+	const registry = (await run('npm', ['config', 'get', 'registry'], { capture: true })).trim().replace(/\/?$/, '/');
+	const endpoint = new URL(`${encodeURIComponent(name)}/${encodeURIComponent(version)}`, registry);
+	const response = await fetch(endpoint);
+	if (response.status === 404) return null;
+	if (!response.ok) throw new Error(`npm registry returned HTTP ${response.status} while checking ${name}@${version}`);
+	const manifest = (await response.json()) as { dist?: { integrity?: unknown } };
+	if (typeof manifest.dist?.integrity !== 'string' || manifest.dist.integrity === '') {
+		throw new Error(`npm registry metadata for ${name}@${version} has no archive integrity`);
+	}
+	return manifest.dist.integrity;
+}
+
+async function inspectAnnotatedTag(version: string): Promise<TagPreflight> {
+	const tag = `v${version}`;
+	const head = (await run('git', ['rev-parse', 'HEAD'], { capture: true })).trim();
+	const remoteTags = await run('git', ['ls-remote', '--tags', 'origin', `refs/tags/${tag}`, `refs/tags/${tag}^{}`], {
+		capture: true,
+	});
+	const remote = parseRemoteAnnotatedTag(remoteTags, tag, head);
+	let existingTarget: string | null = null;
+	try {
+		existingTarget = (await run('git', ['rev-parse', `${tag}^{}`], { capture: true })).trim();
+	} catch {
+		// A missing local tag is the normal first-publication path.
+	}
+	if (existingTarget !== null && existingTarget !== head) {
+		throw new Error(`${tag} points to ${existingTarget}, not current commit ${head}`);
+	}
+	if (existingTarget !== null) {
+		const objectType = (await run('git', ['cat-file', '-t', `refs/tags/${tag}`], { capture: true })).trim();
+		if (objectType !== 'tag') throw new Error(`${tag} exists but is not an annotated tag`);
+	}
+	return { tag, head, remote, localTarget: existingTarget };
+}
+
+async function ensureAnnotatedTag(preflight: TagPreflight): Promise<string> {
+	if (preflight.remote === 'matching') {
+		await run('git', ['fetch', '--force', 'origin', `refs/tags/${preflight.tag}:refs/tags/${preflight.tag}`]);
+		return preflight.tag;
+	}
+	if (preflight.localTarget === null) {
+		await run('git', ['tag', '-a', preflight.tag, '-m', `Moji ${preflight.tag}`]);
+	}
+	await run('git', ['push', 'origin', preflight.tag]);
+	return preflight.tag;
+}
+
+async function inspectGitHubRelease(tag: string, archive: string, temporaryRoot: string): Promise<ReleasePreflight> {
+	let release: { assets?: Array<{ name?: string }> } | null = null;
+	try {
+		release = JSON.parse(await run('gh', ['release', 'view', tag, '--json', 'assets'], { capture: true })) as {
+			assets?: Array<{ name?: string }>;
+		};
+	} catch {
+		return 'missing-release';
+	}
+	const archiveName = basename(archive);
+	if (!release.assets?.some(({ name }) => name === archiveName)) return 'missing-asset';
+	const downloadRoot = join(temporaryRoot, 'github-release-asset');
+	await mkdir(downloadRoot);
+	await run('gh', ['release', 'download', tag, '--pattern', archiveName, '--dir', downloadRoot]);
+	const existingIntegrity = archiveIntegrity(await readFile(join(downloadRoot, archiveName)));
+	const localIntegrity = archiveIntegrity(await readFile(archive));
+	if (existingIntegrity !== localIntegrity) {
+		throw new Error(`GitHub release ${tag} contains ${archiveName} with different archive bytes`);
+	}
+	return 'matching';
+}
+
+async function ensureGitHubRelease(preflight: ReleasePreflight, tag: string, archive: string): Promise<void> {
+	if (preflight === 'missing-release') {
+		await run('gh', [
+			'release',
+			'create',
+			tag,
+			archive,
+			'--verify-tag',
+			'--latest',
+			'--generate-notes',
+			'--title',
+			`Moji ${tag}`,
+		]);
+		return;
+	}
+	if (preflight === 'missing-asset') {
+		await run('gh', ['release', 'upload', tag, archive]);
+		return;
+	}
+	console.log(`GitHub release ${tag} already contains the verified archive; publication is complete.`);
+}
+
+async function main(): Promise<void> {
+  const publish = process.argv.slice(2).includes('--publish');
+  const unknown = process.argv.slice(2).filter((argument) => argument !== '--publish' && argument !== '--verify');
+  if (unknown.length > 0) throw new Error(`unknown release argument: ${unknown.join(', ')}`);
+
+  const projectRoot = resolve(fileURLToPath(new URL('..', import.meta.url)));
+  process.chdir(projectRoot);
+  const manifest = await readManifest(join(projectRoot, 'package.json'));
+	if (publish) await assertPublishPreconditions();
+
+  const temporaryRoot = await mkdtemp(join(tmpdir(), 'moji-release-'));
+  try {
+    // Build explicitly, then force lifecycle scripts during packing. The second
+    // build through prepack is intentional protection against ignore-scripts=true.
+    await run('npm', ['run', 'build:binaries']);
+    const packRoot = join(temporaryRoot, 'pack');
+    await mkdir(packRoot);
+    await run('npm', ['pack', '--ignore-scripts=false', '--pack-destination', packRoot]);
+    const archives = (await readdir(packRoot)).filter((entry) => entry.endsWith('.tgz'));
+    if (archives.length !== 1) throw new Error(`npm pack produced ${archives.length} archives; expected exactly one`);
+    const archive = join(packRoot, archives[0]);
+    const extractionRoot = join(temporaryRoot, 'extract');
+    await mkdir(extractionRoot);
+    await verifyArchive(archive, extractionRoot, manifest);
+    console.log(`Verified ${basename(archive)} with all 6 native binaries at version ${manifest.version}.`);
+
+    if (!publish) {
+      console.log('Verification complete. No package, tag, or GitHub release was published.');
+      return;
+    }
+
+    // Rebuilding must not change tracked release artifacts. The npm package and
+    // GitHub tag therefore describe the exact same committed source and binaries.
+    const rebuiltChanges = await run('git', ['status', '--porcelain', '--', 'binaries'], { capture: true });
+    if (rebuiltChanges.trim()) {
+      throw new Error('rebuilt binaries differ from the commit; commit them and run the release again');
+    }
+
+		const localIntegrity = archiveIntegrity(await readFile(archive));
+		const existingIntegrity = await registryIntegrity(manifest.name, manifest.version);
+		const tagPreflight = await inspectAnnotatedTag(manifest.version);
+		const releasePreflight = await inspectGitHubRelease(tagPreflight.tag, archive, temporaryRoot);
+		if (shouldPublishPackage(existingIntegrity, localIntegrity)) {
+			await run('npm', ['publish', archive, '--access', 'public', '--ignore-scripts=false']);
+		} else {
+			console.log(`${manifest.name}@${manifest.version} already contains the verified archive; resuming publication.`);
+		}
+		const tag = await ensureAnnotatedTag(tagPreflight);
+		await ensureGitHubRelease(releasePreflight, tag, archive);
+    console.log(`Published ${manifest.name}@${manifest.version} and GitHub release ${tag}.`);
+  } finally {
+    await rm(temporaryRoot, { recursive: true, force: true });
+  }
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch((error: unknown) => {
+    console.error(error instanceof Error ? `release: ${error.message}` : error);
+    process.exitCode = 1;
+  });
+}

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -14,7 +14,7 @@ const targets = [
   { directory: 'win32-arm64', executable: 'moji.exe', goos: 'windows', goarch: 'arm64' },
 ] as const;
 
-type BuildMetadata = { goos: string; goarch: string };
+type BuildMetadata = { goos: string; goarch: string; revision: string | null; modified: boolean | null };
 type PackageManifest = { name: string; version: string };
 type TagPreflight = { tag: string; head: string; remote: 'missing' | 'matching'; localTarget: string | null };
 type ReleasePreflight = 'missing-release' | 'missing-asset' | 'matching';
@@ -56,12 +56,37 @@ export function binaryContainsExactVersion(binary: Buffer, version: string): boo
 export function parseBuildMetadata(output: string): BuildMetadata {
   const goos = output.match(/^\s*build\s+GOOS=(\S+)$/m)?.[1];
   const goarch = output.match(/^\s*build\s+GOARCH=(\S+)$/m)?.[1];
+	const revision = output.match(/^\s*build\s+vcs\.revision=(\S+)$/m)?.[1] ?? null;
+	const modifiedValue = output.match(/^\s*build\s+vcs\.modified=(true|false)$/m)?.[1];
   if (!goos || !goarch) throw new Error('native binary is missing GOOS/GOARCH build metadata');
-  return { goos, goarch };
+	return { goos, goarch, revision, modified: modifiedValue === undefined ? null : modifiedValue === 'true' };
+}
+
+export function validateBuildSource(metadata: BuildMetadata, expectedRevision: string): void {
+	if (metadata.revision !== expectedRevision || metadata.modified !== false) {
+		throw new Error(
+			`native binary source is ${metadata.revision ?? 'unknown'}${metadata.modified ? ' with local modifications' : ''}; expected clean commit ${expectedRevision}`,
+		);
+	}
+}
+
+export function validatePublishState(status: string, currentHead: string, expectedHead: string): void {
+	if (status.trim()) throw new Error('release inputs changed during verification; commit them and run the release again');
+	if (currentHead.trim() !== expectedHead) {
+		throw new Error(`HEAD changed during verification; expected ${expectedHead}, found ${currentHead.trim()}`);
+	}
 }
 
 export function archiveIntegrity(content: Buffer): string {
   return `sha512-${createHash('sha512').update(content).digest('base64')}`;
+}
+
+export function validateArtifactIntegrity(actual: string, expected: string): void {
+	if (actual !== expected) throw new Error('verified release archive changed before publication');
+}
+
+async function assertArchiveUnchanged(archive: string, expectedIntegrity: string): Promise<void> {
+	validateArtifactIntegrity(archiveIntegrity(await readFile(archive)), expectedIntegrity);
 }
 
 export function shouldPublishPackage(existingIntegrity: string | null, localIntegrity: string): boolean {
@@ -118,7 +143,12 @@ async function readManifest(path: string): Promise<PackageManifest> {
   return manifest as PackageManifest;
 }
 
-async function verifyArchive(archive: string, extractionRoot: string, expected: PackageManifest): Promise<void> {
+async function verifyArchive(
+	archive: string,
+	extractionRoot: string,
+	expected: PackageManifest,
+	expectedRevision: string | null,
+): Promise<void> {
   await run('tar', ['-xzf', archive, '-C', extractionRoot]);
   const packageRoot = join(extractionRoot, 'package');
   const packed = await readManifest(join(packageRoot, 'package.json'));
@@ -143,6 +173,7 @@ async function verifyArchive(archive: string, extractionRoot: string, expected: 
         `${target.directory} contains ${metadata.goos}/${metadata.goarch}; expected ${target.goos}/${target.goarch}`,
       );
     }
+		if (expectedRevision !== null) validateBuildSource(metadata, expectedRevision);
   }
 
   const launcherVersion = (
@@ -153,12 +184,19 @@ async function verifyArchive(archive: string, extractionRoot: string, expected: 
   }
 }
 
-async function assertPublishPreconditions(): Promise<void> {
+async function assertPublishPreconditions(): Promise<string> {
   const status = await run('git', ['status', '--porcelain'], { capture: true });
   if (status.trim()) throw new Error('refusing to publish from a dirty worktree; commit the verified release first');
 
 	await run('npm', ['whoami'], { capture: true });
 	await run('gh', ['auth', 'status']);
+	return (await run('git', ['rev-parse', 'HEAD'], { capture: true })).trim();
+}
+
+async function assertPublishStateUnchanged(expectedHead: string): Promise<void> {
+	const status = await run('git', ['status', '--porcelain'], { capture: true });
+	const currentHead = await run('git', ['rev-parse', 'HEAD'], { capture: true });
+	validatePublishState(status, currentHead, expectedHead);
 }
 
 async function registryIntegrity(name: string, version: string): Promise<string | null> {
@@ -174,9 +212,10 @@ async function registryIntegrity(name: string, version: string): Promise<string 
 	return manifest.dist.integrity;
 }
 
-async function inspectAnnotatedTag(version: string): Promise<TagPreflight> {
+async function inspectAnnotatedTag(version: string, expectedHead: string): Promise<TagPreflight> {
 	const tag = `v${version}`;
 	const head = (await run('git', ['rev-parse', 'HEAD'], { capture: true })).trim();
+	validatePublishState('', head, expectedHead);
 	const remoteTags = await run('git', ['ls-remote', '--tags', 'origin', `refs/tags/${tag}`, `refs/tags/${tag}^{}`], {
 		capture: true,
 	});
@@ -203,13 +242,18 @@ async function ensureAnnotatedTag(preflight: TagPreflight): Promise<string> {
 		return preflight.tag;
 	}
 	if (preflight.localTarget === null) {
-		await run('git', ['tag', '-a', preflight.tag, '-m', `Moji ${preflight.tag}`]);
+		await run('git', ['tag', '-a', preflight.tag, preflight.head, '-m', `Moji ${preflight.tag}`]);
 	}
 	await run('git', ['push', 'origin', preflight.tag]);
 	return preflight.tag;
 }
 
-async function inspectGitHubRelease(tag: string, archive: string, temporaryRoot: string): Promise<ReleasePreflight> {
+async function inspectGitHubRelease(
+	tag: string,
+	archive: string,
+	temporaryRoot: string,
+	expectedIntegrity: string,
+): Promise<ReleasePreflight> {
 	let release: { assets?: Array<{ name?: string }> } | null = null;
 	try {
 		release = JSON.parse(await run('gh', ['release', 'view', tag, '--json', 'assets'], { capture: true, captureStderr: true })) as {
@@ -222,17 +266,23 @@ async function inspectGitHubRelease(tag: string, archive: string, temporaryRoot:
 	const archiveName = basename(archive);
 	if (!release.assets?.some(({ name }) => name === archiveName)) return 'missing-asset';
 	const downloadRoot = join(temporaryRoot, 'github-release-asset');
+	await rm(downloadRoot, { recursive: true, force: true });
 	await mkdir(downloadRoot);
 	await run('gh', ['release', 'download', tag, '--pattern', archiveName, '--dir', downloadRoot]);
 	const existingIntegrity = archiveIntegrity(await readFile(join(downloadRoot, archiveName)));
-	const localIntegrity = archiveIntegrity(await readFile(archive));
-	if (existingIntegrity !== localIntegrity) {
+	if (existingIntegrity !== expectedIntegrity) {
 		throw new Error(`GitHub release ${tag} contains ${archiveName} with different archive bytes`);
 	}
 	return 'matching';
 }
 
-async function ensureGitHubRelease(preflight: ReleasePreflight, tag: string, archive: string): Promise<void> {
+async function ensureGitHubRelease(
+	preflight: ReleasePreflight,
+	tag: string,
+	archive: string,
+	expectedIntegrity: string,
+): Promise<void> {
+	await assertArchiveUnchanged(archive, expectedIntegrity);
 	if (preflight === 'missing-release') {
 		await run('gh', [
 			'release',
@@ -262,7 +312,7 @@ async function main(): Promise<void> {
   const projectRoot = resolve(fileURLToPath(new URL('..', import.meta.url)));
   process.chdir(projectRoot);
   const manifest = await readManifest(join(projectRoot, 'package.json'));
-	if (publish) await assertPublishPreconditions();
+	const publishHead = publish ? await assertPublishPreconditions() : null;
 
   const temporaryRoot = await mkdtemp(join(tmpdir(), 'moji-release-'));
   try {
@@ -277,32 +327,32 @@ async function main(): Promise<void> {
     const archive = join(packRoot, archives[0]);
     const extractionRoot = join(temporaryRoot, 'extract');
     await mkdir(extractionRoot);
-    await verifyArchive(archive, extractionRoot, manifest);
+    await verifyArchive(archive, extractionRoot, manifest, publishHead);
     console.log(`Verified ${basename(archive)} with all 6 native binaries at version ${manifest.version}.`);
 
     if (!publish) {
       console.log('Verification complete. No package, tag, or GitHub release was published.');
       return;
     }
-
-    // Rebuilding must not change tracked release artifacts. The npm package and
-    // GitHub tag therefore describe the exact same committed source and binaries.
-    const rebuiltChanges = await run('git', ['status', '--porcelain', '--', 'binaries'], { capture: true });
-    if (rebuiltChanges.trim()) {
-      throw new Error('rebuilt binaries differ from the commit; commit them and run the release again');
-    }
+		await assertPublishStateUnchanged(publishHead);
 
 		const localIntegrity = archiveIntegrity(await readFile(archive));
 		const existingIntegrity = await registryIntegrity(manifest.name, manifest.version);
-		const tagPreflight = await inspectAnnotatedTag(manifest.version);
-		const releasePreflight = await inspectGitHubRelease(tagPreflight.tag, archive, temporaryRoot);
+		const tagPreflight = await inspectAnnotatedTag(manifest.version, publishHead);
+		const releasePreflight = await inspectGitHubRelease(tagPreflight.tag, archive, temporaryRoot, localIntegrity);
+		await assertPublishStateUnchanged(publishHead);
 		if (shouldPublishPackage(existingIntegrity, localIntegrity)) {
+			await assertArchiveUnchanged(archive, localIntegrity);
 			await run('npm', ['publish', archive, '--access', 'public', '--ignore-scripts=false']);
 		} else {
 			console.log(`${manifest.name}@${manifest.version} already contains the verified archive; resuming publication.`);
 		}
+		validateArtifactIntegrity((await registryIntegrity(manifest.name, manifest.version)) ?? '', localIntegrity);
 		const tag = await ensureAnnotatedTag(tagPreflight);
-		await ensureGitHubRelease(releasePreflight, tag, archive);
+		await ensureGitHubRelease(releasePreflight, tag, archive, localIntegrity);
+		if ((await inspectGitHubRelease(tag, archive, temporaryRoot, localIntegrity)) !== 'matching') {
+			throw new Error(`GitHub release ${tag} did not retain the verified archive`);
+		}
     console.log(`Published ${manifest.name}@${manifest.version} and GitHub release ${tag}.`);
   } finally {
     await rm(temporaryRoot, { recursive: true, force: true });

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -19,6 +19,16 @@ type PackageManifest = { name: string; version: string };
 type TagPreflight = { tag: string; head: string; remote: 'missing' | 'matching'; localTarget: string | null };
 type ReleasePreflight = 'missing-release' | 'missing-asset' | 'matching';
 
+class CommandError extends Error {
+  constructor(command: string, code: number | null, readonly stderr: string) {
+    super(`${command} exited with code ${code}${stderr.trim() ? `: ${stderr.trim()}` : ''}`);
+  }
+}
+
+export function isMissingReleaseError(stderr: string): boolean {
+  return /(?:release not found|HTTP 404)/i.test(stderr);
+}
+
 export function validateTargets(directories: readonly string[]): void {
   const expected = targets.map(({ directory }) => directory).sort();
   const actual = [...directories].sort();
@@ -80,21 +90,24 @@ export function parseRemoteAnnotatedTag(output: string, tag: string, expectedCom
 async function run(
   command: string,
   args: readonly string[],
-  options: { cwd?: string; capture?: boolean } = {},
+  options: { cwd?: string; capture?: boolean; captureStderr?: boolean } = {},
 ): Promise<string> {
   console.log(`> ${command} ${args.join(' ')}`);
   return await new Promise<string>((resolveRun, rejectRun) => {
     const capture = options.capture ?? false;
+		const captureStderr = options.captureStderr ?? false;
     const child = spawn(command, args, {
       cwd: options.cwd,
-      stdio: capture ? ['ignore', 'pipe', 'inherit'] : 'inherit',
+		stdio: ['ignore', capture ? 'pipe' : 'inherit', captureStderr ? 'pipe' : 'inherit'],
     });
     let stdout = '';
+		let stderr = '';
     if (capture) child.stdout?.on('data', (chunk: Buffer) => (stdout += chunk.toString()));
+		if (captureStderr) child.stderr?.on('data', (chunk: Buffer) => (stderr += chunk.toString()));
     child.once('error', rejectRun);
     child.once('exit', (code) => {
       if (code === 0) resolveRun(stdout);
-      else rejectRun(new Error(`${command} exited with code ${code}`));
+			else rejectRun(new CommandError(command, code, stderr));
     });
   });
 }
@@ -199,11 +212,12 @@ async function ensureAnnotatedTag(preflight: TagPreflight): Promise<string> {
 async function inspectGitHubRelease(tag: string, archive: string, temporaryRoot: string): Promise<ReleasePreflight> {
 	let release: { assets?: Array<{ name?: string }> } | null = null;
 	try {
-		release = JSON.parse(await run('gh', ['release', 'view', tag, '--json', 'assets'], { capture: true })) as {
+		release = JSON.parse(await run('gh', ['release', 'view', tag, '--json', 'assets'], { capture: true, captureStderr: true })) as {
 			assets?: Array<{ name?: string }>;
 		};
-	} catch {
-		return 'missing-release';
+	} catch (error: unknown) {
+		if (error instanceof CommandError && isMissingReleaseError(error.stderr)) return 'missing-release';
+		throw error;
 	}
 	const archiveName = basename(archive);
 	if (!release.assets?.some(({ name }) => name === archiveName)) return 'missing-asset';

--- a/scripts/release.ts
+++ b/scripts/release.ts
@@ -39,18 +39,10 @@ export function validateTargets(directories: readonly string[]): void {
   }
 }
 
-// Go stores string constants as printable byte runs. Requiring a whole run avoids
-// accepting dependency versions such as "module-v0.2.1" as the app version.
-export function binaryContainsExactVersion(binary: Buffer, version: string): boolean {
-  let start = 0;
-  for (let index = 0; index <= binary.length; index += 1) {
-    const byte = binary[index];
-    const printable = byte !== undefined && byte >= 0x20 && byte <= 0x7e;
-    if (printable) continue;
-    if (index > start && binary.toString('ascii', start, index) === version) return true;
-    start = index + 1;
-  }
-  return false;
+// The unique marker avoids false matches from dependency versions while still
+// working when Go concatenates adjacent strings in the binary's read-only data.
+export function binaryContainsVersionMarker(binary: Buffer, version: string): boolean {
+	return binary.includes(Buffer.from(`moji-release-version:${version}:moji-marker-end`, 'ascii'));
 }
 
 export function parseBuildMetadata(output: string): BuildMetadata {
@@ -163,7 +155,7 @@ async function verifyArchive(
   for (const target of targets) {
     const binaryPath = join(binaryRoot, target.directory, target.executable);
     const binary = await readFile(binaryPath);
-    if (!binaryContainsExactVersion(binary, expected.version)) {
+    if (!binaryContainsVersionMarker(binary, expected.version)) {
       throw new Error(`${target.directory} binary does not contain exact app version ${expected.version}`);
     }
 


### PR DESCRIPTION
**Summary**

- Continue through ranked candidates when downloads contain invalid font bytes.
- Stage provenance-coherent family downloads and prefer fuller families.
- Add bounded URL-health caching across CLI and TUI.
- Improve source-reliability ranking without conflating licensing or trust.
- Add resumable six-platform npm release verification.
- Add CI enforcement and reproducible 21-font corpus evidence.

**Validation**

- 134 Go race tests passed.
- 6 release contract tests passed.
- All six native package targets verified.
- Windows-specific implementations cross-compiled.
- Corpus produced 19/21 byte-valid downloads.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hardens font downloads and adds release verification. The main changes are:

- Ranked download fallback continues past invalid font bytes.
- Whole-family downloads stage coherent same-source groups before committing files.
- A bounded URL-health cache suppresses direct links that returned invalid font content.
- Source reliability is added as a ranking tie-breaker.
- Release automation verifies all six native package targets before publishing.
- CI, docs, tests, and corpus evidence are updated for the new behavior.

<h3>Confidence Score: 5/5</h3>

Safe to merge based on the reviewed download, cache, ranking, provider, and release paths.

No accepted functional or security issues remain. The highest-risk changes include focused validation paths, staged commits, bounded persistence, and release artifact checks.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- The earlier test capture ran and produced a log showing the shell wrapper exited with code 2 due to /bin/sh not supporting PIPESTATUS\[0\].
- The primary Bash-based race-validation run completed successfully with exit code 0, and the log records the command, working directory, start and end times, Go version, verbose test output, and package pass lines.

<a href="https://app.greptile.com/trex/runs/14111087/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/app/commands.go | Adds fallback download orchestration, URL-health recording, family group staging, and aggregate errors. |
| internal/download/download.go | Adds typed invalid-content errors and staged batch family commits with rollback-aware no-replace moves. |
| internal/cache/cache.go | Adds bounded expiring URL-health cache with atomic writes and cache clearing support. |
| internal/app/search.go | Filters known-invalid URL health entries from search and records TUI invalid-content failures. |
| internal/rank/rank.go | Adds source reliability tie-breaking and coherent family grouping helpers. |
| internal/provider/discovery.go | Adds signature-based archive discovery and provenance grouping while continuing to reject page content. |
| internal/provider/websearch.go | Expands web-search query coverage and deduplicates discovered direct font and archive results. |
| scripts/release.ts | Adds verify-by-default release automation with archive, native target, VCS metadata, npm, tag, and GitHub release checks. |
| scripts/build-binaries.ts | Embeds exact package version and release marker into all six built native binaries. |
| scripts/release.test.ts | Adds release contract tests for target matrix, version markers, build metadata, publication state, and resume checks. |
| .github/workflows/ci.yml | Adds release contract, archive verification, and committed-binary checks to CI. |
| docs/release-runbook.md | Adds release verification and publish/resume procedure documentation. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant App as CLI/TUI app
participant Search as Providers + Cache
participant Rank as Ranking
participant DL as Downloader
participant Health as URL health cache
participant Release as Release verifier

User->>App: search/get font query
App->>Search: provider search with cached invalid URLs
Search-->>App: direct candidates excluding known-invalid URLs
App->>Rank: rank by relevance, quality, reliability
alt single font get
    loop until max successes or candidates exhausted
        App->>Health: check candidate URL/member
        App->>DL: download + validate bytes
        alt invalid font bytes
            DL-->>App: InvalidContentError
            App->>Health: record invalid URL/member
        else valid font
            DL-->>App: saved file
        end
    end
else family get
    loop coherent family groups
        App->>DL: stage and validate entire group
        alt group valid
            DL-->>App: atomically commit family files
        else member invalid
            App->>Health: record failed member key
        end
    end
end
User->>Release: npm run release / release:publish
Release->>Release: rebuild six targets, pack archive, verify versions/metadata
alt publish mode after verification
    Release->>Release: npm publish, annotated tag, GitHub release
end
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant App as CLI/TUI app
participant Search as Providers + Cache
participant Rank as Ranking
participant DL as Downloader
participant Health as URL health cache
participant Release as Release verifier

User->>App: search/get font query
App->>Search: provider search with cached invalid URLs
Search-->>App: direct candidates excluding known-invalid URLs
App->>Rank: rank by relevance, quality, reliability
alt single font get
    loop until max successes or candidates exhausted
        App->>Health: check candidate URL/member
        App->>DL: download + validate bytes
        alt invalid font bytes
            DL-->>App: InvalidContentError
            App->>Health: record invalid URL/member
        else valid font
            DL-->>App: saved file
        end
    end
else family get
    loop coherent family groups
        App->>DL: stage and validate entire group
        alt group valid
            DL-->>App: atomically commit family files
        else member invalid
            App->>Health: record failed member key
        end
    end
end
User->>Release: npm run release / release:publish
Release->>Release: rebuild six targets, pack archive, verify versions/metadata
alt publish mode after verification
    Release->>Release: npm publish, annotated tag, GitHub release
end
```

</a>

<sub>Reviews (5): Last reviewed commit: ["fix: verify bounded native version marke..."](https://github.com/microck/moji/commit/64e3f0a7e8245d878476f27cd5521c55dd0e5b84) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43546313)</sub>

<!-- /greptile_comment -->