### PR TITLE
fix(tui): repair responsive spacing and terminal output

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"net/http"
 	"os"
 	"runtime"
@@ -61,7 +62,9 @@ func (application App) Run(ctx context.Context, args []string) int {
 		return application.fail(err, 1)
 	}
 	if len(args) == 0 {
-		return application.runHome(ctx, current, current.DefaultFormats, options{downloadDir: current.DownloadDir})
+		return runTerminalUI(func() int {
+			return application.runHome(ctx, current, current.DefaultFormats, options{downloadDir: current.DownloadDir})
+		})
 	}
 	if args[0] == "config" {
 		return application.runConfig(current, configPath, args[1:])
@@ -127,7 +130,9 @@ func (application App) Run(ctx context.Context, args []string) int {
 		}
 	}
 	if interactive {
-		return application.runInteractive(ctx, current, query, formats, parsed)
+		return runTerminalUI(func() int {
+			return application.runInteractive(ctx, current, query, formats, parsed)
+		})
 	}
 	results, failures, err := application.search(ctx, current, query, formats, parsed)
 	if err != nil {
@@ -153,6 +158,13 @@ func (application App) Run(ctx context.Context, args []string) int {
 	}
 	application.writeTable(results)
 	return 0
+}
+
+func runTerminalUI(run func() int) int {
+	previous := log.Writer()
+	log.SetOutput(io.Discard)
+	defer log.SetOutput(previous)
+	return run()
 }
 
 func containsHelp(args []string) bool {

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"log"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -267,6 +268,27 @@ func TestHelpUsesPlainProductDescription(t *testing.T) {
 	code := (App{Stdout: &stdout, Stderr: &bytes.Buffer{}}).Run(context.Background(), []string{"--help"})
 	if code != 0 || !strings.Contains(stdout.String(), "a terminal font finder") || strings.Contains(stdout.String(), "cozy") {
 		t.Fatalf("code=%d help=%q", code, stdout.String())
+	}
+}
+
+func TestTerminalUIOwnsProcessOutputAndRestoresLogger(t *testing.T) {
+	var logs bytes.Buffer
+	previous := log.Writer()
+	log.SetOutput(&logs)
+	t.Cleanup(func() { log.SetOutput(previous) })
+
+	if code := runTerminalUI(func() int {
+		log.Print("must not corrupt the alternate screen")
+		return 7
+	}); code != 7 {
+		t.Fatalf("terminal callback returned %d", code)
+	}
+	if logs.Len() != 0 {
+		t.Fatalf("log escaped into terminal output: %q", logs.String())
+	}
+	log.Print("restored")
+	if !strings.Contains(logs.String(), "restored") {
+		t.Fatalf("logger output was not restored: %q", logs.String())
 	}
 }
 

--- a/internal/tui/config.go
+++ b/internal/tui/config.go
@@ -261,8 +261,18 @@ func (model ConfigModel) View() string {
 	}
 	contentWidth := min(112, max(1, width-4))
 	bodyHeight := max(1, height-4)
-	start := min(max(0, model.cursor-bodyHeight+2), max(0, len(model.fields)-bodyHeight+1))
-	end := min(len(model.fields), start+bodyHeight-1)
+	compact := contentWidth < 60
+	rowsPerField := 1
+	if compact {
+		rowsPerField = 2
+	}
+	statusRows := 0
+	if model.status != "" {
+		statusRows = 1
+	}
+	visibleFields := max(1, (bodyHeight-statusRows)/rowsPerField)
+	start := min(max(0, model.cursor-visibleFields+1), max(0, len(model.fields)-visibleFields))
+	end := min(len(model.fields), start+visibleFields)
 	lines := make([]string, 0, bodyHeight)
 	for index := start; index < end; index++ {
 		field := model.fields[index]
@@ -285,12 +295,21 @@ func (model ConfigModel) View() string {
 		if index == model.cursor && model.editing {
 			cursor = "_"
 		}
-		line := fmt.Sprintf("%s%-28s %s%s", prefix, field.label, value, cursor)
-		line = truncate(line, contentWidth)
-		if index == model.cursor {
-			line = model.accent.Render(line)
+		if compact {
+			label := truncate(prefix+field.label, contentWidth)
+			valueLine := truncate("    "+value+cursor, contentWidth)
+			if index == model.cursor {
+				label = model.accent.Render(label)
+				valueLine = model.accent.Render(valueLine)
+			}
+			lines = append(lines, label, valueLine)
+		} else {
+			line := truncate(fmt.Sprintf("%s%-28s %s%s", prefix, field.label, value, cursor), contentWidth)
+			if index == model.cursor {
+				line = model.accent.Render(line)
+			}
+			lines = append(lines, line)
 		}
-		lines = append(lines, line)
 	}
 	if model.status != "" {
 		lines = append(lines, model.warning.Render(truncate(model.status, contentWidth)))
@@ -298,9 +317,18 @@ func (model ConfigModel) View() string {
 	for len(lines) < bodyHeight {
 		lines = append(lines, "")
 	}
-	header := truncate(model.faint.Render("(´∀｀)")+"  "+model.brand.Render("文字  moji")+model.faint.Render("  configuration"), contentWidth)
+	header := model.faint.Render("(´∀｀)") + "  " + model.brand.Render("文字  moji") + model.faint.Render("  configuration")
+	if contentWidth < 34 {
+		header = model.brand.Render("moji") + model.faint.Render("  config")
+	}
+	header = truncate(header, contentWidth)
 	rule := model.faint.Render(strings.Repeat("─", contentWidth))
 	help := "up/down: select  enter: edit/toggle  s: save  esc: quit"
+	if contentWidth < 34 {
+		help = "enter edit  s  q"
+	} else if contentWidth < 48 {
+		help = "j/k select  enter edit  s save  q"
+	}
 	block := strings.Join([]string{padRight(header, contentWidth), rule, strings.Join(lines, "\n"), rule, truncate(model.faint.Render(help), contentWidth)}, "\n")
 	padding := max(0, (width-contentWidth)/2)
 	if padding == 0 {

--- a/internal/tui/config_test.go
+++ b/internal/tui/config_test.go
@@ -52,6 +52,28 @@ func TestConfigModelMasksTokenAndFitsTerminal(t *testing.T) {
 	}
 }
 
+func TestConfigCompactLayoutPutsValuesBelowLabels(t *testing.T) {
+	model := NewConfigModel(config.Default(), filepath.Join(t.TempDir(), "config.yaml"), false)
+	updated, _ := model.Update(tea.WindowSizeMsg{Width: 40, Height: 16})
+	view := updated.(ConfigModel).View()
+	assertViewFits(t, view, 40, 16)
+	if !strings.Contains(view, "> Download directory\n      /home/") {
+		t.Fatalf("compact config did not give the value its own row:\n%s", view)
+	}
+}
+
+func TestConfigMinimumWidthKeepsHeaderAndActionsVisible(t *testing.T) {
+	model := NewConfigModel(config.Default(), filepath.Join(t.TempDir(), "config.yaml"), false)
+	updated, _ := model.Update(tea.WindowSizeMsg{Width: 24, Height: 8})
+	view := updated.(ConfigModel).View()
+	assertViewFits(t, view, 24, 8)
+	for _, wanted := range []string{"moji  config", "enter edit", "s", "q"} {
+		if !strings.Contains(view, wanted) {
+			t.Fatalf("minimum config omitted %q:\n%s", wanted, view)
+		}
+	}
+}
+
 func TestConfigModelRejectsInvalidValuesWithoutReplacingFile(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "config.yaml")
 	if err := os.WriteFile(path, []byte("sentinel"), 0o600); err != nil {

--- a/internal/tui/results.go
+++ b/internal/tui/results.go
@@ -322,11 +322,19 @@ func (model Model) View() string {
 		return model.viewHome()
 	}
 	if model.screen == screenHealth {
-		return model.chrome("provider health", model.healthBody(), model.healthHelp())
+		context := "provider health"
+		if model.contentWidth() < 34 {
+			context = "health"
+		}
+		return model.chrome(context, model.healthBody(), model.healthHelp())
 	}
 	if model.screen == screenConfirm {
 		body := fmt.Sprintf("\n  Download %d selected files?\n\n  Existing identical files will be reused.", model.selectedCount())
-		return model.chrome("confirm download", body, model.faint.Render("y/enter: download  n/esc: cancel"))
+		context := "confirm download"
+		if model.contentWidth() < 34 {
+			context = "confirm"
+		}
+		return model.chrome(context, body, model.confirmHelp())
 	}
 	if model.screen == screenPreview && len(model.groups) > 0 {
 		if model.previewIsFamily() {
@@ -453,7 +461,11 @@ func (model Model) centerLine(line string, boundaryWidth int) string {
 
 func (model Model) chrome(context, body, help string) string {
 	width := model.contentWidth()
-	header := truncate(model.renderBrand()+model.faint.Render("  "+context), width)
+	header := model.renderBrand() + model.faint.Render("  "+context)
+	if width < 34 {
+		header = model.brand.Render("moji") + model.faint.Render("  "+context)
+	}
+	header = truncate(header, width)
 	rule := model.faint.Render(strings.Repeat("─", width))
 	bodyLines := strings.Split(body, "\n")
 	if body == "" {
@@ -548,6 +560,14 @@ func (model Model) groupRow(group rank.ResultGroup, selected bool) []string {
 		name = titleFamily(name)
 	}
 	formats := strings.ToUpper(strings.Join(group.Formats, "/"))
+	if width < 72 {
+		nameLine := prefix + truncate(name, max(1, width-2))
+		metadata := fmt.Sprintf("  %d files  %s  %s", group.FileCount, model.formatBadge(formats), model.providerTag(group.Source))
+		if selected {
+			return []string{model.accent.Render(truncate(nameLine, width)), model.accent.Render(truncate(metadata, width))}
+		}
+		return []string{truncate(nameLine, width), model.faint.Render(truncate(metadata, width))}
+	}
 	line := fmt.Sprintf("%s%s  %d files  %s  %s", prefix, name, group.FileCount, model.formatBadge(formats), model.providerTag(group.Source))
 	line = truncate(line, width)
 	if selected {
@@ -573,9 +593,9 @@ func (model Model) detailLines(result provider.Result) []string {
 func (model Model) resultsHelp() string {
 	switch {
 	case model.contentWidth() < 34:
-		return model.faint.Render("j/k move  enter open  q")
+		return model.faint.Render("j/k move  enter view  q")
 	case model.contentWidth() < 48:
-		return model.faint.Render("j/k move  enter open  q quit")
+		return model.faint.Render("j/k move  enter view  q quit")
 	case model.contentWidth() < 64:
 		return model.faint.Render("j/k browse  enter preview  / filter  tab health  q quit")
 	case model.contentWidth() < 90:
@@ -766,6 +786,9 @@ func (model Model) downloadSelected() tea.Cmd {
 
 func (model Model) previewContext() string {
 	group := model.currentGroup()
+	if model.contentWidth() < 34 {
+		return fmt.Sprintf("preview %d/%d", model.selectedCount(), len(group.Files))
+	}
 	return fmt.Sprintf("family preview  %d/%d selected", model.selectedCount(), len(group.Files))
 }
 
@@ -794,7 +817,23 @@ func (model Model) familyPreviewBody() string {
 }
 
 func (model Model) familyPreviewHelp() string {
+	if model.contentWidth() < 34 {
+		return model.faint.Render("j/k  space  D  esc")
+	}
+	if model.contentWidth() < 48 {
+		return model.faint.Render("j/k move  space select  D get  esc")
+	}
+	if model.contentWidth() < 72 {
+		return model.faint.Render("j/k browse  space select  D download  esc back")
+	}
 	return model.faint.Render("up/down: browse  space: select  a/n: all/none  D: download  esc: back")
+}
+
+func (model Model) confirmHelp() string {
+	if model.contentWidth() < 34 {
+		return model.faint.Render("y yes  n no")
+	}
+	return model.faint.Render("y/enter: download  n/esc: cancel")
 }
 
 func titleFamily(value string) string {
@@ -854,10 +893,7 @@ func (model Model) healthBody() string {
 	lines = append(lines, model.faint.Render("  Provider        Latest state"), "")
 	for _, name := range names {
 		state := model.providerStatus[name]
-		dot := model.accent.Render("●")
-		if strings.Contains(state, "failed") || strings.Contains(state, "couldn't") {
-			dot = model.warning.Render("●")
-		}
+		dot := model.healthDot(state)
 		lines = append(lines, truncate(fmt.Sprintf("  %s  %-14s %s", dot, name, state), model.contentWidth()))
 	}
 	if model.status != "" {
@@ -866,7 +902,26 @@ func (model Model) healthBody() string {
 	return strings.Join(lines, "\n")
 }
 
+func (model Model) healthDot(state string) string {
+	switch {
+	case strings.HasPrefix(state, "done"):
+		return model.success.Render("●")
+	case strings.Contains(state, "failed"), strings.Contains(state, "couldn't"):
+		return model.danger.Render("●")
+	case strings.Contains(state, "searching"), strings.Contains(state, "rate limited"):
+		return model.warning.Render("●")
+	default:
+		return model.faint.Render("●")
+	}
+}
+
 func (model Model) healthHelp() string {
+	if model.contentWidth() < 34 {
+		return model.faint.Render("r check  tab back  q")
+	}
+	if model.contentWidth() < 48 {
+		return model.faint.Render("r check  tab/esc back  q quit")
+	}
 	return model.faint.Render("r: re-check  tab/esc: results  q: quit")
 }
 

--- a/internal/tui/results_test.go
+++ b/internal/tui/results_test.go
@@ -174,6 +174,15 @@ func TestResponsiveHelpFitsWithoutLosingCommandsMidLabel(t *testing.T) {
 		if got := lipgloss.Width(model.detailHelp()); got > model.contentWidth() {
 			t.Fatalf("detail help is %d cells in %d available cells", got, model.contentWidth())
 		}
+		if got := lipgloss.Width(model.familyPreviewHelp()); got > model.contentWidth() {
+			t.Fatalf("family preview help is %d cells in %d available cells", got, model.contentWidth())
+		}
+		if got := lipgloss.Width(model.healthHelp()); got > model.contentWidth() {
+			t.Fatalf("health help is %d cells in %d available cells", got, model.contentWidth())
+		}
+		if got := lipgloss.Width(model.confirmHelp()); got > model.contentWidth() {
+			t.Fatalf("confirm help is %d cells in %d available cells", got, model.contentWidth())
+		}
 	}
 }
 
@@ -391,6 +400,27 @@ func TestGroupedResultsOpenSelectableFamilyPreview(t *testing.T) {
 	model = updated.(Model)
 	if model.selectedCount() != 1 || !strings.Contains(model.View(), "1/2 selected") {
 		t.Fatalf("selection did not toggle:\n%s", model.View())
+	}
+}
+
+func TestGroupedResultUsesTwoRowsAtNarrowWidths(t *testing.T) {
+	model := NewModel([]provider.Result{
+		{Filename: "Example-Regular.otf", Format: "otf", Source: "github"},
+		{Filename: "Example-Bold.otf", Format: "otf", Source: "github"},
+	}, nil, false)
+	model = sizedModel(t, model, 60, 20)
+	rows := model.groupRow(model.groups[0], true)
+	if len(rows) != 2 || !strings.Contains(rows[0], "Example") || !strings.Contains(rows[1], "2 files") {
+		t.Fatalf("narrow group rows = %#v", rows)
+	}
+}
+
+func TestVeryNarrowChromePrioritizesContext(t *testing.T) {
+	model := sizedModel(t, NewModel([]provider.Result{{Filename: "Example.otf", Format: "otf"}}, nil, false), 24, 8)
+	view := model.View()
+	assertViewFits(t, view, 24, 8)
+	if !strings.Contains(view, "moji  1 groups") || strings.Contains(view, "文字") {
+		t.Fatalf("narrow header did not prioritize context:\n%s", view)
 	}
 }
 


### PR DESCRIPTION
**Summary**

- keep process diagnostics from corrupting Bubble Tea's alternate screen, including provider startup before the first render
- use responsive two-row layouts for compact config fields and grouped results
- prioritize useful context and complete controls on narrow terminals
- color provider-health states semantically

**Root cause**

The interactive search started provider goroutines before Bubble Tea fully owned the terminal, so an HTTP/2 diagnostic could scroll and corrupt the alternate screen. Several layouts also reserved desktop-sized label and help regions at narrow widths, leaving values and required actions clipped.

**Validation**

- `go test -count=1 ./...`
- `CGO_ENABLED=1 go test -race ./internal/tui ./internal/app`
- `go vet ./...`
- agent-tui matrix at 24x8, 40x16, 60x20, 80x24, and 120x40
- color and `NO_COLOR` passes
- home, live search, filtering, sorting, paging, resizing, previews, selection, confirmation, provider health, and config editing
- installed-binary smoke with GitHub, GetFonts, registry, and Kagi websearch enabled

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR repairs terminal UI behavior for interactive search and compact layouts. The main changes are:

- Suppresses process log output while Bubble Tea owns the terminal.
- Adds compact two-row rendering for configuration fields and grouped results.
- Shortens headers and help text for narrow result, preview, confirm, and health screens.
- Adds semantic provider-health dot colors.
- Extends tests for logger restoration and narrow terminal rendering.

<h3>Confidence Score: 5/5</h3>

Safe to merge with low risk.

Changes are localized to terminal rendering and logger redirection around interactive TUI execution. Tests cover the new narrow-width layouts and logger restoration behavior. No correctness or security issues were found in the changed paths.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- Collected PTY terminal captures and command logs for the general contract validation proof and ran a diagnostic scan on alternate-screen segments; no disqualifying strings were found.
- Completed compact-terminal proof and ran the fallback changed-package tests; provider-backed search/results flows were not exercised because of the stop condition.
- Validated the diagnostic scan results to verify the absence of issues in the alternate-screen data.
- Prepared and linked artifact set, including multiple PTY logs and Go and shellscript artifacts, to support review of the proof.

<a href="https://app.greptile.com/trex/runs/14146239/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/app/app.go | Wraps home and interactive search TUI execution with temporary log suppression to prevent process diagnostics from writing into the terminal UI. |
| internal/app/app_test.go | Adds coverage that terminal UI execution discards log output during the callback and restores the prior logger afterward. |
| internal/tui/config.go | Updates configuration TUI rendering to use compact two-row fields, abbreviated headers, and shorter help text on narrow terminals. |
| internal/tui/config_test.go | Adds compact configuration layout tests for value placement and minimum-width header/action visibility. |
| internal/tui/results.go | Improves results, preview, confirmation, and health screen responsiveness with narrower labels, two-row grouped results, and semantic health indicators. |
| internal/tui/results_test.go | Extends TUI tests to cover narrow help text, grouped result rows, and compact chrome behavior. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant App as internal/app.App.Run
participant Guard as runTerminalUI
participant Logger as log package
participant TUI as Bubble Tea TUI
participant Provider as provider goroutines

User->>App: Launch home or interactive search
App->>Guard: Wrap terminal UI callback
Guard->>Logger: Save writer and set output to io.Discard
Guard->>TUI: Run home/search interface
TUI->>Provider: Start or receive provider events
Provider-->>Logger: Diagnostic log output
Logger-->>Guard: Discard while TUI owns terminal
TUI-->>Guard: Exit code
Guard->>Logger: Restore previous writer
Guard-->>App: Return exit code
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant App as internal/app.App.Run
participant Guard as runTerminalUI
participant Logger as log package
participant TUI as Bubble Tea TUI
participant Provider as provider goroutines

User->>App: Launch home or interactive search
App->>Guard: Wrap terminal UI callback
Guard->>Logger: Save writer and set output to io.Discard
Guard->>TUI: Run home/search interface
TUI->>Provider: Start or receive provider events
Provider-->>Logger: Diagnostic log output
Logger-->>Guard: Discard while TUI owns terminal
TUI-->>Guard: Exit code
Guard->>Logger: Restore previous writer
Guard-->>App: Return exit code
```

</a>

<sub>Reviews (1): Last reviewed commit: ["fix(tui): repair responsive spacing and ..."](https://github.com/microck/moji/commit/3d32a165845f2bc01fa7f805d193677a0c6bd226) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43625679)</sub>

<!-- /greptile_comment -->