### PR TITLE
feat(tui): add native config and grouped font screens

### DIFF
--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -77,12 +77,12 @@ func TestMojiBinaryEndToEnd(t *testing.T) {
 		t.Fatalf("non-interactive default returned %d results, want 10: %s", count, searchOutput)
 	}
 
-	interactiveOutput := runTUI(t, binary, []string{"MojiFixture", "--no-cache"}, environment, nil, "Found 12 results")
-	if !bytes.Contains(interactiveOutput, []byte("Found 12 results")) || !bytes.Contains(interactiveOutput, []byte("MojiFixture-Regular.otf")) {
+	interactiveOutput := runTUI(t, binary, []string{"MojiFixture", "--no-cache"}, environment, nil, "Found 12 files in 12 groups")
+	if !bytes.Contains(interactiveOutput, []byte("Found 12 files in 12 groups")) || !bytes.Contains(interactiveOutput, []byte("MojiFixture-Regular.otf")) {
 		t.Fatalf("TUI did not render fixture result: %q", interactiveOutput)
 	}
-	homeOutput := runTUI(t, binary, nil, environment, []byte("MojiFixture\r"), "Found 12 results")
-	if !bytes.Contains(homeOutput, []byte("Type a font name")) || !bytes.Contains(homeOutput, []byte("Found 12 results")) {
+	homeOutput := runTUI(t, binary, nil, environment, []byte("MojiFixture\r"), "Found 12 files in 12 groups")
+	if !bytes.Contains(homeOutput, []byte("Type a font name")) || !bytes.Contains(homeOutput, []byte("Found 12 files in 12 groups")) {
 		t.Fatalf("home TUI did not transition to results: %q", homeOutput)
 	}
 

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -331,61 +331,11 @@ func TestBareNonInteractiveUsageDoesNotDependOnValidConfig(t *testing.T) {
 	}
 }
 
-func TestConfigWithoutEditorFallsBackToAvailableEditor(t *testing.T) {
-	root := t.TempDir()
-	path := filepath.Join(root, "config.yaml")
-	if err := os.WriteFile(path, []byte(""), 0o600); err != nil {
-		t.Fatal(err)
-	}
-	editorBin := filepath.Join(root, "bin")
-	if err := os.MkdirAll(editorBin, 0o700); err != nil {
-		t.Fatal(err)
-	}
-	captured := filepath.Join(root, "captured-path")
-	editor := filepath.Join(editorBin, "editor")
-	editorScript := "#!/bin/sh\nprintf '%s' \"$1\" > \"" + captured + "\"\n"
-	if err := os.WriteFile(editor, []byte(editorScript), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", editorBin+string(os.PathListSeparator)+os.Getenv("PATH"))
-	t.Setenv("MOJI_CONFIG", path)
-	t.Setenv("EDITOR", "")
-	t.Setenv("VISUAL", "")
+func TestConfigRequiresInteractiveTerminal(t *testing.T) {
+	t.Setenv("MOJI_CONFIG", filepath.Join(t.TempDir(), "config.yaml"))
 	var stderr bytes.Buffer
 	code := (App{Stdout: &bytes.Buffer{}, Stderr: &stderr}).Run(context.Background(), []string{"config"})
-	if code != 0 {
-		t.Fatalf("config code = %d stderr=%s", code, stderr.String())
-	}
-	capturedPath, err := os.ReadFile(captured)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if string(capturedPath) != path {
-		t.Fatalf("editor received %q, expected %q", string(capturedPath), path)
-	}
-	if stderr.Len() != 0 {
-		t.Fatalf("code=%d error=%q", code, stderr.String())
-	}
-}
-
-func TestParseEditorCommandPreservesArgumentsAndQuotedPaths(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		value string
-		want  []string
-	}{
-		{"code --wait", []string{"code", "--wait"}},
-		{`"/Applications/Visual Studio Code.app/Contents/MacOS/Electron" --wait`, []string{"/Applications/Visual Studio Code.app/Contents/MacOS/Electron", "--wait"}},
-		{`"C:\Program Files\Editor\editor.exe" --wait`, []string{`C:\Program Files\Editor\editor.exe`, "--wait"}},
-	}
-	for _, test := range tests {
-		got, err := parseEditorCommand(test.value)
-		if err != nil {
-			t.Fatalf("parseEditorCommand(%q): %v", test.value, err)
-		}
-		if fmt.Sprint(got) != fmt.Sprint(test.want) {
-			t.Errorf("parseEditorCommand(%q) = %q, want %q", test.value, got, test.want)
-		}
+	if code != 2 || !strings.Contains(stderr.String(), "interactive terminal") || strings.Contains(stderr.String(), "EDITOR") {
+		t.Fatalf("code=%d stderr=%q", code, stderr.String())
 	}
 }

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -331,14 +331,39 @@ func TestBareNonInteractiveUsageDoesNotDependOnValidConfig(t *testing.T) {
 	}
 }
 
-func TestConfigWithoutEditorProvidesDirectPath(t *testing.T) {
+func TestConfigWithoutEditorFallsBackToAvailableEditor(t *testing.T) {
 	root := t.TempDir()
 	path := filepath.Join(root, "config.yaml")
+	if err := os.WriteFile(path, []byte(""), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	editorBin := filepath.Join(root, "bin")
+	if err := os.MkdirAll(editorBin, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	captured := filepath.Join(root, "captured-path")
+	editor := filepath.Join(editorBin, "editor")
+	editorScript := "#!/bin/sh\nprintf '%s' \"$1\" > \"" + captured + "\"\n"
+	if err := os.WriteFile(editor, []byte(editorScript), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", editorBin+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv("MOJI_CONFIG", path)
 	t.Setenv("EDITOR", "")
+	t.Setenv("VISUAL", "")
 	var stderr bytes.Buffer
 	code := (App{Stdout: &bytes.Buffer{}, Stderr: &stderr}).Run(context.Background(), []string{"config"})
-	if code != 1 || !strings.Contains(stderr.String(), "edit "+path+" directly") {
+	if code != 0 {
+		t.Fatalf("config code = %d stderr=%s", code, stderr.String())
+	}
+	capturedPath, err := os.ReadFile(captured)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(capturedPath) != path {
+		t.Fatalf("editor received %q, expected %q", string(capturedPath), path)
+	}
+	if stderr.Len() != 0 {
 		t.Fatalf("code=%d error=%q", code, stderr.String())
 	}
 }

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -148,13 +148,9 @@ func (application App) runConfig(current config.Config, path string, args []stri
 			return application.fail(err, 1)
 		}
 	}
-	editor := os.Getenv("EDITOR")
-	if editor == "" {
-		return application.fail(fmt.Errorf("Moji couldn't open the config because $EDITOR is not set. Set EDITOR to your preferred editor or edit %s directly", path), 1)
-	}
-	editorCommand, err := parseEditorCommand(editor)
+	editorCommand, err := resolveEditorCommand()
 	if err != nil {
-		return application.fail(fmt.Errorf("Moji couldn't parse $EDITOR: %w. Set EDITOR to an executable with optional shell-style arguments or edit %s directly", err, path), 1)
+		return application.fail(fmt.Errorf("%w. Set VISUAL or EDITOR to an executable command or edit %s directly", err, path), 1)
 	}
 	command := exec.Command(editorCommand[0], append(editorCommand[1:], path)...)
 	command.Stdin, command.Stdout, command.Stderr = application.Stdin, application.Stdout, application.Stderr
@@ -162,6 +158,43 @@ func (application App) runConfig(current config.Config, path string, args []stri
 		return application.fail(fmt.Errorf("the editor couldn't open %s: %w. Your config file was not changed by Moji", path, err), 1)
 	}
 	return 0
+}
+
+func resolveEditorCommand() ([]string, error) {
+	if visual := strings.TrimSpace(os.Getenv("VISUAL")); visual != "" {
+		if command, err := resolveConfiguredEditor("VISUAL", visual); err == nil {
+			return command, nil
+		}
+	}
+
+	if editor := strings.TrimSpace(os.Getenv("EDITOR")); editor != "" {
+		if command, err := resolveConfiguredEditor("EDITOR", editor); err == nil {
+			return command, nil
+		}
+	}
+
+	candidates := []string{"sensible-editor", "editor", "nano", "vim", "vi"}
+	for _, candidate := range candidates {
+		command, err := parseEditorCommand(candidate)
+		if err != nil {
+			continue
+		}
+		if _, err := exec.LookPath(command[0]); err == nil {
+			return command, nil
+		}
+	}
+	return nil, errors.New("couldn't find a usable terminal editor in PATH")
+}
+
+func resolveConfiguredEditor(name, value string) ([]string, error) {
+	command, err := parseEditorCommand(value)
+	if err != nil {
+		return nil, fmt.Errorf("the value of $%s is invalid: %w", name, err)
+	}
+	if _, err := exec.LookPath(command[0]); err != nil {
+		return nil, fmt.Errorf("$%s command %q is not available on PATH", name, command[0])
+	}
+	return command, nil
 }
 
 func parseEditorCommand(value string) ([]string, error) {

--- a/internal/app/commands.go
+++ b/internal/app/commands.go
@@ -4,16 +4,13 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"os"
-	"os/exec"
-	"strings"
-	"unicode"
 
 	"github.com/microck/moji/internal/cache"
 	"github.com/microck/moji/internal/config"
 	"github.com/microck/moji/internal/download"
 	"github.com/microck/moji/internal/provider"
 	"github.com/microck/moji/internal/rank"
+	"github.com/microck/moji/internal/tui"
 )
 
 func (application App) runGet(ctx context.Context, results []provider.Result, parsed options, family bool) int {
@@ -143,115 +140,13 @@ func (application App) runConfig(current config.Config, path string, args []stri
 		}
 		return application.writeJSON(safe)
 	}
-	if _, err := os.Stat(path); errors.Is(err, os.ErrNotExist) {
-		if err := config.Save(path, current); err != nil {
-			return application.fail(err, 1)
-		}
+	if !isTerminal(application.Stdin) || !isTerminal(application.Stdout) {
+		return application.fail(errors.New("moji config needs an interactive terminal. Use `moji config show` to inspect the current configuration"), 2)
 	}
-	editorCommand, err := resolveEditorCommand()
-	if err != nil {
-		return application.fail(fmt.Errorf("%w. Set VISUAL or EDITOR to an executable command or edit %s directly", err, path), 1)
-	}
-	command := exec.Command(editorCommand[0], append(editorCommand[1:], path)...)
-	command.Stdin, command.Stdout, command.Stderr = application.Stdin, application.Stdout, application.Stderr
-	if err := command.Run(); err != nil {
-		return application.fail(fmt.Errorf("the editor couldn't open %s: %w. Your config file was not changed by Moji", path, err), 1)
+	if err := tui.RunConfig(application.Stdin, application.Stdout, current, path, colorEnabled()); err != nil {
+		return application.fail(fmt.Errorf("configuration interface: %w", err), 1)
 	}
 	return 0
-}
-
-func resolveEditorCommand() ([]string, error) {
-	if visual := strings.TrimSpace(os.Getenv("VISUAL")); visual != "" {
-		if command, err := resolveConfiguredEditor("VISUAL", visual); err == nil {
-			return command, nil
-		}
-	}
-
-	if editor := strings.TrimSpace(os.Getenv("EDITOR")); editor != "" {
-		if command, err := resolveConfiguredEditor("EDITOR", editor); err == nil {
-			return command, nil
-		}
-	}
-
-	candidates := []string{"sensible-editor", "editor", "nano", "vim", "vi"}
-	for _, candidate := range candidates {
-		command, err := parseEditorCommand(candidate)
-		if err != nil {
-			continue
-		}
-		if _, err := exec.LookPath(command[0]); err == nil {
-			return command, nil
-		}
-	}
-	return nil, errors.New("couldn't find a usable terminal editor in PATH")
-}
-
-func resolveConfiguredEditor(name, value string) ([]string, error) {
-	command, err := parseEditorCommand(value)
-	if err != nil {
-		return nil, fmt.Errorf("the value of $%s is invalid: %w", name, err)
-	}
-	if _, err := exec.LookPath(command[0]); err != nil {
-		return nil, fmt.Errorf("$%s command %q is not available on PATH", name, command[0])
-	}
-	return command, nil
-}
-
-func parseEditorCommand(value string) ([]string, error) {
-	var command []string
-	var current strings.Builder
-	var quote rune
-	tokenStarted := false
-	runes := []rune(value)
-	flush := func() {
-		if tokenStarted {
-			command = append(command, current.String())
-			current.Reset()
-			tokenStarted = false
-		}
-	}
-
-	for index := 0; index < len(runes); index++ {
-		character := runes[index]
-		if quote != 0 {
-			if character == quote {
-				quote = 0
-				continue
-			}
-			// Within double quotes, only escape a quote or another backslash.
-			// This preserves Windows paths such as C:\Program Files\Editor.
-			if character == '\\' && quote == '"' && index+1 < len(runes) && (runes[index+1] == '"' || runes[index+1] == '\\') {
-				index++
-				character = runes[index]
-			}
-			current.WriteRune(character)
-			tokenStarted = true
-			continue
-		}
-
-		switch {
-		case character == '\'' || character == '"':
-			quote = character
-			tokenStarted = true
-		case unicode.IsSpace(character):
-			flush()
-		case character == '\\' && index+1 < len(runes) && (unicode.IsSpace(runes[index+1]) || runes[index+1] == '\'' || runes[index+1] == '"' || runes[index+1] == '\\'):
-			index++
-			current.WriteRune(runes[index])
-			tokenStarted = true
-		default:
-			current.WriteRune(character)
-			tokenStarted = true
-		}
-	}
-	if quote != 0 {
-		return nil, errors.New("the value contains an unterminated quote")
-	}
-	flush()
-	if len(command) == 0 {
-		return nil, errors.New("the value is empty")
-	}
-	return command, nil
 }
 
 func (application App) runCache(args []string) int {

--- a/internal/tui/config.go
+++ b/internal/tui/config.go
@@ -1,0 +1,320 @@
+package tui
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+	"github.com/microck/moji/internal/config"
+)
+
+type configField struct {
+	label   string
+	value   string
+	secret  bool
+	boolean bool
+}
+
+type ConfigModel struct {
+	path    string
+	current config.Config
+	fields  []configField
+	cursor  int
+	editing bool
+	status  string
+	saved   bool
+	brand   lipgloss.Style
+	accent  lipgloss.Style
+	faint   lipgloss.Style
+	warning lipgloss.Style
+	width   int
+	height  int
+}
+
+func NewConfigModel(current config.Config, path string, color bool) ConfigModel {
+	providers := []string{"github", "getfonts", "registry", "plugins", "websearch"}
+	fields := []configField{
+		{label: "Download directory", value: current.DownloadDir},
+		{label: "GitHub token", value: current.GitHubToken, secret: true},
+		{label: "Search timeout (seconds)", value: strconv.Itoa(current.SearchTimeoutSeconds)},
+		{label: "Cache TTL (seconds)", value: strconv.Itoa(current.CacheTTLSeconds)},
+		{label: "Default formats", value: strings.Join(current.DefaultFormats, ", ")},
+	}
+	for _, name := range providers {
+		setting := current.Providers[name]
+		fields = append(fields, configField{label: name + " enabled", value: strconv.FormatBool(setting.Enabled), boolean: true})
+		if name == "github" || name == "getfonts" || name == "websearch" {
+			fields = append(fields, configField{label: name + " instance", value: setting.Instance})
+		}
+	}
+	fields = append(fields, configField{label: "Source plugins", value: strings.Join(current.SourcePlugins, ", ")})
+	fields = append(fields,
+		configField{label: "Ranking: format", value: formatFloat(current.Ranking.Format)},
+		configField{label: "Ranking: family size", value: formatFloat(current.Ranking.FamilySize)},
+		configField{label: "Ranking: trusted", value: formatFloat(current.Ranking.Trusted)},
+		configField{label: "Ranking: size penalty", value: formatFloat(current.Ranking.SizePenalty)},
+		configField{label: "Ranking: weight bonus", value: formatFloat(current.Ranking.WeightBonus)},
+		configField{label: "Ranking: variable bonus", value: formatFloat(current.Ranking.VariableBonus)},
+	)
+	for _, name := range providers {
+		policy := current.RateLimits[name]
+		fields = append(fields,
+			configField{label: name + " timeout", value: strconv.Itoa(policy.TimeoutSeconds)},
+			configField{label: name + " retries", value: strconv.Itoa(policy.Retries)},
+		)
+	}
+	model := ConfigModel{path: path, current: current, fields: fields}
+	if color {
+		model.brand = lipgloss.NewStyle().Foreground(lipgloss.Color("#FF8C00")).Bold(true)
+		model.accent = lipgloss.NewStyle().Foreground(lipgloss.Color("#FFA500"))
+		model.faint = lipgloss.NewStyle().Foreground(lipgloss.Color("#777777"))
+		model.warning = lipgloss.NewStyle().Foreground(lipgloss.Color("#FFD75F"))
+	}
+	return model
+}
+
+func (model ConfigModel) Init() tea.Cmd { return nil }
+
+func (model ConfigModel) Update(message tea.Msg) (tea.Model, tea.Cmd) {
+	switch message := message.(type) {
+	case tea.WindowSizeMsg:
+		if message.Width > 0 {
+			model.width = message.Width
+		}
+		if message.Height > 0 {
+			model.height = message.Height
+		}
+		return model, nil
+	case tea.KeyMsg:
+		if model.editing {
+			switch message.String() {
+			case "esc":
+				model.editing = false
+			case "enter":
+				model.editing = false
+				model.status = ""
+			case "backspace":
+				runes := []rune(model.fields[model.cursor].value)
+				if len(runes) > 0 {
+					model.fields[model.cursor].value = string(runes[:len(runes)-1])
+				}
+			default:
+				if len(message.Runes) > 0 {
+					model.fields[model.cursor].value += sanitizeInput(message.Runes)
+				}
+			}
+			return model, nil
+		}
+		switch message.String() {
+		case "ctrl+c", "q", "esc":
+			return model, tea.Quit
+		case "up", "k":
+			model.cursor = max(0, model.cursor-1)
+		case "down", "j":
+			model.cursor = min(len(model.fields)-1, model.cursor+1)
+		case "home", "g":
+			model.cursor = 0
+		case "end", "G":
+			model.cursor = len(model.fields) - 1
+		case "enter", " ":
+			field := &model.fields[model.cursor]
+			if field.boolean {
+				field.value = strconv.FormatBool(field.value != "true")
+			} else {
+				model.editing = true
+			}
+		case "ctrl+s", "s":
+			updated, err := model.config()
+			if err != nil {
+				model.status = err.Error()
+				return model, nil
+			}
+			if err := config.Save(model.path, updated); err != nil {
+				model.status = err.Error()
+				return model, nil
+			}
+			model.current = updated
+			model.saved = true
+			model.status = "Saved " + model.path
+		}
+	}
+	return model, nil
+}
+
+func (model ConfigModel) config() (config.Config, error) {
+	updated := model.current
+	updated.DownloadDir = strings.TrimSpace(model.fields[0].value)
+	updated.GitHubToken = strings.TrimSpace(model.fields[1].value)
+	searchTimeout, err := positiveInt(model.fields[2].value, "search timeout")
+	if err != nil {
+		return config.Config{}, err
+	}
+	cacheTTL, err := nonNegativeInt(model.fields[3].value, "cache TTL")
+	if err != nil {
+		return config.Config{}, err
+	}
+	formats, err := config.ParseFormats(model.fields[4].value)
+	if err != nil {
+		return config.Config{}, fmt.Errorf("default formats: %w", err)
+	}
+	updated.SearchTimeoutSeconds = searchTimeout
+	updated.CacheTTLSeconds = cacheTTL
+	updated.DefaultFormats = formats
+
+	index := 5
+	for _, name := range []string{"github", "getfonts", "registry", "plugins", "websearch"} {
+		setting := updated.Providers[name]
+		setting.Enabled = model.fields[index].value == "true"
+		index++
+		if name == "github" || name == "getfonts" || name == "websearch" {
+			setting.Instance = strings.TrimSpace(model.fields[index].value)
+			index++
+		}
+		updated.Providers[name] = setting
+	}
+	plugins := strings.TrimSpace(model.fields[index].value)
+	updated.SourcePlugins = nil
+	if plugins != "" {
+		for _, plugin := range strings.Split(plugins, ",") {
+			if plugin = strings.TrimSpace(plugin); plugin != "" {
+				updated.SourcePlugins = append(updated.SourcePlugins, plugin)
+			}
+		}
+	}
+	index++
+	rankingValues := []*float64{
+		&updated.Ranking.Format, &updated.Ranking.FamilySize, &updated.Ranking.Trusted,
+		&updated.Ranking.SizePenalty, &updated.Ranking.WeightBonus, &updated.Ranking.VariableBonus,
+	}
+	for _, destination := range rankingValues {
+		value, err := nonNegativeFloat(model.fields[index].value, model.fields[index].label)
+		if err != nil {
+			return config.Config{}, err
+		}
+		*destination = value
+		index++
+	}
+	for _, name := range []string{"github", "getfonts", "registry", "plugins", "websearch"} {
+		timeout, err := positiveInt(model.fields[index].value, name+" timeout")
+		if err != nil {
+			return config.Config{}, err
+		}
+		index++
+		retries, err := nonNegativeInt(model.fields[index].value, name+" retries")
+		if err != nil {
+			return config.Config{}, err
+		}
+		index++
+		updated.RateLimits[name] = config.RateLimitConfig{TimeoutSeconds: timeout, Retries: retries}
+	}
+	return updated, nil
+}
+
+func formatFloat(value float64) string { return strconv.FormatFloat(value, 'f', -1, 64) }
+
+func positiveInt(value, label string) (int, error) {
+	number, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil || number <= 0 {
+		return 0, fmt.Errorf("%s must be greater than 0", label)
+	}
+	return number, nil
+}
+
+func nonNegativeInt(value, label string) (int, error) {
+	number, err := strconv.Atoi(strings.TrimSpace(value))
+	if err != nil || number < 0 {
+		return 0, fmt.Errorf("%s must be 0 or greater", label)
+	}
+	return number, nil
+}
+
+func nonNegativeFloat(value, label string) (float64, error) {
+	number, err := strconv.ParseFloat(strings.TrimSpace(value), 64)
+	if err != nil || number < 0 {
+		return 0, fmt.Errorf("%s must be 0 or greater", label)
+	}
+	return number, nil
+}
+
+func sanitizeInput(runes []rune) string {
+	return strings.Map(func(character rune) rune {
+		if character == '\n' || character == '\r' || character == '\t' {
+			return ' '
+		}
+		if character < ' ' {
+			return -1
+		}
+		return character
+	}, string(runes))
+}
+
+func (model ConfigModel) View() string {
+	width, height := model.width, model.height
+	if width <= 0 {
+		width = 100
+	}
+	if height <= 0 {
+		height = 30
+	}
+	contentWidth := min(112, max(1, width-4))
+	bodyHeight := max(1, height-4)
+	start := min(max(0, model.cursor-bodyHeight+2), max(0, len(model.fields)-bodyHeight+1))
+	end := min(len(model.fields), start+bodyHeight-1)
+	lines := make([]string, 0, bodyHeight)
+	for index := start; index < end; index++ {
+		field := model.fields[index]
+		prefix := "  "
+		if index == model.cursor {
+			prefix = "> "
+		}
+		value := field.value
+		if field.secret && value != "" {
+			value = strings.Repeat("*", min(12, len([]rune(value))))
+		}
+		if field.boolean {
+			if value == "true" {
+				value = "[x]"
+			} else {
+				value = "[ ]"
+			}
+		}
+		cursor := ""
+		if index == model.cursor && model.editing {
+			cursor = "_"
+		}
+		line := fmt.Sprintf("%s%-28s %s%s", prefix, field.label, value, cursor)
+		line = truncate(line, contentWidth)
+		if index == model.cursor {
+			line = model.accent.Render(line)
+		}
+		lines = append(lines, line)
+	}
+	if model.status != "" {
+		lines = append(lines, model.warning.Render(truncate(model.status, contentWidth)))
+	}
+	for len(lines) < bodyHeight {
+		lines = append(lines, "")
+	}
+	header := truncate(model.faint.Render("(´∀｀)")+"  "+model.brand.Render("文字  moji")+model.faint.Render("  configuration"), contentWidth)
+	rule := model.faint.Render(strings.Repeat("─", contentWidth))
+	help := "up/down: select  enter: edit/toggle  s: save  esc: quit"
+	block := strings.Join([]string{padRight(header, contentWidth), rule, strings.Join(lines, "\n"), rule, truncate(model.faint.Render(help), contentWidth)}, "\n")
+	padding := max(0, (width-contentWidth)/2)
+	if padding == 0 {
+		return block
+	}
+	prefix := strings.Repeat(" ", padding)
+	rows := strings.Split(block, "\n")
+	for index := range rows {
+		rows[index] = prefix + rows[index]
+	}
+	return strings.Join(rows, "\n")
+}
+
+func RunConfig(input io.Reader, output io.Writer, current config.Config, path string, color bool) error {
+	_, err := tea.NewProgram(NewConfigModel(current, path, color), tea.WithInput(input), tea.WithOutput(output), tea.WithAltScreen()).Run()
+	return err
+}

--- a/internal/tui/config_test.go
+++ b/internal/tui/config_test.go
@@ -1,0 +1,76 @@
+package tui
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/microck/moji/internal/config"
+)
+
+func TestConfigModelEditsTogglesAndSaves(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	model := NewConfigModel(config.Default(), path, false)
+	model = updateConfigModel(t, model, tea.KeyMsg{Type: tea.KeyEnter})
+	for range len([]rune(model.fields[0].value)) {
+		model = updateConfigModel(t, model, tea.KeyMsg{Type: tea.KeyBackspace})
+	}
+	model = updateConfigModel(t, model, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune("/tmp/fonts")})
+	model = updateConfigModel(t, model, tea.KeyMsg{Type: tea.KeyEnter})
+
+	model.cursor = 5
+	model = updateConfigModel(t, model, tea.KeyMsg{Type: tea.KeySpace})
+	model.fields[14].value = "9"
+	model.fields[20].value = "21"
+	model.fields[21].value = "4"
+	model = updateConfigModel(t, model, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	if !model.saved {
+		t.Fatalf("config was not saved: %s", model.status)
+	}
+
+	saved, err := config.Load(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if saved.DownloadDir != "/tmp/fonts" || saved.Providers["github"].Enabled || saved.Ranking.Format != 9 ||
+		saved.RateLimits["github"].TimeoutSeconds != 21 || saved.RateLimits["github"].Retries != 4 {
+		t.Fatalf("saved config = %#v", saved)
+	}
+}
+
+func TestConfigModelMasksTokenAndFitsTerminal(t *testing.T) {
+	current := config.Default()
+	current.GitHubToken = "ghp_secret_value"
+	model := NewConfigModel(current, filepath.Join(t.TempDir(), "config.yaml"), false)
+	updated, _ := model.Update(tea.WindowSizeMsg{Width: 48, Height: 12})
+	view := updated.(ConfigModel).View()
+	assertViewFits(t, view, 48, 12)
+	if strings.Contains(view, current.GitHubToken) || !strings.Contains(view, "************") {
+		t.Fatalf("token was exposed or not masked:\n%s", view)
+	}
+}
+
+func TestConfigModelRejectsInvalidValuesWithoutReplacingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "config.yaml")
+	if err := os.WriteFile(path, []byte("sentinel"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	model := NewConfigModel(config.Default(), path, false)
+	model.fields[2].value = "0"
+	model = updateConfigModel(t, model, tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'s'}})
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if model.saved || string(content) != "sentinel" || !strings.Contains(model.status, "greater than 0") {
+		t.Fatalf("saved=%v status=%q content=%q", model.saved, model.status, content)
+	}
+}
+
+func updateConfigModel(t *testing.T, model ConfigModel, message tea.Msg) ConfigModel {
+	t.Helper()
+	updated, _ := model.Update(message)
+	return updated.(ConfigModel)
+}

--- a/internal/tui/home.go
+++ b/internal/tui/home.go
@@ -23,7 +23,7 @@ var mojiWordmark = []string{
 
 func NewHomeModel(search SearchFunc, downloader DownloadFunc, color bool, wantedWeight string, ranking rank.Weights, maximum int, homeHint string) Model {
 	model := NewModel(nil, downloader, color)
-	model.home = true
+	model.screen = screenHome
 	model.search = search
 	model.wantedWeight = wantedWeight
 	model.ranking = ranking
@@ -55,13 +55,13 @@ func (model Model) updateHome(message tea.Msg) (tea.Model, tea.Cmd) {
 			model.status = "Search couldn't start: " + err.Error()
 			return model, nil
 		}
-		model.home = false
+		model.screen = screenResults
 		model.loading = true
 		model.events = events
 		model.status = ""
 		model.all = nil
 		model.visible = nil
-		model.cursor = 0
+		model.resultsWindow.home()
 		model.providerStatus = make(map[string]string)
 		return model, model.waitForEvent()
 	case "backspace":

--- a/internal/tui/results.go
+++ b/internal/tui/results.go
@@ -16,24 +16,37 @@ import (
 
 type DownloadFunc func(provider.Result) (string, error)
 
+type screen int
+
+const (
+	screenHome screen = iota
+	screenResults
+	screenPreview
+	screenHealth
+	screenConfirm
+)
+
 type Model struct {
-	home           bool
+	screen         screen
 	homeHint       string
 	query          string
 	search         SearchFunc
 	all            []provider.Result
 	visible        []provider.Result
-	cursor         int
+	groups         []rank.ResultGroup
+	resultsWindow  listWindow
+	previewWindow  listWindow
+	selectedFiles  map[int]bool
 	filter         string
 	filtering      bool
 	format         string
 	sortMode       int
-	preview        bool
 	detailOffset   int
 	status         string
 	providerStatus map[string]string
 	events         <-chan provider.Event
 	loading        bool
+	returnScreen   screen
 	wantedWeight   string
 	ranking        rank.Weights
 	maximum        int
@@ -42,13 +55,16 @@ type Model struct {
 	accent         lipgloss.Style
 	faint          lipgloss.Style
 	warning        lipgloss.Style
+	success        lipgloss.Style
+	danger         lipgloss.Style
+	providerStyles map[string]lipgloss.Style
 	width          int
 	height         int
 }
 
 type downloadMessage struct {
-	path string
-	err  error
+	paths []string
+	err   error
 }
 
 type eventMessage struct {
@@ -59,13 +75,23 @@ type eventMessage struct {
 func NewModel(results []provider.Result, downloader DownloadFunc, color bool) Model {
 	model := Model{
 		all: append([]provider.Result(nil), results...), downloader: downloader,
-		format: "all", providerStatus: make(map[string]string), ranking: rank.DefaultWeights(),
+		format: "all", providerStatus: make(map[string]string), ranking: rank.DefaultWeights(), screen: screenResults,
+		selectedFiles: make(map[int]bool),
 	}
 	if color {
 		model.brand = lipgloss.NewStyle().Foreground(lipgloss.Color("#FF8C00")).Bold(true)
 		model.accent = lipgloss.NewStyle().Foreground(lipgloss.Color("#FFA500"))
 		model.faint = lipgloss.NewStyle().Foreground(lipgloss.Color("#666666"))
 		model.warning = lipgloss.NewStyle().Foreground(lipgloss.Color("#FFD75F")).Bold(true)
+		model.success = lipgloss.NewStyle().Foreground(lipgloss.Color("#5FAF5F"))
+		model.danger = lipgloss.NewStyle().Foreground(lipgloss.Color("#D75F5F"))
+		model.providerStyles = map[string]lipgloss.Style{
+			"github":    lipgloss.NewStyle().Foreground(lipgloss.Color("#AF87D7")),
+			"getfonts":  lipgloss.NewStyle().Foreground(lipgloss.Color("#5FAFD7")),
+			"registry":  lipgloss.NewStyle().Foreground(lipgloss.Color("#5FAF87")),
+			"websearch": lipgloss.NewStyle().Foreground(lipgloss.Color("#D7AF5F")),
+			"plugins":   lipgloss.NewStyle().Foreground(lipgloss.Color("#D787AF")),
+		}
 	}
 	model.refresh()
 	return model
@@ -96,7 +122,7 @@ func (model Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		return model, nil
 	}
-	if model.home {
+	if model.screen == screenHome {
 		return model.updateHome(message)
 	}
 	switch message := message.(type) {
@@ -118,7 +144,10 @@ func (model Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		if message.err != nil {
 			model.status = "Download failed: " + message.err.Error()
 		} else {
-			model.status = "Downloaded: " + message.path
+			model.status = fmt.Sprintf("Downloaded %d file(s): %s", len(message.paths), strings.Join(message.paths, ", "))
+		}
+		if model.screen == screenConfirm {
+			model.screen = model.returnScreen
 		}
 		return model, nil
 	case tea.KeyMsg:
@@ -142,13 +171,67 @@ func (model Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 			}
 			return model, nil
 		}
-		if model.preview {
+		if model.screen == screenConfirm {
+			switch message.String() {
+			case "y", "Y", "enter":
+				return model, model.downloadSelected()
+			case "n", "N", "esc":
+				model.screen = model.returnScreen
+			}
+			return model, nil
+		}
+		if model.screen == screenHealth {
+			switch message.String() {
+			case "ctrl+c", "q":
+				return model, tea.Quit
+			case "tab", "esc", "H":
+				model.screen = screenResults
+			case "r":
+				if model.search == nil || strings.TrimSpace(model.query) == "" {
+					model.status = "Re-check is available after a search started from the home screen."
+					return model, nil
+				}
+				events, err := model.search(model.query)
+				if err != nil {
+					model.status = "Provider re-check couldn't start: " + err.Error()
+					return model, nil
+				}
+				model.events = events
+				model.loading = true
+				model.providerStatus = make(map[string]string)
+				return model, model.waitForEvent()
+			}
+			return model, nil
+		}
+		if model.screen == screenPreview && model.previewIsFamily() {
+			switch message.String() {
+			case "up", "k":
+				model.previewWindow.move(-1, len(model.currentGroup().Files), model.bodyHeight()-2)
+				return model, nil
+			case "down", "j":
+				model.previewWindow.move(1, len(model.currentGroup().Files), model.bodyHeight()-2)
+				return model, nil
+			case " ":
+				index := model.previewWindow.cursor
+				model.selectedFiles[index] = !model.selectedFiles[index]
+				return model, nil
+			case "a":
+				for index := range model.currentGroup().Files {
+					model.selectedFiles[index] = true
+				}
+				return model, nil
+			case "n":
+				clear(model.selectedFiles)
+				return model, nil
+			}
+		}
+		if model.screen == screenPreview {
 			switch message.String() {
 			case "up", "k":
 				model.detailOffset = max(0, model.detailOffset-1)
 				return model, nil
 			case "down", "j":
-				maximum := max(0, len(model.detailLines(model.visible[model.cursor]))-model.bodyHeight())
+				maximum := max(0, len(model.detailLines(model.visible[model.resultsWindow.cursor]))-model.bodyHeight())
 				model.detailOffset = min(maximum, model.detailOffset+1)
 				return model, nil
 			}
@@ -157,33 +240,45 @@ func (model Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		case "ctrl+c", "q":
 			return model, tea.Quit
 		case "esc":
-			if model.preview {
-				model.preview = false
+			if model.screen == screenPreview || model.screen == screenHealth {
+				model.screen = screenResults
 				model.detailOffset = 0
+				return model, nil
+			}
+			if model.search != nil {
+				model.screen = screenHome
 				return model, nil
 			}
 			return model, tea.Quit
 		case "up", "k":
-			if model.cursor > 0 {
-				model.cursor--
+			if model.screen != screenResults {
+				break
 			}
+			model.resultsWindow.move(-1, len(model.groups), model.resultPageSize())
 		case "down", "j":
-			if model.cursor+1 < len(model.visible) {
-				model.cursor++
+			if model.screen != screenResults {
+				break
 			}
+			model.resultsWindow.move(1, len(model.groups), model.resultPageSize())
 		case "pgup":
-			model.cursor = max(0, model.cursor-model.resultPageSize())
+			model.resultsWindow.move(-model.resultPageSize(), len(model.groups), model.resultPageSize())
 		case "pgdown":
-			model.cursor = min(max(0, len(model.visible)-1), model.cursor+model.resultPageSize())
+			model.resultsWindow.move(model.resultPageSize(), len(model.groups), model.resultPageSize())
 		case "g", "home":
-			model.cursor = 0
+			model.resultsWindow.home()
 		case "G", "end":
-			model.cursor = max(0, len(model.visible)-1)
+			model.resultsWindow.end(len(model.groups), model.resultPageSize())
 		case "enter":
-			if len(model.visible) > 0 {
-				model.preview = true
+			if len(model.groups) > 0 {
+				model.screen = screenPreview
 				model.detailOffset = 0
+				model.previewWindow.home()
+				model.selectAllCurrentGroup()
 			}
+		case "H":
+			model.screen = screenHealth
+		case "tab":
+			model.screen = screenHealth
 		case "/":
 			model.filtering = true
 		case "f":
@@ -195,30 +290,43 @@ func (model Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 				}
 			}
 			model.refresh()
-		case "tab", "o":
+		case "o":
 			model.sortMode = (model.sortMode + 1) % 3
 			model.refresh()
 		case "D":
-			if len(model.visible) == 0 || model.downloader == nil {
+			if len(model.groups) == 0 || model.downloader == nil {
 				return model, nil
 			}
-			selected := model.visible[model.cursor]
-			model.status = "Downloading " + selected.Filename + "..."
-			return model, func() tea.Msg {
-				path, err := model.downloader(selected)
-				return downloadMessage{path: path, err: err}
+			if model.screen != screenPreview {
+				model.selectedFiles = map[int]bool{0: true}
 			}
+			if model.selectedCount() > 3 {
+				model.returnScreen = model.screen
+				model.screen = screenConfirm
+				return model, nil
+			}
+			return model, model.downloadSelected()
 		}
 	}
 	return model, nil
 }
 
 func (model Model) View() string {
-	if model.home {
+	if model.screen == screenHome {
 		return model.viewHome()
 	}
-	if model.preview && len(model.visible) > 0 {
-		result := model.visible[model.cursor]
+	if model.screen == screenHealth {
+		return model.chrome("provider health", model.healthBody(), model.healthHelp())
+	}
+	if model.screen == screenConfirm {
+		body := fmt.Sprintf("\n  Download %d selected files?\n\n  Existing identical files will be reused.", model.selectedCount())
+		return model.chrome("confirm download", body, model.faint.Render("y/enter: download  n/esc: cancel"))
+	}
+	if model.screen == screenPreview && len(model.groups) > 0 {
+		if model.previewIsFamily() {
+			return model.chrome(model.previewContext(), model.familyPreviewBody(), model.familyPreviewHelp())
+		}
+		result := model.currentGroup().Files[0]
 		lines := model.detailLines(result)
 		maximum := max(0, len(lines)-model.bodyHeight())
 		offset := min(model.detailOffset, maximum)
@@ -247,9 +355,9 @@ func (model Model) resultsContext() string {
 		if model.loading {
 			return fmt.Sprintf("finding %d", len(model.visible))
 		}
-		return fmt.Sprintf("%d results", len(model.visible))
+		return fmt.Sprintf("%d groups", len(model.groups))
 	}
-	return fmt.Sprintf("%s %d results  format:%s  sort:%s", verb, len(model.visible), model.format, model.sortName())
+	return fmt.Sprintf("%s %d files in %d groups  format:%s  sort:%s", verb, len(model.visible), len(model.groups), model.format, model.sortName())
 }
 
 func (model Model) resultsBody() string {
@@ -277,7 +385,7 @@ func (model Model) resultsBody() string {
 	if model.status != "" {
 		remaining--
 	}
-	if len(model.visible) == 0 {
+	if len(model.groups) == 0 {
 		lines = append(lines, "", "  No matching results.")
 	} else if remaining > 0 {
 		lines = append(lines, model.resultWindow(remaining)...)
@@ -364,13 +472,9 @@ func (model Model) resultWindow(height int) []string {
 		rowsPerResult = 2
 	}
 	capacity := max(1, height/rowsPerResult)
-	start := min(max(0, model.cursor-capacity+1), max(0, len(model.visible)-capacity))
-	end := min(len(model.visible), start+capacity)
-	lines := make([]string, 0, height)
-	for index := start; index < end; index++ {
-		lines = append(lines, model.resultRow(model.visible[index], index == model.cursor)...)
-	}
-	return lines
+	return renderWindow(&model.resultsWindow, len(model.groups), capacity, func(index int, selected bool) []string {
+		return model.groupRow(model.groups[index], selected)
+	})
 }
 
 func (model Model) resultPageSize() int {
@@ -409,17 +513,41 @@ func (model Model) resultRow(result provider.Result, selected bool) []string {
 		sourceWidth := min(28, max(12, width/4))
 		nameWidth := max(8, width-2-formatWidth-weightWidth-sourceWidth-6)
 		line := prefix + padRight(truncate(result.Filename, nameWidth), nameWidth) + "  " +
-			padRight(format, formatWidth) + " " +
+			padRight(model.formatBadge(format), formatWidth) + " " +
 			padRight(truncate(displayWeight(result.Weight), weightWidth), weightWidth) + " " +
-			truncate(result.Source, sourceWidth)
+			truncate(model.providerTag(result.Source), sourceWidth)
 		return []string{decorate(line)}
 	}
 	name := prefix + truncate(result.Filename, max(1, width-2))
-	metadata := "  " + format + "  " + displayWeight(result.Weight)
+	metadata := "  " + model.formatBadge(format) + "  " + displayWeight(result.Weight)
 	if width >= 42 && result.Source != "" {
-		metadata += "  " + result.Source
+		metadata += "  " + model.providerTag(result.Source)
 	}
 	return []string{decorate(name), decorate(model.faint.Render(truncate(metadata, width)))}
+}
+
+func (model Model) groupRow(group rank.ResultGroup, selected bool) []string {
+	if group.FileCount == 1 {
+		return model.resultRow(group.Files[0], selected)
+	}
+	width := model.contentWidth()
+	prefix := "  "
+	if selected {
+		prefix = "> "
+	}
+	name := group.FamilyName
+	if name == "" {
+		name = group.Files[0].Filename
+	} else {
+		name = titleFamily(name)
+	}
+	formats := strings.ToUpper(strings.Join(group.Formats, "/"))
+	line := fmt.Sprintf("%s%s  %d files  %s  %s", prefix, name, group.FileCount, model.formatBadge(formats), model.providerTag(group.Source))
+	line = truncate(line, width)
+	if selected {
+		line = model.accent.Render(line)
+	}
+	return []string{line}
 }
 
 func (model Model) detailLines(result provider.Result) []string {
@@ -429,7 +557,7 @@ func (model Model) detailLines(result provider.Result) []string {
 	for index := range nameLines {
 		lines[index] = model.accent.Render(nameLines[index])
 	}
-	fields := [][2]string{{"Format", displayFormat(result)}, {"Weight", displayWeight(result.Weight)}, {"Source", result.Source}, {"License", result.License}, {"URL", result.URL}}
+	fields := [][2]string{{"Format", model.formatBadge(displayFormat(result))}, {"Weight", displayWeight(result.Weight)}, {"Source", model.providerTag(result.Source)}, {"License", model.licenseBadge(result.License)}, {"URL", result.URL}}
 	for _, field := range fields {
 		lines = append(lines, wrapCells(field[0]+": "+field[1], width)...)
 	}
@@ -442,10 +570,12 @@ func (model Model) resultsHelp() string {
 		return model.faint.Render("j/k move  enter open  q")
 	case model.contentWidth() < 48:
 		return model.faint.Render("j/k move  enter open  q quit")
+	case model.contentWidth() < 64:
+		return model.faint.Render("j/k browse  enter preview  / filter  tab health  q quit")
 	case model.contentWidth() < 90:
-		return model.faint.Render("up/down browse  enter details  / filter  q quit")
+		return model.faint.Render("j/k browse  enter preview  D get  / filter  tab health  q quit")
 	default:
-		return model.faint.Render("up/down: browse  pgup/dn: page  enter: details  D: download  /: filter  f: format  tab: sort  q: quit")
+		return model.faint.Render("up/down: browse  pgup/dn: page  enter: preview  D: download  /: filter  f: format  o: sort  tab: health  q: quit")
 	}
 }
 
@@ -496,9 +626,16 @@ func wrapCells(value string, width int) []string {
 		}
 		if cut == 0 {
 			_, cut = utf8.DecodeRuneInString(value)
+		} else if cut < len(value) {
+			// Prefer the last word boundary that still uses most of the row. This
+			// avoids visibly splitting prose such as provider warnings while still
+			// allowing long URLs and filenames to make progress.
+			if boundary := strings.LastIndexByte(value[:cut], ' '); boundary >= cut/2 {
+				cut = boundary + 1
+			}
 		}
-		lines = append(lines, value[:cut])
-		value = value[cut:]
+		lines = append(lines, strings.TrimRight(value[:cut], " "))
+		value = strings.TrimLeft(value[cut:], " ")
 	}
 	if len(lines) == 0 {
 		return []string{""}
@@ -560,13 +697,171 @@ func (model *Model) refresh() {
 	case 2:
 		sort.SliceStable(model.visible, func(i, j int) bool { return model.visible[i].SizeBytes < model.visible[j].SizeBytes })
 	}
-	if model.cursor >= len(model.visible) {
-		model.cursor = max(0, len(model.visible)-1)
-	}
+	model.groups = rank.Groups(model.visible)
+	model.resultsWindow.clamp(len(model.groups), model.resultPageSize())
 	if len(model.visible) == 0 {
-		model.preview = false
+		if model.screen == screenPreview {
+			model.screen = screenResults
+		}
 		model.detailOffset = 0
 	}
+}
+
+func (model Model) currentGroup() rank.ResultGroup {
+	if len(model.groups) == 0 {
+		return rank.ResultGroup{}
+	}
+	index := min(len(model.groups)-1, max(0, model.resultsWindow.cursor))
+	return model.groups[index]
+}
+
+func (model Model) previewIsFamily() bool { return len(model.currentGroup().Files) > 1 }
+
+func (model *Model) selectAllCurrentGroup() {
+	model.selectedFiles = make(map[int]bool, len(model.currentGroup().Files))
+	for index := range model.currentGroup().Files {
+		model.selectedFiles[index] = true
+	}
+}
+
+func (model Model) selectedCount() int {
+	count := 0
+	for index := range model.currentGroup().Files {
+		if model.selectedFiles[index] {
+			count++
+		}
+	}
+	return count
+}
+
+func (model Model) downloadSelected() tea.Cmd {
+	group := model.currentGroup()
+	selected := make([]provider.Result, 0, len(group.Files))
+	for index, result := range group.Files {
+		if model.selectedFiles[index] {
+			selected = append(selected, result)
+		}
+	}
+	if len(selected) == 0 {
+		return nil
+	}
+	return func() tea.Msg {
+		paths := make([]string, 0, len(selected))
+		for _, result := range selected {
+			path, err := model.downloader(result)
+			if err != nil {
+				return downloadMessage{paths: paths, err: err}
+			}
+			paths = append(paths, path)
+		}
+		return downloadMessage{paths: paths}
+	}
+}
+
+func (model Model) previewContext() string {
+	group := model.currentGroup()
+	return fmt.Sprintf("family preview  %d/%d selected", model.selectedCount(), len(group.Files))
+}
+
+func (model Model) familyPreviewBody() string {
+	group := model.currentGroup()
+	available := max(1, model.bodyHeight()-2)
+	lines := []string{truncate(fmt.Sprintf("  %s  %s", titleFamily(group.FamilyName), model.providerTag(group.Source)), model.contentWidth()), ""}
+	lines = append(lines, renderWindow(&model.previewWindow, len(group.Files), available, func(index int, active bool) []string {
+		result := group.Files[index]
+		check := "[ ]"
+		if model.selectedFiles[index] {
+			check = "[x]"
+		}
+		prefix := "  "
+		if active {
+			prefix = "> "
+		}
+		line := fmt.Sprintf("%s%s %s  %s  %s", prefix, check, result.Filename, model.formatBadge(displayFormat(result)), displayWeight(result.Weight))
+		line = truncate(line, model.contentWidth())
+		if active {
+			line = model.accent.Render(line)
+		}
+		return []string{line}
+	})...)
+	return strings.Join(lines, "\n")
+}
+
+func (model Model) familyPreviewHelp() string {
+	return model.faint.Render("up/down: browse  space: select  a/n: all/none  D: download  esc: back")
+}
+
+func titleFamily(value string) string {
+	words := strings.Fields(value)
+	for index, word := range words {
+		runes := []rune(word)
+		if len(runes) > 0 {
+			runes[0] = []rune(strings.ToUpper(string(runes[0])))[0]
+			words[index] = string(runes)
+		}
+	}
+	return strings.Join(words, " ")
+}
+
+func (model Model) providerTag(source string) string {
+	name := strings.ToLower(source)
+	for _, providerName := range []string{"github", "getfonts", "registry", "websearch", "plugins"} {
+		if strings.Contains(name, providerName) {
+			label := "[" + providerName + "]"
+			if style, ok := model.providerStyles[providerName]; ok {
+				return style.Render(label)
+			}
+			return label
+		}
+	}
+	return source
+}
+
+func (model Model) formatBadge(format string) string {
+	return model.faint.Render("[" + strings.ToLower(format) + "]")
+}
+
+func (model Model) licenseBadge(license string) string {
+	if license == "" {
+		return model.warning.Render("unknown")
+	}
+	lower := strings.ToLower(license)
+	if strings.Contains(lower, "ofl") || strings.Contains(lower, "apache") {
+		return model.success.Render(license)
+	}
+	if strings.Contains(lower, "commercial") || strings.Contains(lower, "personal") {
+		return model.danger.Render(license)
+	}
+	return model.warning.Render(license)
+}
+
+func (model Model) healthBody() string {
+	if len(model.providerStatus) == 0 {
+		return "\n  No provider activity yet. Start a search to collect health information."
+	}
+	names := make([]string, 0, len(model.providerStatus))
+	for name := range model.providerStatus {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	lines := make([]string, 0, len(names)+2)
+	lines = append(lines, model.faint.Render("  Provider        Latest state"), "")
+	for _, name := range names {
+		state := model.providerStatus[name]
+		dot := model.accent.Render("●")
+		if strings.Contains(state, "failed") || strings.Contains(state, "couldn't") {
+			dot = model.warning.Render("●")
+		}
+		lines = append(lines, truncate(fmt.Sprintf("  %s  %-14s %s", dot, name, state), model.contentWidth()))
+	}
+	if model.status != "" {
+		lines = append(lines, "", model.warning.Render(truncate(model.status, model.contentWidth())))
+	}
+	return strings.Join(lines, "\n")
+}
+
+func (model Model) healthHelp() string {
+	return model.faint.Render("r: re-check  tab/esc: results  q: quit")
 }
 
 func (model Model) sortName() string {

--- a/internal/tui/results.go
+++ b/internal/tui/results.go
@@ -235,6 +235,12 @@ func (model Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 				model.detailOffset = min(maximum, model.detailOffset+1)
 				return model, nil
 			}
+			switch message.String() {
+			case "D", "esc", "q", "ctrl+c", "H":
+				// These keys are handled by the shared screen actions below.
+			default:
+				return model, nil
+			}
 		}
 		switch message.String() {
 		case "ctrl+c", "q":

--- a/internal/tui/results.go
+++ b/internal/tui/results.go
@@ -231,7 +231,7 @@ func (model Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 				model.detailOffset = max(0, model.detailOffset-1)
 				return model, nil
 			case "down", "j":
-				maximum := max(0, len(model.detailLines(model.visible[model.resultsWindow.cursor]))-model.bodyHeight())
+				maximum := max(0, len(model.detailLines(model.currentGroup().Files[0]))-model.bodyHeight())
 				model.detailOffset = min(maximum, model.detailOffset+1)
 				return model, nil
 			}

--- a/internal/tui/results_test.go
+++ b/internal/tui/results_test.go
@@ -216,6 +216,26 @@ func TestLongDetailsScrollWithoutChangingSelectedResult(t *testing.T) {
 	}
 }
 
+func TestSingleFontPreviewScrollsTheSelectedGroup(t *testing.T) {
+	t.Parallel()
+	model := NewModel([]provider.Result{
+		{Filename: "Alpha-Regular.otf", Format: "otf", Source: "fixture"},
+		{Filename: "Alpha-Bold.otf", Format: "otf", Source: "fixture"},
+		{Filename: "Beta-Regular.otf", Format: "otf", Source: "fixture", URL: "https://example.test/" + strings.Repeat("beta-path/", 12) + "tail.otf"},
+	}, nil, false)
+	model.resultsWindow.cursor = 1
+	model.screen = screenPreview
+	model = sizedModel(t, model, 40, 10)
+	for range 20 {
+		updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyDown})
+		model = updated.(Model)
+	}
+	view := model.View()
+	if model.detailOffset <= 1 || !strings.Contains(view, "tail.otf") {
+		t.Fatalf("selected Beta details stopped at offset %d:\n%s", model.detailOffset, view)
+	}
+}
+
 func TestRefreshClosesDetailsWhenSelectedResultDisappears(t *testing.T) {
 	t.Parallel()
 	model := NewModel([]provider.Result{{Filename: "Only.ttf", Format: "ttf"}}, nil, false)

--- a/internal/tui/results_test.go
+++ b/internal/tui/results_test.go
@@ -36,7 +36,7 @@ func TestModelNavigationFilteringPreviewAndFormatCycle(t *testing.T) {
 		{Filename: "Example-Regular.otf", Format: "otf", Source: "fixture", Score: 2},
 		{Filename: "Example-Bold.ttf", Format: "ttf", Source: "fixture", Score: 1},
 	}, nil, false)
-	if !strings.Contains(model.View(), "Found 2 results") {
+	if !strings.Contains(model.View(), "Found 2 files in 1 groups") {
 		t.Fatal(model.View())
 	}
 	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
@@ -46,12 +46,12 @@ func TestModelNavigationFilteringPreviewAndFormatCycle(t *testing.T) {
 	}
 	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	model = updated.(Model)
-	if !model.preview || !strings.Contains(model.View(), "Example-Regular.otf") {
+	if model.screen != screenPreview || !strings.Contains(model.View(), "Example-Regular.otf") {
 		t.Fatal("preview did not open")
 	}
 	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyEsc})
 	model = updated.(Model)
-	if model.preview {
+	if model.screen == screenPreview {
 		t.Fatal("preview did not close")
 	}
 }
@@ -99,7 +99,7 @@ func TestViewsFitSupportedTerminalSizes(t *testing.T) {
 			model := sizedModel(t, NewModel(results, nil, false), size.width, size.height)
 			assertViewFits(t, model.View(), size.width, size.height)
 
-			model.preview = true
+			model.screen = screenPreview
 			assertViewFits(t, model.View(), size.width, size.height)
 
 			home := sizedModel(t, NewHomeModel(nil, nil, false, "", rank.DefaultWeights(), 10, ""), size.width, size.height)
@@ -130,7 +130,7 @@ func TestResultsKeepChromeVisibleAndScrollSelectionIntoView(t *testing.T) {
 	}
 	view := model.View()
 	assertViewFits(t, view, 80, 12)
-	for _, wanted := range []string{"文字  moji", "Found 20 results", "Font-15.otf", "up/down"} {
+	for _, wanted := range []string{"文字  moji", "Found 20 files in 20 groups", "Font-15.otf", "j/k"} {
 		if !strings.Contains(view, wanted) {
 			t.Fatalf("%q is not visible after scrolling:\n%s", wanted, view)
 		}
@@ -147,20 +147,20 @@ func TestResultsSupportPageAndBoundaryNavigation(t *testing.T) {
 
 	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyPgDown})
 	model = updated.(Model)
-	if model.cursor <= 1 {
-		t.Fatalf("page down only moved to result %d", model.cursor)
+	if model.resultsWindow.cursor <= 1 {
+		t.Fatalf("page down only moved to result %d", model.resultsWindow.cursor)
 	}
 
 	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyEnd})
 	model = updated.(Model)
-	if model.cursor != len(results)-1 || !strings.Contains(model.View(), "Font-29.otf") {
-		t.Fatalf("end did not select the last result: cursor=%d\n%s", model.cursor, model.View())
+	if model.resultsWindow.cursor != len(results)-1 || !strings.Contains(model.View(), "Font-29.otf") {
+		t.Fatalf("end did not select the last result: cursor=%d\n%s", model.resultsWindow.cursor, model.View())
 	}
 
 	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyHome})
 	model = updated.(Model)
-	if model.cursor != 0 {
-		t.Fatalf("home selected result %d", model.cursor)
+	if model.resultsWindow.cursor != 0 {
+		t.Fatalf("home selected result %d", model.resultsWindow.cursor)
 	}
 }
 
@@ -183,7 +183,7 @@ func TestLongDetailValuesWrapInsteadOfClipping(t *testing.T) {
 		Filename: "SourceSans3VF-UltraLightItalic.woff2", Format: "woff2", Weight: "ultralight",
 		Source: "fixture", License: "OFL-1.1", URL: "https://example.test/a/very/long/path/to/a/font/file.woff2?download=1",
 	}}, nil, false)
-	model.preview = true
+	model.screen = screenPreview
 	model = sizedModel(t, model, 40, 14)
 	view := model.View()
 	assertViewFits(t, view, 40, 14)
@@ -199,7 +199,7 @@ func TestLongDetailsScrollWithoutChangingSelectedResult(t *testing.T) {
 		{Filename: "First.otf", Format: "otf", URL: "https://example.test/" + strings.Repeat("long-path/", 12) + "first.otf"},
 		{Filename: "Second.otf", Format: "otf", URL: "https://example.test/second.otf"},
 	}, nil, false)
-	model.preview = true
+	model.screen = screenPreview
 	model = sizedModel(t, model, 40, 10)
 	initial := model.View()
 	for range 10 {
@@ -208,8 +208,8 @@ func TestLongDetailsScrollWithoutChangingSelectedResult(t *testing.T) {
 	}
 	view := model.View()
 	assertViewFits(t, view, 40, 10)
-	if model.cursor != 0 {
-		t.Fatalf("detail scrolling changed the selected result to %d", model.cursor)
+	if model.resultsWindow.cursor != 0 {
+		t.Fatalf("detail scrolling changed the selected result to %d", model.resultsWindow.cursor)
 	}
 	if view == initial || !strings.Contains(view, "first.otf") {
 		t.Fatalf("detail viewport did not reveal the URL tail:\n%s", view)
@@ -219,19 +219,19 @@ func TestLongDetailsScrollWithoutChangingSelectedResult(t *testing.T) {
 func TestRefreshClosesDetailsWhenSelectedResultDisappears(t *testing.T) {
 	t.Parallel()
 	model := NewModel([]provider.Result{{Filename: "Only.ttf", Format: "ttf"}}, nil, false)
-	model.preview = true
+	model.screen = screenPreview
 
 	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
 	model = updated.(Model)
-	if model.preview || len(model.visible) != 0 {
-		t.Fatalf("preview=%v visible=%d, want closed preview with no results", model.preview, len(model.visible))
+	if model.screen == screenPreview || len(model.visible) != 0 {
+		t.Fatalf("screen=%v visible=%d, want closed preview with no results", model.screen, len(model.visible))
 	}
 
 	// Scrolling after the refresh must remain safe when the filtered list is empty.
 	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyDown})
 	model = updated.(Model)
-	if model.cursor != 0 {
-		t.Fatalf("empty result cursor moved to %d", model.cursor)
+	if model.resultsWindow.cursor != 0 {
+		t.Fatalf("empty result cursor moved to %d", model.resultsWindow.cursor)
 	}
 }
 
@@ -257,8 +257,8 @@ func TestHomeModelStartsLiveSearchFromTypedQuery(t *testing.T) {
 	model = updated.(Model)
 	updated, command := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
 	model = updated.(Model)
-	if searched != "quicksand" || model.home || !model.loading || command == nil {
-		t.Fatalf("searched=%q home=%v loading=%v command=%v", searched, model.home, model.loading, command != nil)
+	if searched != "quicksand" || model.screen == screenHome || !model.loading || command == nil {
+		t.Fatalf("searched=%q screen=%v loading=%v command=%v", searched, model.screen, model.loading, command != nil)
 	}
 	for command != nil {
 		updated, command = model.Update(command())
@@ -311,8 +311,61 @@ func TestModelDownloadCommandReportsStatus(t *testing.T) {
 	}
 	updated, _ = model.Update(command())
 	model = updated.(Model)
-	if !strings.Contains(model.status, "Downloaded: /tmp/Example.otf") {
+	if !strings.Contains(model.status, "Downloaded 1 file(s): /tmp/Example.otf") {
 		t.Fatal(model.status)
+	}
+}
+
+func TestGroupedResultsOpenSelectableFamilyPreview(t *testing.T) {
+	t.Parallel()
+	model := NewModel([]provider.Result{
+		{Filename: "Example-Regular.otf", Format: "otf", Weight: "regular", Source: "fixture"},
+		{Filename: "Example-Bold.otf", Format: "otf", Weight: "bold", Source: "fixture"},
+	}, nil, false)
+	if len(model.groups) != 1 || model.groups[0].FileCount != 2 {
+		t.Fatalf("groups = %#v", model.groups)
+	}
+	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	if model.screen != screenPreview || !strings.Contains(model.View(), "2/2 selected") {
+		t.Fatalf("family preview missing:\n%s", model.View())
+	}
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeySpace})
+	model = updated.(Model)
+	if model.selectedCount() != 1 || !strings.Contains(model.View(), "1/2 selected") {
+		t.Fatalf("selection did not toggle:\n%s", model.View())
+	}
+}
+
+func TestLargeFamilyDownloadRequiresConfirmation(t *testing.T) {
+	t.Parallel()
+	results := make([]provider.Result, 4)
+	for index, weight := range []string{"Regular", "Light", "Bold", "Black"} {
+		results[index] = provider.Result{Filename: "Example-" + weight + ".otf", Format: "otf", Source: "fixture"}
+	}
+	model := NewModel(results, func(result provider.Result) (string, error) { return "/tmp/" + result.Filename, nil }, false)
+	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	updated, command := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}})
+	model = updated.(Model)
+	if model.screen != screenConfirm || command != nil || !strings.Contains(model.View(), "Download 4 selected files?") {
+		t.Fatalf("confirmation missing:\n%s", model.View())
+	}
+}
+
+func TestProviderHealthScreenUsesStreamedStatuses(t *testing.T) {
+	t.Parallel()
+	model := NewModel(nil, nil, false)
+	model.providerStatus["github"] = "rate limited"
+	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'H'}})
+	model = updated.(Model)
+	if model.screen != screenHealth || !strings.Contains(model.View(), "github") || !strings.Contains(model.View(), "rate limited") {
+		t.Fatalf("provider health missing:\n%s", model.View())
+	}
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyTab})
+	model = updated.(Model)
+	if model.screen != screenResults {
+		t.Fatalf("tab returned to screen %v, want results", model.screen)
 	}
 }
 
@@ -322,7 +375,7 @@ func TestResultsReserveAVisibleRowForStatus(t *testing.T) {
 		results[index] = provider.Result{Filename: fmt.Sprintf("Font-%02d.otf", index), Format: "otf"}
 	}
 	model := sizedModel(t, NewModel(results, nil, false), 80, 12)
-	model.cursor = 15
+	model.resultsWindow.cursor = 15
 	model.status = "Downloaded: /tmp/Font-15.otf"
 
 	view := model.View()

--- a/internal/tui/results_test.go
+++ b/internal/tui/results_test.go
@@ -236,19 +236,56 @@ func TestSingleFontPreviewScrollsTheSelectedGroup(t *testing.T) {
 	}
 }
 
+func TestPreviewKeysCannotRetargetTheSelectedGroup(t *testing.T) {
+	t.Parallel()
+	var downloaded string
+	model := NewModel([]provider.Result{
+		{Filename: "Alpha-Regular.otf", Format: "otf", Source: "fixture"},
+		{Filename: "Alpha-Bold.otf", Format: "otf", Source: "fixture"},
+		{Filename: "Beta-Regular.otf", Format: "otf", Source: "fixture"},
+	}, func(result provider.Result) (string, error) {
+		downloaded = result.Filename
+		return "/tmp/" + result.Filename, nil
+	}, false)
+	model.resultsWindow.cursor = 1
+	model.screen = screenPreview
+	model.selectAllCurrentGroup()
+	for _, key := range []tea.KeyMsg{
+		{Type: tea.KeyPgUp}, {Type: tea.KeyPgDown}, {Type: tea.KeyHome}, {Type: tea.KeyEnd},
+		{Type: tea.KeyRunes, Runes: []rune{'g'}}, {Type: tea.KeyRunes, Runes: []rune{'G'}},
+		{Type: tea.KeyRunes, Runes: []rune{'f'}}, {Type: tea.KeyRunes, Runes: []rune{'o'}},
+		{Type: tea.KeyRunes, Runes: []rune{'/'}}, {Type: tea.KeyEnter},
+	} {
+		updated, _ := model.Update(key)
+		model = updated.(Model)
+	}
+	if model.resultsWindow.cursor != 1 || model.currentGroup().FamilyName != "beta" {
+		t.Fatalf("preview retargeted cursor=%d group=%q", model.resultsWindow.cursor, model.currentGroup().FamilyName)
+	}
+	updated, command := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}})
+	model = updated.(Model)
+	if command == nil {
+		t.Fatal("preview download command is nil")
+	}
+	model.Update(command())
+	if downloaded != "Beta-Regular.otf" {
+		t.Fatalf("downloaded %q, want previewed Beta-Regular.otf", downloaded)
+	}
+}
+
 func TestRefreshClosesDetailsWhenSelectedResultDisappears(t *testing.T) {
 	t.Parallel()
 	model := NewModel([]provider.Result{{Filename: "Only.ttf", Format: "ttf"}}, nil, false)
 	model.screen = screenPreview
 
-	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
-	model = updated.(Model)
+	model.format = "otf"
+	model.refresh()
 	if model.screen == screenPreview || len(model.visible) != 0 {
 		t.Fatalf("screen=%v visible=%d, want closed preview with no results", model.screen, len(model.visible))
 	}
 
 	// Scrolling after the refresh must remain safe when the filtered list is empty.
-	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyDown})
+	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyDown})
 	model = updated.(Model)
 	if model.resultsWindow.cursor != 0 {
 		t.Fatalf("empty result cursor moved to %d", model.resultsWindow.cursor)

--- a/internal/tui/window.go
+++ b/internal/tui/window.go
@@ -1,0 +1,54 @@
+package tui
+
+type listWindow struct {
+	cursor int
+	offset int
+}
+
+func (window *listWindow) move(delta, total, visible int) {
+	if total <= 0 {
+		window.cursor = 0
+		window.offset = 0
+		return
+	}
+	window.cursor = min(total-1, max(0, window.cursor+delta))
+	window.clamp(total, visible)
+}
+
+func (window *listWindow) home() {
+	window.cursor = 0
+	window.offset = 0
+}
+
+func (window *listWindow) end(total, visible int) {
+	window.cursor = max(0, total-1)
+	window.clamp(total, visible)
+}
+
+func (window *listWindow) clamp(total, visible int) (int, int) {
+	if total <= 0 {
+		window.cursor = 0
+		window.offset = 0
+		return 0, 0
+	}
+	visible = max(1, visible)
+	window.cursor = min(total-1, max(0, window.cursor))
+	maximumOffset := max(0, total-visible)
+	window.offset = min(maximumOffset, max(0, window.offset))
+	if window.cursor < window.offset {
+		window.offset = window.cursor
+	}
+	if window.cursor >= window.offset+visible {
+		window.offset = window.cursor - visible + 1
+	}
+	return window.offset, min(total, window.offset+visible)
+}
+
+func renderWindow(window *listWindow, total, visible int, render func(index int, selected bool) []string) []string {
+	start, end := window.clamp(total, visible)
+	lines := make([]string, 0, visible)
+	for index := start; index < end; index++ {
+		lines = append(lines, render(index, index == window.cursor)...)
+	}
+	return lines
+}

--- a/internal/tui/window_test.go
+++ b/internal/tui/window_test.go
@@ -1,0 +1,20 @@
+package tui
+
+import "testing"
+
+func TestListWindowKeepsCursorVisible(t *testing.T) {
+	window := listWindow{}
+	window.move(7, 10, 3)
+	start, end := window.clamp(10, 3)
+	if window.cursor != 7 || start != 5 || end != 8 {
+		t.Fatalf("cursor=%d range=%d:%d", window.cursor, start, end)
+	}
+	window.home()
+	if start, end = window.clamp(10, 3); window.cursor != 0 || start != 0 || end != 3 {
+		t.Fatalf("home cursor=%d range=%d:%d", window.cursor, start, end)
+	}
+	window.end(10, 3)
+	if start, end = window.clamp(10, 3); window.cursor != 9 || start != 7 || end != 10 {
+		t.Fatalf("end cursor=%d range=%d:%d", window.cursor, start, end)
+	}
+}


### PR DESCRIPTION
**Summary**

- replace the editor-based `moji config` flow with a native Bubble Tea configuration form
- expose provider, ranking, timeout, retry, format, token, plugin, cache, and download settings
- add enum-routed home, grouped results, family preview, provider health, and confirmation screens
- extract reusable list-window navigation and add responsive shared chrome
- add selectable family variants, semantic provider/format/license styling, and safe large-family confirmation

**Validation**

- `go test ./...`
- `CGO_ENABLED=1 go test -race ./...`
- `go vet ./...`
- fixed-size 80x24 PTY walkthrough with agent-tui 1.1.0 covering home, live Futura search, grouped results, family preview, confirmation, provider health, config scrolling, and config persistence

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces the editor-based config flow with native TUI screens. The main changes are:

- Native Bubble Tea configuration form with editable provider, ranking, timeout, retry, token, plugin, cache, format, and download settings.
- Screen-based home, grouped results, family preview, provider health, and download confirmation flows.
- Shared list-window navigation for result and preview scrolling.
- Grouped font-family selection with selectable variants and large-family confirmation.
- Updated unit and end-to-end tests for the new TUI behavior.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

The changed paths are covered by focused unit and end-to-end tests, and no blocking correctness or security issues were identified.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Verified the Home screen displays the moji home TUI on an 80x24 PTY with a prompt and a GitHub-disabled hint.
- Verified the initial native config UI appears at 80x24 with the Download directory prefilled and fields that fit within the terminal.
- Verified the config editing flow shows editing, scrolling to the bottom fields including websearch retries, returning to the top, and saving.
- Verified the edited DownloadDir is persisted and read back by the CLI after saving.
- Captured and reviewed the harness walkthrough script and command execution to validate the end-to-end flow.

<a href="https://app.greptile.com/trex/runs/14122451/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| e2e/cli_test.go | Updates end-to-end TUI assertions to match grouped result counts. |
| internal/app/commands.go | Routes `moji config` into the native TUI after checking for an interactive terminal. |
| internal/tui/config.go | Adds the native Bubble Tea configuration model with field editing, validation, masking, and persistence. |
| internal/tui/config_test.go | Covers config editing, token masking, terminal fit, and invalid-save behavior. |
| internal/tui/results.go | Adds enum-routed result, preview, health, and confirmation screens with grouped family selection and shared window navigation. |
| internal/tui/results_test.go | Expands TUI coverage for grouped results, preview navigation regressions, confirmation, provider health, and live limits. |
| internal/tui/window.go | Introduces reusable list-window cursor and offset management. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant App as App.runConfig/runHome
participant ConfigTUI as ConfigModel
participant ResultsTUI as Results Model
participant Providers as Search providers
participant Downloader

User->>App: moji config
App->>App: verify stdin/stdout are terminals
App->>ConfigTUI: RunConfig(current, path)
User->>ConfigTUI: edit/toggle fields
User->>ConfigTUI: s / ctrl+s
ConfigTUI->>ConfigTUI: validate values
ConfigTUI-->>App: save config and exit

User->>App: open home / search query
App->>ResultsTUI: NewHomeModel / NewLiveModel
ResultsTUI->>Providers: start search events
Providers-->>ResultsTUI: status + result events
ResultsTUI->>ResultsTUI: rank, filter, group results
User->>ResultsTUI: preview group / select files
ResultsTUI->>Downloader: download selected files
Downloader-->>ResultsTUI: paths or error
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant App as App.runConfig/runHome
participant ConfigTUI as ConfigModel
participant ResultsTUI as Results Model
participant Providers as Search providers
participant Downloader

User->>App: moji config
App->>App: verify stdin/stdout are terminals
App->>ConfigTUI: RunConfig(current, path)
User->>ConfigTUI: edit/toggle fields
User->>ConfigTUI: s / ctrl+s
ConfigTUI->>ConfigTUI: validate values
ConfigTUI-->>App: save config and exit

User->>App: open home / search query
App->>ResultsTUI: NewHomeModel / NewLiveModel
ResultsTUI->>Providers: start search events
Providers-->>ResultsTUI: status + result events
ResultsTUI->>ResultsTUI: rank, filter, group results
User->>ResultsTUI: preview group / select files
ResultsTUI->>Downloader: download selected files
Downloader-->>ResultsTUI: paths or error
```

</a>

<sub>Reviews (4): Last reviewed commit: ["fix(tui): keep preview navigation scoped..."](https://github.com/microck/moji/commit/334d95e58a1cd72ebaf0ead01684a9151ed24133) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43570235)</sub>

<!-- /greptile_comment -->