### PR TITLE
fix: maximize bounded GitHub font discovery

### DIFF
--- a/docs/content/docs/reference/providers.mdx
+++ b/docs/content/docs/reference/providers.mdx
@@ -20,7 +20,7 @@ GetFonts is the zero-configuration default.
 - Default: enabled
 - Authentication: optional; required for Code Search
 - Token sources: `GITHUB_TOKEN`, config, or `--token-stdin`
-- Queries: one filename-variant request, then at most one broad extension fallback
+- Queries: adaptive filename and contextual variants within GitHub's remaining allowance
 - Result trust: untrusted
 
 GitHub's general unauthenticated REST allowance does not unlock Code Search;
@@ -29,12 +29,21 @@ Moji skips that guaranteed failure and uses its bounded repository, tree, and
 release search. The TUI home screen explains that `GITHUB_TOKEN` enables code
 search and higher limits.
 
-The filename request covers compact, hyphenated, underscored, lowercase, and
-quoted exact-extension forms. Selected formats are still validated locally.
-When both code queries miss, Moji inspects at most two matching repositories.
-For each repository it reads one recursive tree and up to three releases. Tree
-files use raw GitHub URLs; release results must be direct font or supported
-archive assets.
+Code Search generates literal TTF and OTF filenames, space, hyphen, underscore,
+and compact filename conventions, then broader contextual forms. Moji reads
+GitHub's remaining Code Search allowance after every response, uses as many
+variants as the current allowance permits, and stops before making a guaranteed
+rate-limited request. Repository-tree matching normalizes the same conventions.
+GitHub's REST endpoint does not support
+the website's combined `extension:` and `filename:` recipe, so Moji uses these
+bounded REST-compatible queries instead. Multiple queries are needed because a
+candidate URL is not known to contain valid font bytes until download validation.
+Duplicate direct URLs are discarded. CSS, documentation, and source matches seed at most
+three recursive repository tree reads. Full paths are matched locally using
+normalized family names and bounded foundry abbreviations such as `Premr` for
+`Premier`. Adaptive query spellings share this Code Search budget. If contextual trees miss,
+Moji inspects at most two repositories from repository search. Tree files use
+raw GitHub URLs; release results must be direct font or supported archive assets.
 
 ## Registry
 

--- a/internal/aggregator/aggregator.go
+++ b/internal/aggregator/aggregator.go
@@ -90,6 +90,10 @@ func (a Aggregator) searchProvider(ctx context.Context, source provider.Provider
 			emit(ctx, out, provider.Event{Provider: name, Type: provider.EventStatus, Status: provider.StateDone, Count: count})
 			return
 		}
+		if errors.Is(searchErr, provider.ErrSearchSkipped) {
+			emit(ctx, out, provider.Event{Provider: name, Type: provider.EventStatus, Status: provider.StateDone, Count: count})
+			return
+		}
 		if errors.Is(searchErr, provider.ErrBlocked) || errors.Is(searchErr, provider.ErrNonRetryable) || errors.Is(searchErr, context.Canceled) || attempt == policy.Retries {
 			emit(ctx, out, provider.Event{Provider: name, Type: provider.EventStatus, Status: provider.StateFailed, Err: searchErr, Count: count})
 			return

--- a/internal/aggregator/aggregator_test.go
+++ b/internal/aggregator/aggregator_test.go
@@ -3,6 +3,9 @@ package aggregator
 import (
 	"context"
 	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -13,6 +16,45 @@ type fakeProvider struct {
 	name     string
 	failures int
 	calls    int
+}
+
+func TestGitHubRetryKeepsClaimedQuery(t *testing.T) {
+	t.Parallel()
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		requests++
+		if requests == 1 {
+			response.Header().Set("Retry-After", "1")
+			response.WriteHeader(http.StatusTooManyRequests)
+			return
+		}
+		fmt.Fprint(response, `{"items":[{"name":"Example.ttf","path":"Example.ttf","repository":{"full_name":"fixture/fonts","default_branch":"main"}}]}`)
+	}))
+	defer server.Close()
+
+	github := provider.GitHub{Client: server.Client(), Endpoint: server.URL, Token: "secret"}
+	aggregate := Aggregator{
+		Providers: []provider.Provider{github},
+		Policies: map[string]provider.RatePolicy{"github": {
+			Retries: 1, Timeout: 3 * time.Second, BackoffBase: time.Millisecond,
+		}},
+	}
+	results := 0
+	var final provider.Event
+	for event := range aggregate.Search(provider.WithSearchCycle(context.Background()), "Example", []string{"ttf"}) {
+		if event.Type == provider.EventResult {
+			results++
+		}
+		if event.Type == provider.EventStatus {
+			final = event
+		}
+	}
+	// The first exact query is throttled. The retry then completes the exact and
+	// contextual pair plus one family-tree inspection without losing the claimed
+	// user query.
+	if requests != 4 || results != 1 || final.Status != provider.StateDone {
+		t.Fatalf("requests=%d results=%d final=%#v", requests, results, final)
+	}
 }
 
 func (f *fakeProvider) Name() string { return f.name }
@@ -53,6 +95,29 @@ type blockedProvider struct{}
 func (blockedProvider) Name() string { return "blocked" }
 func (blockedProvider) Search(context.Context, string, []string, chan<- provider.Event) error {
 	return provider.ErrBlocked
+}
+
+type skippedProvider struct{ calls int }
+
+func (source *skippedProvider) Name() string { return "skipped" }
+func (source *skippedProvider) Search(context.Context, string, []string, chan<- provider.Event) error {
+	source.calls++
+	return provider.ErrSearchSkipped
+}
+
+func TestSkippedProviderCompletesWithoutRetryOrFailure(t *testing.T) {
+	t.Parallel()
+	source := &skippedProvider{}
+	aggregate := Aggregator{Providers: []provider.Provider{source}, Policies: map[string]provider.RatePolicy{
+		"skipped": {Retries: 3, Timeout: time.Second},
+	}}
+	var final provider.Event
+	for event := range aggregate.Search(context.Background(), "Example", []string{"ttf"}) {
+		final = event
+	}
+	if source.calls != 1 || final.Status != provider.StateDone || final.Err != nil {
+		t.Fatalf("calls = %d, final = %#v", source.calls, final)
+	}
 }
 
 type retryAfterProvider struct{ calls int }

--- a/internal/app/search.go
+++ b/internal/app/search.go
@@ -89,6 +89,7 @@ func (application App) searchEvents(ctx context.Context, current config.Config, 
 		cached = append(cached, cache.CachedProvider{Source: source, Store: store, Bypass: parsed.noCache})
 	}
 	searchCtx, cancel := context.WithTimeout(ctx, time.Duration(current.SearchTimeoutSeconds)*time.Second)
+	searchCtx = provider.WithSearchCycle(searchCtx)
 	aggregate := aggregator.Aggregator{Providers: cached, Policies: current.Policies()}
 	events := make(chan provider.Event)
 	go func() {

--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -1,8 +1,10 @@
 package cache
 
 import (
+	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -10,6 +12,27 @@ import (
 
 	"github.com/microck/moji/internal/provider"
 )
+
+type skippedProvider struct{}
+
+func (skippedProvider) Name() string { return "skipped" }
+func (skippedProvider) Search(context.Context, string, []string, chan<- provider.Event) error {
+	return provider.ErrSearchSkipped
+}
+
+func TestCachedProviderDoesNotCacheSkippedSearch(t *testing.T) {
+	t.Parallel()
+	store := Store{Directory: t.TempDir(), TTL: time.Hour}
+	cached := CachedProvider{Source: skippedProvider{}, Store: store}
+	err := cached.Search(context.Background(), "ProximaNova", []string{"ttf"}, make(chan provider.Event, 1))
+	if !errors.Is(err, provider.ErrSearchSkipped) {
+		t.Fatalf("search error = %v, want skipped signal", err)
+	}
+	_, hit, getErr := store.Get("ProximaNova", "skipped", []string{"ttf"})
+	if getErr != nil || hit {
+		t.Fatalf("cache hit = %v, error = %v; skipped search must not be cached", hit, getErr)
+	}
+}
 
 func TestStoreHonorsTTLAndFormatIndependentOrder(t *testing.T) {
 	t.Parallel()

--- a/internal/provider/github.go
+++ b/internal/provider/github.go
@@ -9,15 +9,21 @@ import (
 	"net/http"
 	"net/url"
 	"path/filepath"
-	"sort"
 	"strconv"
 	"strings"
 	"time"
+	"unicode"
 )
 
 const maxGitHubResponseSize int64 = 20 << 20
 
 const maxGitHubTreeResults = 500
+
+const maxGitHubContextRepositories = 3
+
+const maxGitHubDirectRepositories = 1
+
+const maxGitHubCodeQueries = 10
 
 type GitHub struct {
 	Client   *http.Client
@@ -46,12 +52,25 @@ type githubRepositorySearchResponse struct {
 	} `json:"items"`
 }
 
+type githubRepository struct {
+	FullName      string
+	DefaultBranch string
+	HintPath      string
+}
+
 type githubTreeResponse struct {
-	Tree []struct {
+	Truncated bool `json:"truncated"`
+	Tree      []struct {
 		Path string `json:"path"`
 		Type string `json:"type"`
 		Size int64  `json:"size"`
 	} `json:"tree"`
+}
+
+type githubContentItem struct {
+	Path string `json:"path"`
+	Type string `json:"type"`
+	Size int64  `json:"size"`
 }
 
 type githubRelease struct {
@@ -63,6 +82,9 @@ type githubRelease struct {
 }
 
 func (source GitHub) Search(ctx context.Context, query string, formats []string, out chan<- Event) error {
+	if !claimGitHubSearch(ctx, query) {
+		return ErrSearchSkipped
+	}
 	client := source.Client
 	if client == nil {
 		client = http.DefaultClient
@@ -79,11 +101,15 @@ func (source GitHub) Search(ctx context.Context, query string, formats []string,
 	// releases retain a small unauthenticated allowance, so tokenless users skip
 	// directly to that bounded fallback instead of making a guaranteed 401 call.
 	useCodeSearch := source.Token != "" || source.Endpoint != ""
+	totalEmitted := 0
+	seenDirectURLs := make(map[string]bool)
+	inspectedRepositories := make(map[string]bool)
+	directRepositoryInspections := 0
 	for _, searchQuery := range githubSearchQueries(query, formats) {
 		if !useCodeSearch {
 			break
 		}
-		payload, err := source.search(ctx, client, endpoint, searchQuery, out)
+		payload, remaining, err := source.search(ctx, client, endpoint, searchQuery, out)
 		if err != nil {
 			return err
 		}
@@ -98,6 +124,10 @@ func (source GitHub) Search(ctx context.Context, query string, formats []string,
 				branch = branchFromHTMLURL(item.HTMLURL)
 			}
 			rawURL := githubRepositoryRawURL(item.Repository.FullName, branch, item.Path)
+			if seenDirectURLs[rawURL] {
+				continue
+			}
+			seenDirectURLs[rawURL] = true
 			out <- Event{Type: EventResult, Result: Result{
 				Name: query, Filename: filepath.Base(item.Name), Format: format,
 				Source: "github.com/" + item.Repository.FullName, URL: rawURL,
@@ -105,11 +135,228 @@ func (source GitHub) Search(ctx context.Context, query string, formats []string,
 			}}
 			emitted++
 		}
-		if emitted > 0 {
-			return nil
+		totalEmitted += emitted
+		candidates := githubCandidateRepositories(payload)
+		repositories := make([]githubRepository, 0, len(candidates))
+		for _, repository := range candidates {
+			if len(inspectedRepositories) >= maxGitHubContextRepositories {
+				break
+			}
+			if inspectedRepositories[repository.FullName] {
+				continue
+			}
+			format := strings.TrimPrefix(strings.ToLower(filepath.Ext(repository.HintPath)), ".")
+			isDirectRepository := githubFontExtension(format)
+			if isDirectRepository && directRepositoryInspections >= maxGitHubDirectRepositories {
+				continue
+			}
+			if isDirectRepository {
+				directRepositoryInspections++
+			}
+			inspectedRepositories[repository.FullName] = true
+			repositories = append(repositories, repository)
+		}
+		if len(repositories) > 0 {
+			emitted, inspectErr := source.inspectRepositoryTrees(ctx, client, endpoint, repositories, query, allowed, seenDirectURLs, out)
+			if inspectErr != nil {
+				return inspectErr
+			}
+			if emitted > 0 {
+				return nil
+			}
+		}
+		if remaining == 0 {
+			break
 		}
 	}
+	if totalEmitted > 0 {
+		return nil
+	}
 	return source.searchRepositories(ctx, client, endpoint, query, allowed, out)
+}
+
+func githubCandidateRepositories(payload githubSearchResponse) []githubRepository {
+	seen := make(map[string]bool)
+	repositories := make([]githubRepository, 0, maxGitHubContextRepositories)
+	for _, includeFonts := range []bool{false, true} {
+		for _, item := range payload.Items {
+			format := strings.TrimPrefix(strings.ToLower(filepath.Ext(item.Name)), ".")
+			if githubFontExtension(format) != includeFonts {
+				continue
+			}
+			name := item.Repository.FullName
+			if name == "" || seen[name] {
+				continue
+			}
+			seen[name] = true
+			repositories = append(repositories, githubRepository{FullName: name, DefaultBranch: item.Repository.DefaultBranch, HintPath: item.Path})
+			if len(repositories) == maxGitHubContextRepositories {
+				return repositories
+			}
+		}
+	}
+	return repositories
+}
+
+func githubFontExtension(format string) bool {
+	switch format {
+	case "ttf", "otf", "woff2", "woff", "dfont", "pfb", "pfm":
+		return true
+	default:
+		return false
+	}
+}
+
+func (source GitHub) inspectRepositoryTrees(ctx context.Context, client *http.Client, codeEndpoint string, repositories []githubRepository, query string, allowed map[string]bool, seenResultURLs map[string]bool, out chan<- Event) (int, error) {
+	base, err := url.Parse(codeEndpoint)
+	if err != nil {
+		return 0, err
+	}
+	base.Path = strings.TrimSuffix(base.Path, "/search/code")
+	emitted := 0
+	for _, repository := range repositories {
+		if emitted >= maxGitHubTreeResults {
+			return emitted, nil
+		}
+		branch := repository.DefaultBranch
+		if branch == "" {
+			branch = "HEAD"
+		}
+		apiRoot := strings.TrimRight(base.String(), "/") + "/repos/" + repository.FullName
+		var tree githubTreeResponse
+		treeErr := source.getJSON(ctx, client, apiRoot+"/git/trees/"+url.PathEscape(branch), url.Values{"recursive": {"1"}}, &tree, out)
+		if stopGitHubFallback(treeErr) {
+			return emitted, treeErr
+		}
+		if treeErr != nil {
+			continue
+		}
+		seenPaths := make(map[string]bool)
+		for _, item := range tree.Tree {
+			format := strings.TrimPrefix(strings.ToLower(filepath.Ext(item.Path)), ".")
+			if item.Type != "blob" || !allowed[format] || !githubPathMatchesQuery(item.Path, query) {
+				continue
+			}
+			rawURL := githubRepositoryRawURL(repository.FullName, branch, item.Path)
+			seenPaths[item.Path] = true
+			if seenResultURLs[rawURL] {
+				continue
+			}
+			seenResultURLs[rawURL] = true
+			out <- Event{Type: EventResult, Result: Result{
+				Name: query, Filename: filepath.Base(item.Path), Format: format, SizeBytes: item.Size,
+				Source: "github.com/" + repository.FullName,
+				URL:    rawURL, Trusted: false, License: "unknown",
+			}}
+			emitted++
+			if emitted >= maxGitHubTreeResults {
+				return emitted, nil
+			}
+		}
+		if tree.Truncated {
+			repository.DefaultBranch = branch
+			contentCount, contentErr := source.inspectRepositoryDirectory(ctx, client, base.String(), repository, query, allowed, seenPaths, seenResultURLs, maxGitHubTreeResults-emitted, out)
+			if stopGitHubFallback(contentErr) {
+				return emitted, contentErr
+			}
+			emitted += contentCount
+		}
+	}
+	return emitted, nil
+}
+
+func (source GitHub) inspectRepositoryDirectory(ctx context.Context, client *http.Client, apiBase string, repository githubRepository, query string, allowed map[string]bool, seenPaths, seenResultURLs map[string]bool, limit int, out chan<- Event) (int, error) {
+	if limit <= 0 {
+		return 0, nil
+	}
+	directory := filepath.ToSlash(filepath.Dir(repository.HintPath))
+	if directory == "." {
+		directory = ""
+	}
+	branch := repository.DefaultBranch
+	if branch == "" {
+		branch = "HEAD"
+	}
+	endpoint := strings.TrimRight(apiBase, "/") + "/repos/" + githubEscapePath(repository.FullName) + "/contents"
+	if directory != "" {
+		endpoint += "/" + githubEscapePath(strings.TrimLeft(directory, "/"))
+	}
+	var items []githubContentItem
+	if err := source.getJSON(ctx, client, endpoint, url.Values{"ref": {branch}}, &items, out); err != nil {
+		return 0, err
+	}
+	emitted := 0
+	for _, item := range items {
+		format := strings.TrimPrefix(strings.ToLower(filepath.Ext(item.Path)), ".")
+		if item.Type != "file" || seenPaths[item.Path] || !allowed[format] || !githubPathMatchesQuery(item.Path, query) {
+			continue
+		}
+		rawURL := githubRepositoryRawURL(repository.FullName, branch, item.Path)
+		if seenResultURLs != nil && seenResultURLs[rawURL] {
+			continue
+		}
+		if seenResultURLs != nil {
+			seenResultURLs[rawURL] = true
+		}
+		out <- Event{Type: EventResult, Result: Result{
+			Name: query, Filename: filepath.Base(item.Path), Format: format, SizeBytes: item.Size,
+			Source: "github.com/" + repository.FullName,
+			URL:    rawURL, Trusted: false, License: "unknown",
+		}}
+		emitted++
+		if emitted >= limit {
+			break
+		}
+	}
+	return emitted, nil
+}
+
+func githubEscapePath(value string) string {
+	parts := strings.Split(value, "/")
+	for index := range parts {
+		parts[index] = url.PathEscape(parts[index])
+	}
+	return strings.Join(parts, "/")
+}
+
+func githubPathMatchesQuery(pathValue, query string) bool {
+	compactPath := githubCompact(pathValue)
+	words := strings.FieldsFunc(strings.ToLower(query), func(character rune) bool {
+		return !unicode.IsLetter(character) && !unicode.IsNumber(character)
+	})
+	aliases := map[string][]string{
+		"premier": {"premr"}, "regular": {"reg", "rg"}, "bold": {"bd"},
+		"italic": {"it"}, "condensed": {"cond", "cn"}, "narrow": {"nr"}, "light": {"lt"},
+	}
+	variants := []string{""}
+	for _, word := range words {
+		options := append([]string{word}, aliases[word]...)
+		next := make([]string, 0, min(32, len(variants)*len(options)))
+		for _, prefix := range variants {
+			for _, option := range options {
+				if len(next) == 32 {
+					break
+				}
+				next = append(next, prefix+option)
+			}
+		}
+		variants = next
+	}
+	for _, variant := range variants {
+		if variant != "" && strings.Contains(compactPath, variant) {
+			return true
+		}
+	}
+	return false
+}
+
+func githubCompact(value string) string {
+	return strings.Map(func(character rune) rune {
+		if unicode.IsLetter(character) || unicode.IsNumber(character) {
+			return unicode.ToLower(character)
+		}
+		return -1
+	}, value)
 }
 
 func (source GitHub) searchRepositories(ctx context.Context, client *http.Client, codeEndpoint, query string, allowed map[string]bool, out chan<- Event) error {
@@ -134,11 +381,12 @@ func (source GitHub) searchRepositories(ctx context.Context, client *http.Client
 		if stopGitHubFallback(treeErr) {
 			return treeErr
 		}
+		emittedFromTree := 0
+		seenPaths := make(map[string]bool)
 		if treeErr == nil {
-			emittedFromTree := 0
 			for _, item := range tree.Tree {
 				format := strings.TrimPrefix(strings.ToLower(filepath.Ext(item.Path)), ".")
-				if item.Type != "blob" || !allowed[format] {
+				if item.Type != "blob" || !allowed[format] || !githubPathMatchesQuery(item.Path, query) {
 					continue
 				}
 				out <- Event{Type: EventResult, Result: Result{
@@ -147,10 +395,20 @@ func (source GitHub) searchRepositories(ctx context.Context, client *http.Client
 					URL:     githubRepositoryRawURL(repository.FullName, branch, item.Path),
 					Trusted: false, License: "unknown",
 				}}
+				seenPaths[item.Path] = true
 				emittedFromTree++
 				if emittedFromTree >= maxGitHubTreeResults {
 					break
 				}
+			}
+			if tree.Truncated {
+				contentCount, contentErr := source.inspectRepositoryDirectory(ctx, client, base.String(), githubRepository{
+					FullName: repository.FullName, DefaultBranch: branch,
+				}, query, allowed, seenPaths, nil, maxGitHubTreeResults-emittedFromTree, out)
+				if stopGitHubFallback(contentErr) {
+					return contentErr
+				}
+				emittedFromTree += contentCount
 			}
 		}
 		var releases []githubRelease
@@ -241,11 +499,11 @@ func decodeGitHubJSON(reader io.Reader, destination any) error {
 	return json.Unmarshal(content, destination)
 }
 
-func (source GitHub) search(ctx context.Context, client *http.Client, endpoint, query string, out chan<- Event) (githubSearchResponse, error) {
+func (source GitHub) search(ctx context.Context, client *http.Client, endpoint, query string, out chan<- Event) (githubSearchResponse, int, error) {
 	parameters := url.Values{"q": {query}, "per_page": {"100"}}
 	request, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint+"?"+parameters.Encode(), nil)
 	if err != nil {
-		return githubSearchResponse{}, err
+		return githubSearchResponse{}, -1, err
 	}
 	request.Header.Set("Accept", "application/vnd.github+json")
 	request.Header.Set("X-GitHub-Api-Version", "2022-11-28")
@@ -255,76 +513,83 @@ func (source GitHub) search(ctx context.Context, client *http.Client, endpoint, 
 	}
 	response, err := client.Do(request)
 	if err != nil {
-		return githubSearchResponse{}, fmt.Errorf("%w: github request: %v", ErrUnavailable, err)
+		return githubSearchResponse{}, -1, fmt.Errorf("%w: github request: %v", ErrUnavailable, err)
 	}
 	defer response.Body.Close()
 	if response.StatusCode == http.StatusTooManyRequests ||
 		(response.StatusCode == http.StatusForbidden && response.Header.Get("X-RateLimit-Remaining") == "0") {
 		retryAfter := githubRetryAfter(response.Header, time.Now())
 		out <- Event{Type: EventStatus, Status: StateThrottled, Err: ErrRateLimited, RetryAfter: retryAfter}
-		return githubSearchResponse{}, ErrRateLimited
+		return githubSearchResponse{}, 0, ErrRateLimited
 	}
 	if response.StatusCode >= 400 && response.StatusCode < 500 {
-		return githubSearchResponse{}, fmt.Errorf("%w: github returned HTTP %d", ErrNonRetryable, response.StatusCode)
+		return githubSearchResponse{}, -1, fmt.Errorf("%w: github returned HTTP %d", ErrNonRetryable, response.StatusCode)
 	}
 	if response.StatusCode != http.StatusOK {
-		return githubSearchResponse{}, fmt.Errorf("%w: github returned HTTP %d", ErrBadResponse, response.StatusCode)
+		return githubSearchResponse{}, -1, fmt.Errorf("%w: github returned HTTP %d", ErrBadResponse, response.StatusCode)
 	}
 	var payload githubSearchResponse
 	if err := decodeGitHubJSON(response.Body, &payload); err != nil {
-		return githubSearchResponse{}, fmt.Errorf("%w: decode github response: %v", ErrBadResponse, err)
+		return githubSearchResponse{}, -1, fmt.Errorf("%w: decode github response: %v", ErrBadResponse, err)
 	}
-	return payload, nil
+	remaining := -1
+	if value, parseErr := strconv.Atoi(response.Header.Get("X-RateLimit-Remaining")); parseErr == nil {
+		remaining = value
+	}
+	return payload, remaining, nil
 }
 
 func githubSearchQueries(query string, formats []string) []string {
-	words := strings.Fields(query)
-	variants := []string{
-		strings.Join(words, ""),
-		strings.Join(words, "-"),
-		strings.Join(words, "_"),
-		strings.ToLower(strings.Join(words, "")),
-	}
-	seen := make(map[string]bool)
-	terms := make([]string, 0, len(variants)+len(variants)*len(formats))
-	appendTerm := func(term string) {
-		if term != "" && !seen[term] {
-			seen[term] = true
-			terms = append(terms, term)
-		}
-	}
-	for _, variant := range variants {
-		appendTerm("filename:" + variant)
-	}
-	for _, variant := range variants {
-		for _, format := range formats {
-			appendTerm(fmt.Sprintf("%q", variant+"."+strings.TrimPrefix(strings.ToLower(format), ".")))
-		}
-	}
-	exact := make([]string, 0, len(terms))
-	length := 0
-	for _, term := range terms {
-		addition := len(term)
-		if len(exact) > 0 {
-			addition += len(" OR ")
-		}
-		if length+addition > 240 {
-			break
-		}
-		exact = append(exact, term)
-		length += addition
-	}
-	qualifiers := make([]string, 0, len(formats))
-	seenQualifiers := make(map[string]bool)
+	allowed := make(map[string]bool, len(formats))
 	for _, format := range formats {
-		qualifier := "extension:" + strings.TrimPrefix(strings.ToLower(format), ".")
-		if !seenQualifiers[qualifier] {
-			seenQualifiers[qualifier] = true
-			qualifiers = append(qualifiers, qualifier)
+		allowed[strings.TrimPrefix(strings.ToLower(format), ".")] = true
+	}
+	orderedFormats := make([]string, 0, len(allowed))
+	for _, preferred := range []string{"ttf", "otf", "woff2", "woff", "dfont", "pfb", "pfm"} {
+		if allowed[preferred] {
+			orderedFormats = append(orderedFormats, preferred)
 		}
 	}
-	sort.Strings(qualifiers)
-	return []string{strings.Join(exact, " OR "), query + " " + strings.Join(qualifiers, " OR ")}
+	name := strings.TrimSpace(query)
+	if name == "" || len(orderedFormats) == 0 {
+		return nil
+	}
+	primaryCount := min(2, len(orderedFormats))
+	queries := make([]string, 0, maxGitHubCodeQueries)
+	names := []string{name}
+	words := strings.Fields(name)
+	if len(words) > 1 {
+		names = append(names, strings.Join(words, "-"), strings.Join(words, "_"), strings.Join(words, ""))
+	}
+	for _, format := range orderedFormats[:primaryCount] {
+		queries = append(queries, name+"."+format)
+	}
+	for _, format := range orderedFormats[:primaryCount] {
+		queries = append(queries, name+" ."+format)
+	}
+	for _, filename := range names[1:] {
+		for _, format := range orderedFormats[:primaryCount] {
+			queries = append(queries, filename+"."+format)
+		}
+	}
+	unique := uniqueStrings(queries)
+	if len(unique) > maxGitHubCodeQueries {
+		unique = unique[:maxGitHubCodeQueries]
+	}
+	return unique
+}
+
+func uniqueStrings(values []string) []string {
+	seen := make(map[string]bool, len(values))
+	unique := make([]string, 0, len(values))
+	for _, value := range values {
+		if seen[value] {
+			continue
+		}
+		seen[value] = true
+		unique = append(unique, value)
+	}
+	return unique
 }
 
 func branchFromHTMLURL(value string) string {

--- a/internal/provider/github_test.go
+++ b/internal/provider/github_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -24,9 +25,13 @@ func TestGitHubSearchesOnceAndFiltersFormats(t *testing.T) {
 		if request.Header.Get("Authorization") != "Bearer secret" {
 			t.Errorf("authorization was not set")
 		}
+		if request.URL.Path == "/repos/acme/fonts/git/trees/main" {
+			fmt.Fprint(response, `{"tree":[{"path":"fonts/Example-Bold.otf","type":"blob"},{"path":"fonts/Example-Regular.TTF","type":"blob"}]}`)
+			return
+		}
 		query := request.URL.Query().Get("q")
-		if !strings.Contains(query, "filename:Example") || !strings.Contains(query, `"Example.otf"`) || strings.Contains(query, "extension:") {
-			t.Errorf("filename query = %q", query)
+		if query != "Example.ttf" && query != "Example.otf" && query != "Example .ttf" && query != "Example .otf" {
+			t.Errorf("context query = %q", query)
 		}
 		if got := request.URL.Query().Get("per_page"); got != "100" {
 			t.Errorf("per_page = %q", got)
@@ -50,28 +55,36 @@ func TestGitHubSearchesOnceAndFiltersFormats(t *testing.T) {
 			t.Fatalf("raw URL = %q", event.Result.URL)
 		}
 	}
-	if requests != 1 {
-		t.Fatalf("requests = %d, want 1", requests)
+	if requests != 5 {
+		t.Fatalf("requests = %d, want four Code Search requests and one family tree", requests)
 	}
 }
 
-func TestGitHubFallsBackToBroadExtensionQuery(t *testing.T) {
+func TestGitHubUsesExactThenContextualSearchBeforeRepositoryFallback(t *testing.T) {
 	t.Parallel()
 	var queries []string
 	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
-		queries = append(queries, request.URL.Query().Get("q"))
-		if len(queries) == 1 {
+		switch request.URL.Path {
+		case "/search/code":
+			queries = append(queries, request.URL.Query().Get("q"))
 			fmt.Fprint(response, `{"items":[]}`)
-			return
+		case "/search/repositories":
+			fmt.Fprint(response, `{"items":[{"full_name":"fixture/fonts","default_branch":"main"}]}`)
+		case "/repos/fixture/fonts/git/trees/main":
+			fmt.Fprint(response, `{"tree":[{"path":"ProximaNova-Regular.ttf","type":"blob","size":1234}]}`)
+		case "/repos/fixture/fonts/releases":
+			fmt.Fprint(response, `[]`)
+		default:
+			t.Fatalf("unexpected request %q", request.URL.Path)
 		}
-		fmt.Fprint(response, `{"items":[{"name":"ProximaNova-Regular.ttf","path":"ProximaNova-Regular.ttf","repository":{"full_name":"fixture/fonts","default_branch":"main"}}]}`)
 	}))
 	defer server.Close()
 	out := make(chan Event, 2)
-	if err := (GitHub{Client: server.Client(), Endpoint: server.URL}).Search(context.Background(), "Proxima Nova", []string{"ttf"}, out); err != nil {
+	if err := (GitHub{Client: server.Client(), Endpoint: server.URL + "/search/code"}).Search(context.Background(), "Proxima Nova", []string{"ttf"}, out); err != nil {
 		t.Fatal(err)
 	}
-	if len(queries) != 2 || queries[1] != "Proxima Nova extension:ttf" {
+	wantQueries := []string{"Proxima Nova.ttf", "Proxima Nova .ttf", "Proxima-Nova.ttf", "Proxima_Nova.ttf", "ProximaNova.ttf"}
+	if fmt.Sprint(queries) != fmt.Sprint(wantQueries) {
 		t.Fatalf("queries = %#v", queries)
 	}
 	if len(out) != 1 {
@@ -172,14 +185,346 @@ func TestGitHubRepositoryFallbackChecksReleasesAfterTreeFailure(t *testing.T) {
 
 func TestGitHubFilenameVariants(t *testing.T) {
 	t.Parallel()
-	query := githubSearchQueries("Proxima Nova", []string{"ttf"})[0]
-	for _, want := range []string{"filename:ProximaNova", "filename:Proxima-Nova", "filename:Proxima_Nova", "filename:proximanova", `"ProximaNova.ttf"`} {
-		if !strings.Contains(query, want) {
-			t.Errorf("query %q missing %q", query, want)
+	queries := githubSearchQueries("Proxima Nova", []string{"otf", "ttf"})
+	want := []string{
+		"Proxima Nova.ttf", "Proxima Nova.otf", "Proxima Nova .ttf", "Proxima Nova .otf",
+		"Proxima-Nova.ttf", "Proxima-Nova.otf", "Proxima_Nova.ttf", "Proxima_Nova.otf",
+		"ProximaNova.ttf", "ProximaNova.otf",
+	}
+	if fmt.Sprint(queries) != fmt.Sprint(want) {
+		t.Fatalf("queries = %#v", queries)
+	}
+	for _, query := range queries {
+		if strings.Contains(query, " OR ") {
+			t.Fatalf("REST Code Search query contains unsupported OR fan-out: %q", query)
 		}
 	}
-	if len(query) > 240 {
-		t.Fatalf("query length = %d", len(query))
+}
+
+func TestGitHubFilenameVariantsStayWithinCodeSearchRateBudget(t *testing.T) {
+	t.Parallel()
+	queries := githubSearchQueries("Times New Roman", []string{"otf", "ttf", "woff2", "dfont", "pfb", "pfm"})
+	if len(queries) > maxGitHubCodeQueries {
+		t.Fatalf("queries = %d, budget = %d", len(queries), maxGitHubCodeQueries)
+	}
+	joined := strings.Join(queries, "\n")
+	for _, required := range []string{
+		"Times New Roman.ttf", "Times New Roman.otf", "Times-New-Roman.ttf", "Times-New-Roman.otf",
+		"Times_New_Roman.ttf", "Times_New_Roman.otf", "TimesNewRoman.ttf", "TimesNewRoman.otf",
+		"Times New Roman .ttf", "Times New Roman .otf",
+	} {
+		if !strings.Contains(joined, required) {
+			t.Errorf("queries do not contain %q: %#v", required, queries)
+		}
+	}
+}
+
+func TestGitHubUsesReportedCodeSearchAllowance(t *testing.T) {
+	t.Parallel()
+	codeCalls := 0
+	var queries []string
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.URL.Path != "/search/code" {
+			t.Fatalf("unexpected request path %q", request.URL.Path)
+		}
+		codeCalls++
+		queries = append(queries, request.URL.Query().Get("q"))
+		response.Header().Set("X-RateLimit-Remaining", strconv.Itoa(3-codeCalls))
+		fmt.Fprint(response, `{"items":[{"name":"Example.ttf","path":"Example.ttf","repository":{}}]}`)
+	}))
+	defer server.Close()
+
+	out := make(chan Event, 2)
+	err := (GitHub{Client: server.Client(), Endpoint: server.URL + "/search/code", Token: "secret"}).Search(
+		context.Background(), "Example Family", []string{"ttf", "otf"}, out,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if codeCalls != 3 {
+		t.Fatalf("code calls = %d, want reported allowance", codeCalls)
+	}
+	if queries[2] != "Example Family .ttf" {
+		t.Fatalf("queries = %#v, contextual search did not run before exhaustion", queries)
+	}
+}
+
+func TestGitHubContextMatchInspectsRepositoryTree(t *testing.T) {
+	t.Parallel()
+	requests := make([]string, 0, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		requests = append(requests, request.URL.Path)
+		switch request.URL.Path {
+		case "/search/code":
+			if got := request.URL.Query().Get("q"); got != "Garamond Premier Pro.ttf" {
+				t.Fatalf("query = %q", got)
+			}
+			fmt.Fprint(response, `{"items":[{"name":"stylesheet.css","path":"Garamond-Premier-Pro/stylesheet.css","repository":{"full_name":"fixture/fonts","default_branch":"main"}}]}`)
+		case "/repos/fixture/fonts/git/trees/main":
+			fmt.Fprint(response, `{"tree":[{"path":"Garamond-Premier-Pro/GaramondPremrPro.ttf","type":"blob","size":1000},{"path":"Garamond-Premier-Pro/GaramondPremrPro-Bd.ttf","type":"blob","size":1100},{"path":"Other/Unrelated.ttf","type":"blob","size":1200}]}`)
+		default:
+			t.Fatalf("unexpected request path %q", request.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	out := make(chan Event, 4)
+	err := (GitHub{Client: server.Client(), Endpoint: server.URL + "/search/code", Token: "secret"}).Search(
+		context.Background(), "Garamond Premier Pro", []string{"otf", "ttf"}, out,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	close(out)
+	if len(out) != 2 {
+		t.Fatalf("results = %d, want two matching direct fonts", len(out))
+	}
+	for event := range out {
+		if !strings.Contains(event.Result.URL, "raw.githubusercontent.com/fixture/fonts/main/Garamond-Premier-Pro/GaramondPremrPro") {
+			t.Fatalf("URL = %q", event.Result.URL)
+		}
+	}
+	if len(requests) != 2 {
+		t.Fatalf("requests = %#v", requests)
+	}
+}
+
+func TestGitHubExactFilenameContextFindsArcherFont(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/search/code":
+			if got := request.URL.Query().Get("q"); got != "Archer.ttf" {
+				t.Fatalf("query = %q", got)
+			}
+			fmt.Fprint(response, `{"items":[{"name":"App.vue","path":"src/App.vue","repository":{"full_name":"fixture/daegmael","default_branch":"master"}}]}`)
+		case "/repos/fixture/daegmael/git/trees/master":
+			fmt.Fprint(response, `{"tree":[{"path":"src/assets/fonts/archer.ttf","type":"blob","size":1234}]}`)
+		default:
+			t.Fatalf("unexpected request path %q", request.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	out := make(chan Event, 2)
+	err := (GitHub{Client: server.Client(), Endpoint: server.URL + "/search/code", Token: "secret"}).Search(
+		context.Background(), "Archer", []string{"ttf"}, out,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	close(out)
+	if len(out) != 1 || (<-out).Result.Filename != "archer.ttf" {
+		t.Fatal("exact filename context did not find Archer font")
+	}
+}
+
+func TestGitHubSearchCycleSpendsCodeSearchBudgetOnOneQuerySpelling(t *testing.T) {
+	t.Parallel()
+	requests := 0
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		requests++
+		fmt.Fprint(response, `{"items":[{"name":"Example.ttf","path":"Example.ttf","repository":{"full_name":"fixture/fonts","default_branch":"main"}}]}`)
+	}))
+	defer server.Close()
+
+	ctx := WithSearchCycle(context.Background())
+	for index, query := range []string{"Example", "Example-Regular"} {
+		out := make(chan Event, 2)
+		err := (GitHub{Client: server.Client(), Endpoint: server.URL, Token: "secret"}).Search(ctx, query, []string{"ttf"}, out)
+		if index == 0 && err != nil {
+			t.Fatal(err)
+		}
+		if index == 1 && !errors.Is(err, ErrSearchSkipped) {
+			t.Fatalf("adaptive search error = %v, want skipped signal", err)
+		}
+	}
+	if requests != 3 {
+		t.Fatalf("requests = %d, want one exact/contextual pair and one family tree per command", requests)
+	}
+}
+
+func TestGitHubContextStillInspectsSourcesAlongsideDuplicateDirectMatch(t *testing.T) {
+	t.Parallel()
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		switch request.URL.Path {
+		case "/search/code":
+			if request.URL.Query().Get("q") == "Example.ttf" {
+				fmt.Fprint(response, `{"items":[{"name":"Example.ttf","path":"fonts/Example.ttf","repository":{"full_name":"fixture/direct","default_branch":"main"}}]}`)
+				return
+			}
+			fmt.Fprint(response, `{"items":[{"name":"Example.ttf","path":"fonts/Example.ttf","repository":{"full_name":"fixture/direct","default_branch":"main"}},{"name":"stylesheet.css","path":"styles/stylesheet.css","repository":{"full_name":"fixture/context","default_branch":"main"}}]}`)
+		case "/repos/fixture/context/git/trees/main":
+			fmt.Fprint(response, `{"tree":[{"path":"fonts/Example-Bold.ttf","type":"blob","size":1400}]}`)
+		case "/repos/fixture/direct/git/trees/main":
+			fmt.Fprint(response, `{"tree":[{"path":"fonts/Example.ttf","type":"blob","size":1200}]}`)
+		default:
+			t.Fatalf("unexpected request path %q", request.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	out := make(chan Event, 3)
+	err := (GitHub{Client: server.Client(), Endpoint: server.URL + "/search/code", Token: "secret"}).Search(
+		context.Background(), "Example", []string{"ttf"}, out,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	close(out)
+	if len(out) != 2 {
+		t.Fatalf("results = %d, want deduplicated direct match plus contextual tree match", len(out))
+	}
+	filenames := map[string]bool{}
+	for event := range out {
+		filenames[event.Result.Filename] = true
+	}
+	if !filenames["Example.ttf"] || !filenames["Example-Bold.ttf"] {
+		t.Fatalf("filenames = %#v", filenames)
+	}
+}
+
+func TestGitHubRepositoryInspectionBudgetIsSharedAcrossQueries(t *testing.T) {
+	t.Parallel()
+	codeCalls := 0
+	treeCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		if request.URL.Path == "/search/code" {
+			codeCalls++
+			fmt.Fprintf(response, `{"items":[{"name":"Example.ttf","path":"fonts/Example-%d-a.ttf","repository":{"full_name":"fixture/%d-a","default_branch":"main"}},{"name":"Example.ttf","path":"fonts/Example-%d-b.ttf","repository":{"full_name":"fixture/%d-b","default_branch":"main"}},{"name":"Example.ttf","path":"fonts/Example-%d-c.ttf","repository":{"full_name":"fixture/%d-c","default_branch":"main"}}]}`,
+				codeCalls, codeCalls, codeCalls, codeCalls, codeCalls, codeCalls)
+			return
+		}
+		if strings.Contains(request.URL.Path, "/git/trees/main") {
+			treeCalls++
+			fmt.Fprint(response, `{"tree":[]}`)
+			return
+		}
+		t.Fatalf("unexpected request path %q", request.URL.Path)
+	}))
+	defer server.Close()
+
+	out := make(chan Event, 12)
+	err := (GitHub{Client: server.Client(), Endpoint: server.URL + "/search/code", Token: "secret"}).Search(
+		context.Background(), "Example", []string{"ttf", "otf"}, out,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if codeCalls != len(githubSearchQueries("Example", []string{"ttf", "otf"})) || treeCalls > maxGitHubContextRepositories {
+		t.Fatalf("code calls = %d, tree calls = %d", codeCalls, treeCalls)
+	}
+}
+
+func TestGitHubReservesTreeBudgetForLaterContextSources(t *testing.T) {
+	t.Parallel()
+	directTreeCalls := 0
+	contextTreeCalls := 0
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		switch {
+		case request.URL.Path == "/search/code" && request.URL.Query().Get("q") == "Example.ttf":
+			fmt.Fprint(response, `{"items":[{"name":"Example.ttf","path":"fonts/Example-a.ttf","repository":{"full_name":"fixture/a","default_branch":"main"}},{"name":"Example.ttf","path":"fonts/Example-b.ttf","repository":{"full_name":"fixture/b","default_branch":"main"}},{"name":"Example.ttf","path":"fonts/Example-c.ttf","repository":{"full_name":"fixture/c","default_branch":"main"}}]}`)
+		case request.URL.Path == "/search/code" && request.URL.Query().Get("q") == "Example.otf":
+			fmt.Fprint(response, `{"items":[]}`)
+		case request.URL.Path == "/search/code":
+			fmt.Fprint(response, `{"items":[{"name":"stylesheet.css","path":"Example/stylesheet.css","repository":{"full_name":"fixture/context","default_branch":"main"}}]}`)
+		case request.URL.Path == "/repos/fixture/context/git/trees/main":
+			contextTreeCalls++
+			fmt.Fprint(response, `{"tree":[{"path":"Example/Example-Bold.ttf","type":"blob","size":1400}]}`)
+		case strings.Contains(request.URL.Path, "/git/trees/main"):
+			directTreeCalls++
+			fmt.Fprint(response, `{"tree":[]}`)
+		default:
+			t.Fatalf("unexpected request path %q", request.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	out := make(chan Event, 6)
+	err := (GitHub{Client: server.Client(), Endpoint: server.URL + "/search/code", Token: "secret"}).Search(
+		context.Background(), "Example", []string{"ttf", "otf"}, out,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if directTreeCalls != maxGitHubDirectRepositories || contextTreeCalls != 1 {
+		t.Fatalf("direct tree calls = %d, context tree calls = %d", directTreeCalls, contextTreeCalls)
+	}
+	foundSibling := false
+	for len(out) > 0 {
+		if (<-out).Result.Filename == "Example-Bold.ttf" {
+			foundSibling = true
+		}
+	}
+	if !foundSibling {
+		t.Fatal("later contextual source did not recover its family sibling")
+	}
+}
+
+func TestGitHubPathMatchingCombinesFoundryAliases(t *testing.T) {
+	t.Parallel()
+	for pathValue, query := range map[string]string{
+		"BelariusSerifNrRg.ttf":       "Belarius Serif Narrow Regular",
+		"GaramondPremrPro-Bd.ttf":     "Garamond Premier Pro Bold",
+		"Family/CondLtIt/Example.otf": "Family Condensed Light Italic",
+		"Times New Roman.ttf":         "Times New Roman",
+		"Times-New-Roman.otf":         "Times New Roman",
+		"Times_New_Roman.ttf":         "Times New Roman",
+		"TimesNewRoman.otf":           "Times New Roman",
+	} {
+		if !githubPathMatchesQuery(pathValue, query) {
+			t.Errorf("path %q did not match %q", pathValue, query)
+		}
+	}
+	if githubPathMatchesQuery("Other/Unrelated.ttf", "Belarius Serif Narrow Regular") {
+		t.Fatal("unrelated path matched foundry aliases")
+	}
+	longQuery := "Premier Regular Bold Italic Condensed Narrow Light Unique"
+	if githubPathMatchesQuery("PremierRegularBoldItalicCondensedNarrowLight.ttf", longQuery) {
+		t.Fatal("path matched after dropping a trailing query word")
+	}
+	if !githubPathMatchesQuery("PremierRegularBoldItalicCondensedNarrowLightUnique.ttf", longQuery) {
+		t.Fatal("complete canonical path did not match a long query")
+	}
+}
+
+func TestGitHubTruncatedTreeInspectsContextDirectory(t *testing.T) {
+	t.Parallel()
+	requests := make([]string, 0, 3)
+	server := httptest.NewServer(http.HandlerFunc(func(response http.ResponseWriter, request *http.Request) {
+		requests = append(requests, request.URL.Path)
+		switch request.URL.Path {
+		case "/search/code":
+			fmt.Fprint(response, `{"items":[{"name":"stylesheet.css","path":"Example #1?/stylesheet.css","repository":{"full_name":"fixture/fonts"}}]}`)
+		case "/repos/fixture/fonts/git/trees/HEAD":
+			fmt.Fprint(response, `{"truncated":true,"tree":[{"path":"Example #1?/Example-Regular.ttf","type":"blob","size":1200}]}`)
+		case "/repos/fixture/fonts/contents/Example #1?":
+			if request.URL.EscapedPath() != "/repos/fixture/fonts/contents/Example%20%231%3F" {
+				t.Fatalf("escaped contents path = %q", request.URL.EscapedPath())
+			}
+			if request.URL.Query().Get("ref") != "HEAD" {
+				t.Fatalf("contents ref = %q", request.URL.Query().Get("ref"))
+			}
+			fmt.Fprint(response, `[{"path":"Example #1?/Example-Regular.ttf","type":"file","size":1200},{"path":"Example #1?/Example-Bold.ttf","type":"file","size":1400}]`)
+		default:
+			t.Fatalf("unexpected request path %q", request.URL.Path)
+		}
+	}))
+	defer server.Close()
+
+	out := make(chan Event, 3)
+	err := (GitHub{Client: server.Client(), Endpoint: server.URL + "/search/code", Token: "secret"}).Search(
+		context.Background(), "Example", []string{"ttf"}, out,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	close(out)
+	if len(out) != 2 {
+		t.Fatalf("results = %d, want deduplicated tree result plus recovered sibling", len(out))
+	}
+	if len(requests) != 3 {
+		t.Fatalf("requests = %#v", requests)
 	}
 }
 

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -4,15 +4,17 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 )
 
 var (
-	ErrRateLimited  = errors.New("rate limited")
-	ErrBlocked      = errors.New("blocked by site protection")
-	ErrUnavailable  = errors.New("provider unavailable")
-	ErrBadResponse  = errors.New("bad response from provider")
-	ErrNonRetryable = errors.New("non-retryable provider failure")
+	ErrRateLimited   = errors.New("rate limited")
+	ErrBlocked       = errors.New("blocked by site protection")
+	ErrUnavailable   = errors.New("provider unavailable")
+	ErrBadResponse   = errors.New("bad response from provider")
+	ErrNonRetryable  = errors.New("non-retryable provider failure")
+	ErrSearchSkipped = errors.New("provider search skipped")
 )
 
 func DescribeFailure(name string, err error) string {
@@ -105,6 +107,32 @@ type Event struct {
 type Provider interface {
 	Name() string
 	Search(ctx context.Context, query string, formats []string, out chan<- Event) error
+}
+
+type searchCycle struct {
+	mutex       sync.Mutex
+	githubQuery string
+}
+
+type searchCycleKey struct{}
+
+// WithSearchCycle lets providers share a per-command request budget across
+// adaptive query spellings without exposing provider-specific state to callers.
+func WithSearchCycle(ctx context.Context) context.Context {
+	return context.WithValue(ctx, searchCycleKey{}, &searchCycle{})
+}
+
+func claimGitHubSearch(ctx context.Context, query string) bool {
+	cycle, ok := ctx.Value(searchCycleKey{}).(*searchCycle)
+	if !ok {
+		return true
+	}
+	cycle.mutex.Lock()
+	defer cycle.mutex.Unlock()
+	if cycle.githubQuery == "" {
+		cycle.githubQuery = query
+	}
+	return cycle.githubQuery == query
 }
 
 type RatePolicy struct {

--- a/internal/rank/rank.go
+++ b/internal/rank/rank.go
@@ -51,6 +51,7 @@ var (
 		"reg": "regular", "roman": "regular", "med": "medium",
 		"bd": "bold", "bld": "bold", "sb": "semibold", "semibd": "semibold",
 	}
+	familyAliases = map[string]string{"premr": "premier"}
 )
 
 func DefaultWeights() Weights {
@@ -104,6 +105,9 @@ func ParseFilename(filename string) Tags {
 			continue
 		}
 		if compact != "" {
+			if canonical, ok := familyAliases[compact]; ok {
+				compact = canonical
+			}
 			family = append(family, compact)
 		}
 	}

--- a/internal/rank/rank_test.go
+++ b/internal/rank/rank_test.go
@@ -22,6 +22,7 @@ func TestParseFilename(t *testing.T) {
 		{"Proxima-Nova-Regular.otf", "proxima nova", "regular", "otf", false, false},
 		{"HelveticaNeueLTStd-Light.otf", "helvetica neue lt std", "light", "otf", false, false},
 		{"AvenirNextCondensed-Bold.ttf", "avenir next condensed", "bold", "ttf", false, false},
+		{"GaramondPremrPro-Bd.ttf", "garamond premier pro", "bold", "ttf", false, false},
 		{"FF-Meta-Pro-Normal-Italic.otf", "ff meta pro", "regular", "otf", true, false},
 		{"ExampleSC-Bd.pfb", "example", "bold", "pfb", false, false},
 		{"SourceSans-SemiBoldItalic.woff2", "source sans", "semibold", "woff2", true, false},


### PR DESCRIPTION
Expand GitHub font discovery while respecting GitHub's live request allowance.

**Changes**

- Expand filename and format queries dynamically within the reported Code Search allowance.
- Preserve direct-download validation and family-folder recovery.
- Add quota, retry, naming-variant, and sibling-discovery regressions.
- Document the adaptive request strategy.

**Verification**

- 166 standard tests pass.
- 166 race tests pass.
- Documentation typecheck and lint pass.
- Release-package verification passes for all six native targets.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR expands GitHub font discovery while keeping requests bounded. The main changes are:

- Adaptive GitHub Code Search filename and contextual query variants.
- Shared per-command GitHub search-cycle budgeting across adaptive query spellings.
- Contextual repository tree inspection with direct URL deduplication and bounded repository reads.
- Skipped-search handling in the aggregator and cache tests.
- Ranking support for the `Premr` to `Premier` family alias.
- Updated provider documentation and regression coverage for quota, retry, naming-variant, sibling-discovery, and truncated-tree paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

The changed GitHub discovery paths are bounded by explicit query and repository limits. Skipped searches are handled without retrying or caching empty successful results. Targeted tests cover quota handling, retry behavior, deduplication, contextual tree recovery, truncated trees, and ranking aliases. No blocking correctness or security issues were identified.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Ran the standard Go tests for all five changed packages and confirmed they passed with exit code 0.
- Executed the race-enabled tests for all five changed packages and confirmed they passed under -race with exit code 0.
- Reviewed the command summary to verify the exact commands, their working directories, exit codes, elapsed times, and the release packaging rationale.

<a href="https://app.greptile.com/trex/runs/14117781/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/content/docs/reference/providers.mdx | Updates the GitHub provider reference to describe adaptive Code Search variants, tree inspection, deduplication, and repository fallback bounds. |
| internal/aggregator/aggregator.go | Treats the new GitHub search-skipped sentinel as a completed provider state so adaptive query budgeting does not surface as a provider failure. |
| internal/app/search.go | Wraps each search operation in a provider search cycle so GitHub can share its bounded budget across adaptive query spellings. |
| internal/provider/github.go | Expands GitHub discovery with bounded filename variants, remaining-quota checks, contextual repository tree inspection, URL deduplication, and alias-aware path matching. |
| internal/provider/provider.go | Introduces the skipped-search sentinel and per-command search-cycle state used to claim one GitHub adaptive query spelling. |
| internal/rank/rank.go | Adds a family alias normalization so abbreviated foundry spellings rank with their canonical family names. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant App as App search
participant Agg as Aggregator
participant GH as GitHub provider
participant API as GitHub API
participant Rank as Rank/cache consumers

App->>App: WithSearchCycle(searchCtx)
App->>Agg: Search(adaptive query, formats)
Agg->>GH: Search(ctx, query, formats)
GH->>GH: claimGitHubSearch(query)
alt query already spent this cycle
    GH-->>Agg: ErrSearchSkipped
    Agg-->>App: StateDone
else query claimed
    loop bounded Code Search variants
        GH->>API: "/search/code?q=filename/context variant"
        API-->>GH: items + X-RateLimit-Remaining
        GH-->>App: direct font results (deduped URLs)
        opt contextual candidates
            GH->>API: "/repos/{repo}/git/trees/{branch}?recursive=1"
            API-->>GH: tree
            GH-->>App: matching family tree results
        end
    end
    alt no Code Search results
        GH->>API: /search/repositories
        GH->>API: tree and releases fallback
        GH-->>App: fallback results
    end
    GH-->>Agg: nil
    Agg-->>App: StateDone
end
App->>Rank: Relevance / final result ranking
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant App as App search
participant Agg as Aggregator
participant GH as GitHub provider
participant API as GitHub API
participant Rank as Rank/cache consumers

App->>App: WithSearchCycle(searchCtx)
App->>Agg: Search(adaptive query, formats)
Agg->>GH: Search(ctx, query, formats)
GH->>GH: claimGitHubSearch(query)
alt query already spent this cycle
    GH-->>Agg: ErrSearchSkipped
    Agg-->>App: StateDone
else query claimed
    loop bounded Code Search variants
        GH->>API: "/search/code?q=filename/context variant"
        API-->>GH: items + X-RateLimit-Remaining
        GH-->>App: direct font results (deduped URLs)
        opt contextual candidates
            GH->>API: "/repos/{repo}/git/trees/{branch}?recursive=1"
            API-->>GH: tree
            GH-->>App: matching family tree results
        end
    end
    alt no Code Search results
        GH->>API: /search/repositories
        GH->>API: tree and releases fallback
        GH-->>App: fallback results
    end
    GH-->>Agg: nil
    Agg-->>App: StateDone
end
App->>Rank: Relevance / final result ranking
```

</a>

<sub>Reviews (2): Last reviewed commit: ["fix: maximize adaptive GitHub font disco..."](https://github.com/microck/moji/commit/a2509a3626562ee64b8ad64eb37013cf0069605c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43566389)</sub>

<!-- /greptile_comment -->