### PR TITLE
feat: improve GitHub auth and family-focused TUI

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,10 @@ moji get "Futura entire family" --download-dir ~/Downloads/moji
 
 the default GetFonts and registry providers work without an account. GitHub's
 repository, tree, and release search also uses its small unauthenticated
-allowance. set `GITHUB_TOKEN` or `github_token` to add Code Search and higher
-limits. the TUI points this out when GitHub search is limited.
+allowance. Moji automatically uses an existing authenticated `gh` session when
+GitHub CLI is installed. `GITHUB_TOKEN` and `github_token` take precedence and
+also enable Code Search and higher limits. the TUI points this out when GitHub
+search is limited.
 
 the `websearch` provider automatically uses
 [`kagi-cli`](https://github.com/Microck/kagi-cli) when it is installed. Run

--- a/docs/content/docs/explanation/ranking-and-families.mdx
+++ b/docs/content/docs/explanation/ranking-and-families.mdx
@@ -50,6 +50,20 @@ highest-ranked result, then selects matching family files from that same
 source. This keeps the set coherent and rewards sources that contain several
 weights.
 
+The TUI shows these source-bounded bundles as family candidates. A one-file
+candidate remains a family candidate in the results list instead of changing
+into an apparent child file. Open a candidate to inspect its individual
+filenames. Raw source provenance remains available in machine output, while the
+results grid shows only the provider name.
+
+Opening a multi-file candidate selects one highest-ranked file for each
+normalized style category. Categories combine weight and posture, such as
+Regular, Regular Italic, Bold, and Bold Italic; variable fonts form a separate
+category for each posture. This keeps duplicate paths or alternate formats
+from entering the default family download without treating Roman and Italic
+variable fonts as substitutes. The preview still allows selecting every file
+or toggling individual alternatives.
+
 If a member fails byte validation, the whole staged group is discarded before
 Moji tries the next family source. A completed family never combines weights
 from unrelated repositories or hosts.
@@ -58,5 +72,6 @@ from unrelated repositories or hosts.
 
 A high score means a result matches the query and quality heuristics. It does
 not prove authorship, integrity beyond the validated file format, or a license
-grant. Source and license fields remain visible so the user can make that
-decision.
+grant. Machine output preserves source and license fields for callers that need
+to evaluate that provenance; the TUI keeps the results grid focused on provider
+identity and exposes the direct URL when a candidate is opened.

--- a/docs/content/docs/how-to/github-authentication.mdx
+++ b/docs/content/docs/how-to/github-authentication.mdx
@@ -3,8 +3,22 @@ title: Enable GitHub search
 description: Configure the token required by the GitHub Code Search provider.
 ---
 
-GitHub Code Search requires authentication. Moji does not register the GitHub
-provider until a token or custom endpoint is available.
+GitHub Code Search requires authentication. Without a token, Moji keeps using
+GitHub's bounded unauthenticated repository, tree, and release search.
+
+## Use an existing GitHub CLI login
+
+If GitHub CLI is installed and already authenticated, Moji automatically uses
+its token for GitHub.com:
+
+```sh
+gh auth login
+moji "Futura" --provider github
+```
+
+Moji only reads an existing login with `gh auth token`. It never starts a login
+flow, stores the CLI token in Moji's config, or prints the token. An explicit
+`GITHUB_TOKEN`, `github_token`, or `--token-stdin` value takes precedence.
 
 ## Use an environment variable
 
@@ -49,7 +63,10 @@ stored value.
 
 If Moji reports that GitHub search is not configured:
 
-1. confirm that `GITHUB_TOKEN` is exported in the same shell;
-2. run `moji config show` and confirm that `GitHubToken` is `[redacted]`;
-3. confirm that the token can read public repositories; and
-4. retry with `--provider getfonts` to keep working without GitHub.
+1. run `gh auth status` if GitHub CLI should supply the token;
+2. confirm that `GITHUB_TOKEN` is exported in the same shell when using the
+   environment variable;
+3. run `moji config show` and confirm that `GitHubToken` is `[redacted]` when
+   using the stored token;
+4. confirm that the token can read public repositories; and
+5. retry with `--provider getfonts` to keep working without GitHub.

--- a/docs/content/docs/reference/cli.mdx
+++ b/docs/content/docs/reference/cli.mdx
@@ -26,6 +26,19 @@ waiting for input.
 Search enabled providers. When stdin and stdout are terminals, open the live
 TUI. Otherwise print a table. `--json` always prints structured output.
 
+The results TUI keeps the query visible and presents every result as a
+source-bounded family candidate, including candidates that contain only one
+file. The Family, Files, Format, and Provider columns use one grid, and the
+Provider column shows only the provider name. `enter` opens the candidate and
+reveals its individual files. The family preview initially selects the
+highest-ranked file for each normalized weight and posture, so duplicate Bold
+files do not all enter a family download. `a` selects every file when needed;
+`space` toggles individual files. `D` downloads the current selection. The
+default order recommends the strongest match, while the other orders put the
+largest families or preferred formats first. Navigation and the current
+position remain in the footer. Provider details remain available from the
+Health screen instead of occupying settled results.
+
 ### `moji get <query>`
 
 Search, rank, select, and download. A trailing weight is parsed from the query.
@@ -61,7 +74,7 @@ Delete cached provider responses and recreate the cache directory.
 | `--token-stdin` | | off | Read a GitHub token from standard input |
 | `--allow-insecure` | | off | Allow HTTP for a source you explicitly trust |
 | `--help` | `-h` | | Show help and ignore other arguments |
-| `--version` | | | Print `0.2.1` |
+| `--version` | | | Print the installed Moji version |
 
 Flags may appear before or after query words. Values can use a separate
 argument or `--flag=value`.
@@ -77,10 +90,13 @@ argument or `--flag=value`.
 | `page up` / `page down` | Move by one visible page |
 | `home` / `g` | Select the first result |
 | `end` / `G` | Select the last result |
+| `space` | Toggle the active file in a family preview |
+| `a` / `n` | Select all files or clear the selection in a family preview |
 | `D` | Download selected result |
 | `/` | Filter loaded results |
 | `f` | Cycle all, OTF, TTF, and WOFF2 |
-| `tab` / `o` | Cycle score, format, and size sorting |
+| `o` | Cycle best-match, most-files, and preferred-format ordering |
+| `tab` / `H` | Open provider health |
 | `esc` | Close details or exit |
 | `q` / `Ctrl-C` | Exit |
 

--- a/docs/content/docs/reference/configuration.mdx
+++ b/docs/content/docs/reference/configuration.mdx
@@ -86,4 +86,6 @@ providers:
 | `TERM=dumb` | Disable styled terminal output |
 
 Per-invocation flags override general config defaults. Provider availability
-still depends on required credentials and instance settings.
+still depends on required credentials and instance settings. If no explicit
+token is available, Moji uses an existing authenticated GitHub CLI session for
+GitHub.com without saving its token.

--- a/docs/content/docs/reference/providers.mdx
+++ b/docs/content/docs/reference/providers.mdx
@@ -19,15 +19,18 @@ GetFonts is the zero-configuration default.
 - Name: `github`
 - Default: enabled
 - Authentication: optional; required for Code Search
-- Token sources: `GITHUB_TOKEN`, config, or `--token-stdin`
+- Token sources, in precedence order: `GITHUB_TOKEN`, config or
+  `--token-stdin`, then an existing authenticated GitHub CLI session
 - Queries: adaptive filename and contextual variants within GitHub's remaining allowance
 - Result trust: untrusted
 
 GitHub's general unauthenticated REST allowance does not unlock Code Search;
 the Code Search endpoint returns `Requires authentication`. Without a token,
 Moji skips that guaranteed failure and uses its bounded repository, tree, and
-release search. The TUI home screen explains that `GITHUB_TOKEN` enables code
-search and higher limits.
+release search. When no explicit token exists, Moji reads `gh auth token` if
+GitHub CLI is installed and already authenticated. It does not initiate login
+or persist that token. The TUI home screen explains when GitHub search remains
+limited.
 
 Code Search generates literal TTF and OTF filenames, space, hyphen, underscore,
 and compact filename conventions, then broader contextual forms. Moji reads

--- a/e2e/cli_test.go
+++ b/e2e/cli_test.go
@@ -77,12 +77,12 @@ func TestMojiBinaryEndToEnd(t *testing.T) {
 		t.Fatalf("non-interactive default returned %d results, want 10: %s", count, searchOutput)
 	}
 
-	interactiveOutput := runTUI(t, binary, []string{"MojiFixture", "--no-cache"}, environment, nil, "Found 12 files in 12 groups")
-	if !bytes.Contains(interactiveOutput, []byte("Found 12 files in 12 groups")) || !bytes.Contains(interactiveOutput, []byte("MojiFixture-Regular.otf")) {
+	interactiveOutput := runTUI(t, binary, []string{"MojiFixture", "--no-cache"}, environment, nil, "12 options  12 files")
+	if !bytes.Contains(interactiveOutput, []byte("12 options  12 files")) || !bytes.Contains(interactiveOutput, []byte("Moji Fixture")) {
 		t.Fatalf("TUI did not render fixture result: %q", interactiveOutput)
 	}
-	homeOutput := runTUI(t, binary, nil, environment, []byte("MojiFixture\r"), "Found 12 files in 12 groups")
-	if !bytes.Contains(homeOutput, []byte("Type a font name")) || !bytes.Contains(homeOutput, []byte("Found 12 files in 12 groups")) {
+	homeOutput := runTUI(t, binary, nil, environment, []byte("MojiFixture\r"), "12 options  12 files")
+	if !bytes.Contains(homeOutput, []byte("Type a font name")) || !bytes.Contains(homeOutput, []byte("12 options  12 files")) {
 		t.Fatalf("home TUI did not transition to results: %q", homeOutput)
 	}
 

--- a/internal/aggregator/aggregator.go
+++ b/internal/aggregator/aggregator.go
@@ -72,6 +72,7 @@ func (a Aggregator) searchProvider(ctx context.Context, source provider.Provider
 				}
 				if event.Type == provider.EventResult {
 					count++
+					event.Result.Provider = name
 				}
 				event.Provider = name
 				if !emit(ctx, out, event) {

--- a/internal/aggregator/aggregator_test.go
+++ b/internal/aggregator/aggregator_test.go
@@ -80,6 +80,9 @@ func TestSearchRetriesOneProviderWithoutLosingAnother(t *testing.T) {
 	for event := range aggregate.Search(context.Background(), "Example", []string{"otf"}) {
 		if event.Type == provider.EventResult {
 			results++
+			if event.Result.Provider != event.Provider {
+				t.Fatalf("result provider = %q, event provider = %q", event.Result.Provider, event.Provider)
+			}
 		}
 		if event.Status == provider.StateThrottled {
 			throttled = true

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -62,6 +62,7 @@ func (application App) Run(ctx context.Context, args []string) int {
 		return application.fail(err, 1)
 	}
 	if len(args) == 0 {
+		current = resolveGitHubToken(ctx, current, "")
 		return runTerminalUI(func() int {
 			return application.runHome(ctx, current, current.DefaultFormats, options{downloadDir: current.DownloadDir})
 		})
@@ -111,6 +112,7 @@ func (application App) Run(ctx context.Context, args []string) int {
 		}
 		current.GitHubToken = strings.TrimSpace(string(token))
 	}
+	current = resolveGitHubToken(ctx, current, parsed.providers)
 	formats := current.DefaultFormats
 	if parsed.formats != "" {
 		formats, err = config.ParseFormats(parsed.formats)

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -9,12 +9,85 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/microck/moji/internal/cache"
+	"github.com/microck/moji/internal/config"
 	"github.com/microck/moji/internal/provider"
 )
+
+func TestGitHubCLITokenIsAnEphemeralFallback(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the executable fixture uses a POSIX shell")
+	}
+	root := t.TempDir()
+	executable := filepath.Join(root, "gh")
+	fixture := `#!/bin/sh
+test "$GH_PROMPT_DISABLED" = "1" || exit 8
+test "$1" = "auth" || exit 9
+test "$2" = "token" || exit 10
+test "$3" = "--hostname" || exit 11
+test "$4" = "github.com" || exit 12
+printf '  cli-token  '
+`
+	if err := os.WriteFile(executable, []byte(fixture), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", root)
+	t.Setenv("GITHUB_TOKEN", "")
+
+	current := config.Default()
+	resolved := resolveGitHubToken(context.Background(), current, "")
+	if resolved.GitHubToken != "cli-token" {
+		t.Fatalf("resolved token = %q", resolved.GitHubToken)
+	}
+	if current.GitHubToken != "" {
+		t.Fatalf("CLI token mutated the loaded config: %q", current.GitHubToken)
+	}
+}
+
+func TestExplicitGitHubTokensPrecedeGitHubCLI(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	current := config.Default()
+	current.GitHubToken = "config-token"
+	if got := resolveGitHubToken(context.Background(), current, "").GitHubToken; got != "config-token" {
+		t.Fatalf("config token = %q", got)
+	}
+
+	t.Setenv("GITHUB_TOKEN", "environment-token")
+	if got := resolveGitHubToken(context.Background(), current, "").Token(); got != "environment-token" {
+		t.Fatalf("environment token = %q", got)
+	}
+}
+
+func TestGitHubCLITokenRunsOnlyForDefaultSelectedGitHub(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("the executable fixture uses a POSIX shell")
+	}
+	root := t.TempDir()
+	marker := filepath.Join(root, "called")
+	executable := filepath.Join(root, "gh")
+	fixture := "#!/bin/sh\nprintf called > '" + marker + "'\nprintf token\n"
+	if err := os.WriteFile(executable, []byte(fixture), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", root)
+	t.Setenv("GITHUB_TOKEN", "")
+
+	current := config.Default()
+	resolveGitHubToken(context.Background(), current, "getfonts")
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("GitHub CLI ran for a getfonts-only search: %v", err)
+	}
+
+	current.Providers["github"] = config.ProviderConfig{Enabled: true, Instance: "https://example.test"}
+	resolveGitHubToken(context.Background(), current, "github")
+	if _, err := os.Stat(marker); !os.IsNotExist(err) {
+		t.Fatalf("GitHub CLI ran for a custom endpoint: %v", err)
+	}
+}
 
 func TestRunSearchJSONAndGetDownload(t *testing.T) {
 	font := append([]byte("OTTO"), make([]byte, 32)...)

--- a/internal/app/search.go
+++ b/internal/app/search.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"os/exec"
 	"sort"
 	"strings"
@@ -17,6 +18,45 @@ import (
 	"github.com/microck/moji/internal/rank"
 	"github.com/microck/moji/internal/tui"
 )
+
+const githubCLITokenTimeout = 2 * time.Second
+
+// resolveGitHubToken adds an authenticated GitHub CLI session as the final
+// credential source for this invocation. The returned config is a copy, so a
+// token owned by gh can reach the provider without ever being saved by Moji.
+func resolveGitHubToken(ctx context.Context, current config.Config, requested string) config.Config {
+	github := current.Providers["github"]
+	if current.Token() != "" || github.Instance != "" || !githubProviderSelected(github.Enabled, requested) {
+		return current
+	}
+	executable, err := exec.LookPath("gh")
+	if err != nil {
+		return current
+	}
+	commandCtx, cancel := context.WithTimeout(ctx, githubCLITokenTimeout)
+	defer cancel()
+	command := exec.CommandContext(commandCtx, executable, "auth", "token", "--hostname", "github.com")
+	command.Env = append(os.Environ(), "GH_PROMPT_DISABLED=1")
+	command.Stderr = nil
+	output, err := command.Output()
+	if err != nil {
+		return current
+	}
+	current.GitHubToken = strings.TrimSpace(string(output))
+	return current
+}
+
+func githubProviderSelected(enabled bool, requested string) bool {
+	if requested == "" || requested == "all" {
+		return enabled
+	}
+	for _, raw := range strings.Split(requested, ",") {
+		if strings.EqualFold(strings.TrimSpace(raw), "github") {
+			return true
+		}
+	}
+	return false
+}
 
 func (application App) search(ctx context.Context, current config.Config, query string, formats []string, parsed options) ([]provider.Result, []string, error) {
 	events, providerCount, err := application.searchEvents(ctx, current, query, formats, parsed)
@@ -136,7 +176,7 @@ func (application App) runHome(ctx context.Context, current config.Config, forma
 	homeHint := ""
 	github := current.Providers["github"]
 	if github.Enabled && current.Token() == "" && github.Instance == "" {
-		homeHint = "GitHub search is limited. Set GITHUB_TOKEN to search code and more repositories."
+		homeHint = "GitHub search is limited. Run gh auth login or set GITHUB_TOKEN to search code and more repositories."
 	} else if !github.Enabled {
 		homeHint = "GitHub search is off. Enable it in the config to search more repositories."
 	}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -69,6 +69,7 @@ type Result struct {
 	Variable      bool    `json:"variable,omitempty" yaml:"variable,omitempty"`
 	ArchiveFormat string  `json:"archive_format,omitempty" yaml:"archive_format,omitempty"`
 	ArchiveMember string  `json:"archive_member,omitempty" yaml:"archive_member,omitempty"`
+	Provider      string  `json:"-" yaml:"-"`
 	FamilyGroup   string  `json:"-" yaml:"-"`
 	Score         float64 `json:"score,omitempty" yaml:"score,omitempty"`
 }
@@ -77,7 +78,7 @@ func UniqueResults(results []Result) []Result {
 	seen := make(map[string]bool, len(results))
 	unique := make([]Result, 0, len(results))
 	for _, result := range results {
-		key := resultIdentity(result)
+		key := ResultIdentity(result)
 		if seen[key] {
 			continue
 		}
@@ -87,7 +88,9 @@ func UniqueResults(results []Result) []Result {
 	return unique
 }
 
-func resultIdentity(result Result) string {
+// ResultIdentity returns the same stable key used to deduplicate streamed
+// results, so interactive selections can survive live ranking updates.
+func ResultIdentity(result Result) string {
 	if result.URL != "" {
 		return result.URL + "\x00" + result.ArchiveMember
 	}

--- a/internal/provider/websearch.go
+++ b/internal/provider/websearch.go
@@ -40,7 +40,7 @@ func (source WebSearch) Search(ctx context.Context, query string, formats []stri
 	for backends > 0 {
 		select {
 		case event := <-backendEvents:
-			key := resultIdentity(event.Result)
+			key := ResultIdentity(event.Result)
 			if event.Type != EventResult || !seen[key] {
 				if event.Type == EventResult {
 					seen[key] = true
@@ -96,7 +96,7 @@ func (source WebSearch) searchSearXNG(ctx context.Context, query string, formats
 		}
 		successes++
 		for _, result := range search.results {
-			key := resultIdentity(result)
+			key := ResultIdentity(result)
 			if !seen[key] {
 				seen[key] = true
 				out <- Event{Type: EventResult, Result: result}

--- a/internal/rank/rank.go
+++ b/internal/rank/rank.go
@@ -397,7 +397,9 @@ func ParseIntent(input string) Intent {
 }
 
 type ResultGroup struct {
+	GroupID    string
 	FamilyName string
+	Provider   string
 	Source     string
 	Files      []provider.Result
 	Weights    []string
@@ -425,7 +427,7 @@ func Groups(results []provider.Result) []ResultGroup {
 			}
 			index = len(groups)
 			indices[key] = index
-			groups = append(groups, ResultGroup{FamilyName: tags.Family, Source: result.Source, familyRank: familyRank})
+			groups = append(groups, ResultGroup{GroupID: key, FamilyName: tags.Family, Provider: result.Provider, Source: result.Source, familyRank: familyRank})
 		}
 		group := &groups[index]
 		group.Files = append(group.Files, result)
@@ -501,5 +503,16 @@ func appendUnique(values []string, value string) []string {
 }
 
 func formatValue(format string) int {
-	return map[string]int{"otf": 4, "ttf": 3, "woff2": 2, "woff": 1}[format]
+	order := PreferredFormatOrder(format)
+	if order == 7 {
+		return 0
+	}
+	return 7 - order
+}
+
+func PreferredFormatOrder(format string) int {
+	if order, ok := map[string]int{"otf": 0, "ttf": 1, "dfont": 2, "pfb": 3, "woff2": 4, "woff": 5, "pfm": 6}[strings.ToLower(format)]; ok {
+		return order
+	}
+	return 7
 }

--- a/internal/tui/home.go
+++ b/internal/tui/home.go
@@ -63,6 +63,7 @@ func (model Model) updateHome(message tea.Msg) (tea.Model, tea.Cmd) {
 		model.visible = nil
 		model.resultsWindow.home()
 		model.providerStatus = make(map[string]string)
+		model.providerStates = make(map[string]provider.State)
 		return model, model.waitForEvent()
 	case "backspace":
 		runes := []rune(model.query)

--- a/internal/tui/results.go
+++ b/internal/tui/results.go
@@ -44,6 +44,7 @@ type Model struct {
 	detailOffset   int
 	status         string
 	providerStatus map[string]string
+	providerStates map[string]provider.State
 	events         <-chan provider.Event
 	loading        bool
 	returnScreen   screen
@@ -57,6 +58,8 @@ type Model struct {
 	warning        lipgloss.Style
 	success        lipgloss.Style
 	danger         lipgloss.Style
+	secondary      lipgloss.Style
+	selection      lipgloss.Style
 	providerStyles map[string]lipgloss.Style
 	width          int
 	height         int
@@ -72,19 +75,29 @@ type eventMessage struct {
 	open  bool
 }
 
+type previewSnapshot struct {
+	groupID, activeFile string
+	selectedFiles       map[string]bool
+}
+
 func NewModel(results []provider.Result, downloader DownloadFunc, color bool) Model {
 	model := Model{
 		all: append([]provider.Result(nil), results...), downloader: downloader,
-		format: "all", providerStatus: make(map[string]string), ranking: rank.DefaultWeights(), screen: screenResults,
+		format: "all", providerStatus: make(map[string]string), providerStates: make(map[string]provider.State), ranking: rank.DefaultWeights(), screen: screenResults,
 		selectedFiles: make(map[int]bool),
+		selection:     lipgloss.NewStyle().Reverse(true),
 	}
 	if color {
 		model.brand = lipgloss.NewStyle().Foreground(lipgloss.Color("#FF8C00")).Bold(true)
 		model.accent = lipgloss.NewStyle().Foreground(lipgloss.Color("#FFA500"))
-		model.faint = lipgloss.NewStyle().Foreground(lipgloss.Color("#666666"))
+		model.faint = lipgloss.NewStyle().Foreground(lipgloss.Color("#858585"))
+		model.secondary = lipgloss.NewStyle().Foreground(lipgloss.Color("#B0B0B0"))
 		model.warning = lipgloss.NewStyle().Foreground(lipgloss.Color("#FFD75F")).Bold(true)
 		model.success = lipgloss.NewStyle().Foreground(lipgloss.Color("#5FAF5F"))
 		model.danger = lipgloss.NewStyle().Foreground(lipgloss.Color("#D75F5F"))
+		model.selection = lipgloss.NewStyle().
+			Foreground(lipgloss.Color("#FFA500")).
+			Bold(true)
 		model.providerStyles = map[string]lipgloss.Style{
 			"github":    lipgloss.NewStyle().Foreground(lipgloss.Color("#AF87D7")),
 			"getfonts":  lipgloss.NewStyle().Foreground(lipgloss.Color("#5FAFD7")),
@@ -134,10 +147,12 @@ func (model Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 		}
 		event := message.event
 		if event.Type == provider.EventResult {
+			event.Result.Provider = event.Provider
 			model.all = provider.UniqueResults(append(model.all, event.Result))
 			model.refresh()
 		} else {
 			model.providerStatus[event.Provider] = eventStatus(event)
+			model.providerStates[event.Provider] = event.Status
 		}
 		return model, model.waitForEvent()
 	case downloadMessage:
@@ -199,6 +214,7 @@ func (model Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 				model.events = events
 				model.loading = true
 				model.providerStatus = make(map[string]string)
+				model.providerStates = make(map[string]provider.State)
 				return model, model.waitForEvent()
 			}
 			return model, nil
@@ -216,9 +232,7 @@ func (model Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 				model.selectedFiles[index] = !model.selectedFiles[index]
 				return model, nil
 			case "a":
-				for index := range model.currentGroup().Files {
-					model.selectedFiles[index] = true
-				}
+				model.selectAllCurrentGroup()
 				return model, nil
 			case "n":
 				clear(model.selectedFiles)
@@ -279,7 +293,7 @@ func (model Model) Update(message tea.Msg) (tea.Model, tea.Cmd) {
 				model.screen = screenPreview
 				model.detailOffset = 0
 				model.previewWindow.home()
-				model.selectAllCurrentGroup()
+				model.selectRecommendedCurrentGroup()
 			}
 		case "H":
 			model.screen = screenHealth
@@ -361,40 +375,14 @@ func (model Model) View() string {
 }
 
 func (model Model) resultsContext() string {
-	verb := "Found"
-	if model.loading {
-		verb = "Finding"
+	if model.contentWidth() < 34 {
+		return "results"
 	}
-	if model.contentWidth() < 48 {
-		if model.loading {
-			return fmt.Sprintf("finding %d", len(model.visible))
-		}
-		return fmt.Sprintf("%d groups", len(model.groups))
-	}
-	return fmt.Sprintf("%s %d files in %d groups  format:%s  sort:%s", verb, len(model.visible), len(model.groups), model.format, model.sortName())
+	return "search results"
 }
 
 func (model Model) resultsBody() string {
-	lines := make([]string, 0, model.bodyHeight())
-	if len(model.providerStatus) > 0 {
-		names := make([]string, 0, len(model.providerStatus))
-		for name := range model.providerStatus {
-			names = append(names, name)
-		}
-		sort.Strings(names)
-		statuses := make([]string, 0, len(names))
-		for _, name := range names {
-			statuses = append(statuses, name+": "+model.providerStatus[name])
-		}
-		lines = append(lines, model.faint.Render(truncate(strings.Join(statuses, "  "), model.contentWidth())))
-	}
-	if model.filtering || model.filter != "" {
-		cursor := ""
-		if model.filtering {
-			cursor = "_"
-		}
-		lines = append(lines, truncate("Filter: "+model.filter+cursor, model.contentWidth()))
-	}
+	lines := model.resultsPrelude()
 	remaining := model.bodyHeight() - len(lines)
 	if model.status != "" {
 		remaining--
@@ -410,11 +398,118 @@ func (model Model) resultsBody() string {
 	return strings.Join(lines, "\n")
 }
 
+func (model Model) resultsPrelude() []string {
+	query := model.query
+	if query == "" {
+		query = "all fonts"
+	}
+	lines := []string{truncate(model.faint.Render("Query  ")+model.secondary.Render(query), model.contentWidth())}
+	compactFilter := model.bodyHeight() < 6 && (model.filtering || model.filter != "")
+	compactStatus := model.bodyHeight() < 6 && model.status != ""
+	if !compactFilter && !compactStatus {
+		lines = append(lines, model.resultsToolbar())
+	}
+	if model.bodyHeight() >= 7 {
+		if recommendation := model.resultsRecommendation(); recommendation != "" {
+			lines = append(lines, recommendation)
+		}
+	}
+	if model.loading && model.bodyHeight() >= 7 {
+		if progress := model.providerProgress(); progress != "" {
+			lines = append(lines, model.warning.Render(progress))
+		}
+	} else if model.bodyHeight() >= 7 {
+		attention := model.providerAttention()
+		if attention != "" {
+			lines = append(lines, model.warning.Render(attention))
+		}
+	}
+	if model.filtering || model.filter != "" {
+		cursor := ""
+		if model.filtering {
+			cursor = "_"
+		}
+		lines = append(lines, truncate("Filter  "+model.filter+cursor, model.contentWidth()))
+	}
+	if len(model.groups) > 0 && !newResultsLayout(model.contentWidth()).stacked && model.bodyHeight()-len(lines) >= 2 {
+		lines = append(lines, model.resultsHeading())
+	}
+	return lines
+}
+
+func (model Model) resultsToolbar() string {
+	left := fmt.Sprintf("%d options  %d files", len(model.groups), len(model.visible))
+	if model.contentWidth() < 52 {
+		return model.secondary.Render(truncate(left, model.contentWidth()))
+	}
+	right := fmt.Sprintf("Format %s  Order %s", displayFormatFilter(model.format), displaySort(model.sortName()))
+	return model.secondary.Render(joinSides(left, right, model.contentWidth()))
+}
+
+func (model Model) resultsRecommendation() string {
+	if model.sortMode != 0 || len(model.groups) == 0 {
+		return ""
+	}
+	group := model.groups[0]
+	format := strings.ToUpper(strings.Join(group.Formats, "/"))
+	label := "Recommended"
+	if model.loading {
+		label = "Best so far"
+	}
+	description := ""
+	if group.FileCount > 1 {
+		description = fmt.Sprintf("%d-file %s family - match + coverage", group.FileCount, format)
+	} else {
+		description = fmt.Sprintf("%s file - strongest match", format)
+	}
+	if model.contentWidth() < 52 {
+		if !model.loading {
+			label = "Best"
+		}
+		if group.FileCount > 1 {
+			description = fmt.Sprintf("%d-file family", group.FileCount)
+		} else {
+			description = format + " file"
+		}
+	}
+	return truncate(model.accent.Render(label)+model.secondary.Render("  "+description+"  ")+model.providerTag(group.Provider), model.contentWidth())
+}
+
+func (model Model) providerProgress() string {
+	if len(model.providerStates) == 0 {
+		return "Searching providers"
+	}
+	finished := 0
+	for _, state := range model.providerStates {
+		if state == provider.StateDone || state == provider.StateFailed {
+			finished++
+		}
+	}
+	return fmt.Sprintf("Searching providers  %d/%d finished", finished, len(model.providerStates))
+}
+
+func (model Model) providerAttention() string {
+	count := 0
+	for _, state := range model.providerStates {
+		if state == provider.StateFailed || state == provider.StateThrottled {
+			count++
+		}
+	}
+	if count == 0 {
+		return ""
+	}
+	noun := "providers need"
+	if count == 1 {
+		noun = "provider needs"
+	}
+	return fmt.Sprintf("%d %s attention - open Health", count, noun)
+}
+
 func (model Model) renderBrand() string {
 	return model.faint.Render("(´∀｀)") + "  " + model.brand.Render("文字  moji")
 }
 
-const maxContentWidth = 112
+const maxContentWidth = 118
 
 func (model Model) termWidth() int {
 	if model.width <= 0 {
@@ -432,7 +527,10 @@ func (model Model) termHeight() int {
 
 func (model Model) contentWidth() int {
 	width := model.termWidth()
-	if width >= 32 {
+	switch {
+	case width >= 80:
+		width -= 8
+	case width >= 32:
 		width -= 4
 	}
 	return min(maxContentWidth, max(1, width))
@@ -478,102 +576,201 @@ func (model Model) chrome(context, body, help string) string {
 		bodyLines = append(bodyLines, "")
 	}
 	for index := range bodyLines {
-		bodyLines[index] = truncate(bodyLines[index], width)
+		bodyLines[index] = padRight(truncate(bodyLines[index], width), width)
 	}
-	parts := []string{padRight(header, width), rule, strings.Join(bodyLines, "\n"), rule, truncate(help, width)}
+	parts := []string{padRight(header, width), rule, strings.Join(bodyLines, "\n"), rule, padRight(truncate(help, width), width)}
 	return model.center(strings.Join(parts, "\n"))
 }
 
+type resultsLayout struct {
+	stacked                                         bool
+	nameWidth, countWidth, formatWidth, sourceWidth int
+}
+
+type previewLayout struct {
+	stacked                             bool
+	nameWidth, formatWidth, weightWidth int
+}
+
+func newResultsLayout(width int) resultsLayout {
+	layout := resultsLayout{stacked: width < 52, countWidth: 5, formatWidth: 9}
+	if layout.stacked {
+		return layout
+	}
+	layout.sourceWidth = 10
+	// Two cells are reserved for the cursor and three spaces separate the four
+	// columns. The family name absorbs every remaining cell.
+	layout.nameWidth = max(8, width-2-layout.countWidth-layout.formatWidth-layout.sourceWidth-3)
+	return layout
+}
+
+func newPreviewLayout(width int) previewLayout {
+	layout := previewLayout{stacked: width < 52, formatWidth: 8, weightWidth: 10}
+	if !layout.stacked {
+		// The cursor, checkbox, and three separators consume eight cells.
+		layout.nameWidth = max(8, width-8-layout.formatWidth-layout.weightWidth)
+	}
+	return layout
+}
+
+func (model Model) resultsHeading() string {
+	layout := newResultsLayout(model.contentWidth())
+	line := "  " + padRight("Family", layout.nameWidth) + " " +
+		padLeft("Files", layout.countWidth) + " " +
+		padRight("Format", layout.formatWidth) + " " +
+		padRight("Provider", layout.sourceWidth)
+	return model.secondary.Render(padRight(truncate(line, model.contentWidth()), model.contentWidth()))
+}
+
+func (model Model) previewHeading(layout previewLayout) string {
+	line := "      " + padRight("File", layout.nameWidth) + " " +
+		padRight("Format", layout.formatWidth) + " " +
+		padRight("Weight", layout.weightWidth)
+	return model.secondary.Render(padRight(truncate(line, model.contentWidth()), model.contentWidth()))
+}
+
+func (model Model) previewFileRows(layout previewLayout, prefix, check string, result provider.Result, active bool) []string {
+	format := strings.ToUpper(displayFormat(result))
+	weight := displayWeight(result.Weight)
+	if layout.stacked {
+		nameLine := padRight(truncate(prefix+check+" "+result.Filename, model.contentWidth()), model.contentWidth())
+		metadataLine := padRight(truncate("      "+padRight(format, layout.formatWidth)+" "+weight, model.contentWidth()), model.contentWidth())
+		if active {
+			return []string{model.accent.Render(nameLine), model.accent.Render(metadataLine)}
+		}
+		return []string{nameLine, model.secondary.Render(metadataLine)}
+	}
+	line := prefix + check + " " +
+		padRight(truncate(result.Filename, layout.nameWidth), layout.nameWidth) + " " +
+		padRight(truncate(format, layout.formatWidth), layout.formatWidth) + " " +
+		padRight(truncate(weight, layout.weightWidth), layout.weightWidth)
+	line = padRight(truncate(line, model.contentWidth()), model.contentWidth())
+	if active {
+		return []string{model.accent.Render(line)}
+	}
+	return []string{line}
+}
+
+func (model Model) compactPreviewFileRow(prefix, check string, result provider.Result, active bool) []string {
+	format := strings.ToUpper(displayFormat(result))
+	weight := displayWeight(result.Weight)
+	formatWidth := min(5, lipgloss.Width(format))
+	weightWidth := min(8, lipgloss.Width(weight))
+	fixedWidth := lipgloss.Width(prefix) + lipgloss.Width(check) + 3 + formatWidth + weightWidth
+	nameWidth := max(1, model.contentWidth()-fixedWidth)
+	line := prefix + check + " " +
+		padRight(truncate(result.Filename, nameWidth), nameWidth) + " " +
+		padRight(truncate(format, formatWidth), formatWidth) + " " +
+		padRight(truncate(weight, weightWidth), weightWidth)
+	line = padRight(truncate(line, model.contentWidth()), model.contentWidth())
+	if active {
+		line = model.accent.Render(line)
+	}
+	return []string{line}
+}
+
 func (model Model) resultWindow(height int) []string {
+	layout := newResultsLayout(model.contentWidth())
+	if layout.stacked && height < 2 {
+		start, _ := model.resultsWindow.clamp(len(model.groups), 1)
+		if len(model.groups) == 0 || height < 1 {
+			return nil
+		}
+		return []string{model.compactResultRow(model.groups[start], start == model.resultsWindow.cursor)}
+	}
 	rowsPerResult := 1
-	if model.contentWidth() < 72 {
+	if layout.stacked {
 		rowsPerResult = 2
 	}
 	capacity := max(1, height/rowsPerResult)
-	return renderWindow(&model.resultsWindow, len(model.groups), capacity, func(index int, selected bool) []string {
+	lines := renderWindow(&model.resultsWindow, len(model.groups), capacity, func(index int, selected bool) []string {
 		return model.groupRow(model.groups[index], selected)
 	})
+	return lines[:min(len(lines), max(0, height))]
 }
 
 func (model Model) resultPageSize() int {
-	height := model.bodyHeight()
+	height := model.bodyHeight() - len(model.resultsPrelude())
 	if model.status != "" {
 		height--
 	}
-	if len(model.providerStatus) > 0 {
-		height--
-	}
-	if model.filtering || model.filter != "" {
-		height--
-	}
-	if model.contentWidth() < 72 {
+	if newResultsLayout(model.contentWidth()).stacked {
 		height /= 2
 	}
 	return max(1, height)
 }
 
-func (model Model) resultRow(result provider.Result, selected bool) []string {
-	width := model.contentWidth()
-	prefix := "  "
-	if selected {
-		prefix = "> "
-	}
-	decorate := func(line string) string {
-		line = truncate(line, width)
-		if selected {
-			return model.accent.Render(line)
-		}
-		return line
-	}
-	format := displayFormat(result)
-	if width >= 72 {
-		formatWidth, weightWidth := 7, 11
-		sourceWidth := min(28, max(12, width/4))
-		nameWidth := max(8, width-2-formatWidth-weightWidth-sourceWidth-6)
-		line := prefix + padRight(truncate(result.Filename, nameWidth), nameWidth) + "  " +
-			padRight(model.formatBadge(format), formatWidth) + " " +
-			padRight(truncate(displayWeight(result.Weight), weightWidth), weightWidth) + " " +
-			truncate(model.providerTag(result.Source), sourceWidth)
-		return []string{decorate(line)}
-	}
-	name := prefix + truncate(result.Filename, max(1, width-2))
-	metadata := "  " + model.formatBadge(format) + "  " + displayWeight(result.Weight)
-	if width >= 42 && result.Source != "" {
-		metadata += "  " + model.providerTag(result.Source)
-	}
-	return []string{decorate(name), decorate(model.faint.Render(truncate(metadata, width)))}
-}
-
 func (model Model) groupRow(group rank.ResultGroup, selected bool) []string {
-	if group.FileCount == 1 {
-		return model.resultRow(group.Files[0], selected)
-	}
-	width := model.contentWidth()
-	prefix := "  "
-	if selected {
-		prefix = "> "
-	}
 	name := group.FamilyName
 	if name == "" {
 		name = group.Files[0].Filename
 	} else {
 		name = titleFamily(name)
 	}
-	formats := strings.ToUpper(strings.Join(group.Formats, "/"))
-	if width < 72 {
-		nameLine := prefix + truncate(name, max(1, width-2))
-		metadata := fmt.Sprintf("  %d files  %s  %s", group.FileCount, model.formatBadge(formats), model.providerTag(group.Source))
-		if selected {
-			return []string{model.accent.Render(truncate(nameLine, width)), model.accent.Render(truncate(metadata, width))}
-		}
-		return []string{truncate(nameLine, width), model.faint.Render(truncate(metadata, width))}
-	}
-	line := fmt.Sprintf("%s%s  %d files  %s  %s", prefix, name, group.FileCount, model.formatBadge(formats), model.providerTag(group.Source))
-	line = truncate(line, width)
+	return model.renderResultRow(name, group.FileCount, strings.ToUpper(strings.Join(group.Formats, "/")), group.Provider, selected)
+}
+
+func (model Model) renderResultRow(name string, count int, format, providerName string, selected bool) []string {
+	width := model.contentWidth()
+	layout := newResultsLayout(width)
+	cursor := " "
 	if selected {
-		line = model.accent.Render(line)
+		cursor = ">"
 	}
+	prefix := cursor + " "
+	plainProvider := displayProvider(providerName)
+	if layout.stacked {
+		nameLine := prefix + truncate(name, max(1, width-lipgloss.Width(prefix)))
+		metadata := "  " + padLeft(fmt.Sprintf("%d", count), layout.countWidth) + " " + padRight(format, layout.formatWidth)
+		if width >= 34 && plainProvider != "" {
+			metadata += " " + plainProvider
+		}
+		rows := []string{padRight(truncate(nameLine, width), width), padRight(truncate(metadata, width), width)}
+		if selected {
+			for index := range rows {
+				rows[index] = model.selection.Render(rows[index])
+			}
+		} else {
+			metadataLine := model.secondary.Render("  " + padLeft(fmt.Sprintf("%d", count), layout.countWidth) + " " + padRight(format, layout.formatWidth))
+			if width >= 34 && plainProvider != "" {
+				sourceWidth := max(1, width-lipgloss.Width(metadataLine)-1)
+				metadataLine += " " + model.renderProvider(providerName, sourceWidth)
+			}
+			rows[1] = padRight(truncate(metadataLine, width), width)
+		}
+		return rows
+	}
+	nameCell := padRight(truncate(name, layout.nameWidth), layout.nameWidth)
+	plainLine := prefix + nameCell + " " +
+		padLeft(fmt.Sprintf("%d", count), layout.countWidth) + " " +
+		padRight(truncate(format, layout.formatWidth), layout.formatWidth) + " " +
+		padRight(truncate(plainProvider, layout.sourceWidth), layout.sourceWidth)
+	plainLine = padRight(truncate(plainLine, width), width)
+	if selected {
+		return []string{model.selection.Render(plainLine)}
+	}
+	line := prefix + nameCell + " " +
+		padLeft(fmt.Sprintf("%d", count), layout.countWidth) + " " +
+		padRight(truncate(format, layout.formatWidth), layout.formatWidth) + " " +
+		model.renderProvider(providerName, layout.sourceWidth)
+	line = padRight(truncate(line, width), width)
 	return []string{line}
+}
+
+func (model Model) compactResultRow(group rank.ResultGroup, selected bool) string {
+	name := titleFamily(group.FamilyName)
+	if name == "" {
+		name = group.Files[0].Filename
+	}
+	prefix := "  "
+	if selected {
+		prefix = "> "
+	}
+	line := padRight(truncate(prefix+name, model.contentWidth()), model.contentWidth())
+	if selected {
+		return model.selection.Render(line)
+	}
+	return line
 }
 
 func (model Model) detailLines(result provider.Result) []string {
@@ -583,7 +780,7 @@ func (model Model) detailLines(result provider.Result) []string {
 	for index := range nameLines {
 		lines[index] = model.accent.Render(nameLines[index])
 	}
-	fields := [][2]string{{"Format", model.formatBadge(displayFormat(result))}, {"Weight", displayWeight(result.Weight)}, {"Source", model.providerTag(result.Source)}, {"License", model.licenseBadge(result.License)}, {"URL", result.URL}}
+	fields := [][2]string{{"Format", model.formatBadge(displayFormat(result))}, {"Weight", displayWeight(result.Weight)}, {"Provider", model.providerTag(result.Provider)}, {"License", model.licenseBadge(result.License)}, {"URL", result.URL}}
 	for _, field := range fields {
 		lines = append(lines, wrapCells(field[0]+": "+field[1], width)...)
 	}
@@ -591,18 +788,23 @@ func (model Model) detailLines(result provider.Result) []string {
 }
 
 func (model Model) resultsHelp() string {
-	switch {
-	case model.contentWidth() < 34:
-		return model.faint.Render("j/k move  enter view  q")
-	case model.contentWidth() < 48:
-		return model.faint.Render("j/k move  enter view  q quit")
-	case model.contentWidth() < 64:
-		return model.faint.Render("j/k browse  enter preview  / filter  tab health  q quit")
-	case model.contentWidth() < 90:
-		return model.faint.Render("j/k browse  enter preview  D get  / filter  tab health  q quit")
-	default:
-		return model.faint.Render("up/down: browse  pgup/dn: page  enter: preview  D: download  /: filter  f: format  o: sort  tab: health  q: quit")
+	width := model.contentWidth()
+	position := "0/0"
+	if len(model.groups) > 0 {
+		position = fmt.Sprintf("%d/%d", model.resultsWindow.cursor+1, len(model.groups))
 	}
+	left := "j/k enter D"
+	switch {
+	case width >= 90:
+		left = "j/k move  enter review  D top file  / filter  f format  o order  H health  q quit"
+	case width >= 64:
+		left = "j/k move  enter review  D top  / filter  f fmt  o order  H"
+	case width >= 48:
+		left = "j/k  enter  D  /  f format  o order  H"
+	case width >= 34:
+		left = "j/k enter D / f o H"
+	}
+	return model.secondary.Render(joinSides(left, position, width))
 }
 
 func (model Model) detailHelp() string {
@@ -630,6 +832,54 @@ func truncate(value string, width int) string {
 
 func padRight(value string, width int) string {
 	return value + strings.Repeat(" ", max(0, width-lipgloss.Width(value)))
+}
+
+func padLeft(value string, width int) string {
+	return strings.Repeat(" ", max(0, width-lipgloss.Width(value))) + value
+}
+
+func joinSides(left, right string, width int) string {
+	right = truncate(right, width)
+	available := width - lipgloss.Width(right)
+	if available <= 1 {
+		return padRight(right, width)
+	}
+	left = truncate(left, available-2)
+	gap := max(2, width-lipgloss.Width(left)-lipgloss.Width(right))
+	return padRight(truncate(left+strings.Repeat(" ", gap)+right, width), width)
+}
+
+func displayFormatFilter(format string) string {
+	if format == "" || strings.EqualFold(format, "all") {
+		return "All"
+	}
+	return strings.ToUpper(format)
+}
+
+func displaySort(sort string) string {
+	if sort == "score" {
+		return "Best match"
+	}
+	if sort == "" {
+		return "Best match"
+	}
+	return strings.ToUpper(sort[:1]) + sort[1:]
+}
+
+func displayProvider(providerName string) string {
+	if providerName == "" {
+		return "unknown"
+	}
+	return "[" + strings.ToLower(providerName) + "]"
+}
+
+func (model Model) renderProvider(providerName string, width int) string {
+	providerName = strings.ToLower(providerName)
+	label := displayProvider(providerName)
+	if style, ok := model.providerStyles[providerName]; ok {
+		label = style.Render(label)
+	}
+	return padRight(truncate(label, width), width)
 }
 
 func wrapCells(value string, width int) []string {
@@ -698,6 +948,10 @@ func eventStatus(event provider.Event) string {
 }
 
 func (model *Model) refresh() {
+	// Live provider events can reorder both groups and their files. Capture the
+	// reviewed identities before ranking again so a numeric cursor never points
+	// at a different download after the refresh.
+	preview := model.capturePreview()
 	model.visible = model.visible[:0]
 	filter := strings.ToLower(model.filter)
 	for _, result := range rank.Results(model.all, model.query, model.wantedWeight, model.ranking) {
@@ -708,7 +962,7 @@ func (model *Model) refresh() {
 		if model.format != "all" && result.Format != model.format {
 			continue
 		}
-		searchable := strings.ToLower(result.Filename + " " + result.Weight + " " + result.Source)
+		searchable := strings.ToLower(result.Filename + " " + result.Weight + " " + result.Provider + " " + result.Source)
 		if filter != "" && !strings.Contains(searchable, filter) {
 			continue
 		}
@@ -717,13 +971,20 @@ func (model *Model) refresh() {
 			break
 		}
 	}
+	model.groups = rank.Groups(model.visible)
 	switch model.sortMode {
 	case 1:
-		sort.SliceStable(model.visible, func(i, j int) bool { return model.visible[i].Format < model.visible[j].Format })
+		sort.SliceStable(model.groups, func(i, j int) bool {
+			return model.groups[i].FileCount > model.groups[j].FileCount
+		})
 	case 2:
-		sort.SliceStable(model.visible, func(i, j int) bool { return model.visible[i].SizeBytes < model.visible[j].SizeBytes })
+		sort.SliceStable(model.groups, func(i, j int) bool {
+			left := rank.PreferredFormatOrder(model.groups[i].BestFormat)
+			right := rank.PreferredFormatOrder(model.groups[j].BestFormat)
+			return left < right
+		})
 	}
-	model.groups = rank.Groups(model.visible)
+	model.restorePreview(preview)
 	model.resultsWindow.clamp(len(model.groups), model.resultPageSize())
 	if len(model.visible) == 0 {
 		if model.screen == screenPreview {
@@ -731,6 +992,58 @@ func (model *Model) refresh() {
 		}
 		model.detailOffset = 0
 	}
+}
+
+func (model Model) capturePreview() previewSnapshot {
+	previewOpen := model.screen == screenPreview || model.screen == screenConfirm && model.returnScreen == screenPreview
+	if !previewOpen || len(model.groups) == 0 {
+		return previewSnapshot{}
+	}
+	group := model.currentGroup()
+	snapshot := previewSnapshot{groupID: group.GroupID, selectedFiles: make(map[string]bool)}
+	for index, result := range group.Files {
+		if model.selectedFiles[index] {
+			snapshot.selectedFiles[provider.ResultIdentity(result)] = true
+		}
+	}
+	if len(group.Files) > 0 {
+		activeIndex := min(len(group.Files)-1, max(0, model.previewWindow.cursor))
+		snapshot.activeFile = provider.ResultIdentity(group.Files[activeIndex])
+	}
+	return snapshot
+}
+
+func (model *Model) restorePreview(snapshot previewSnapshot) {
+	if snapshot.groupID == "" {
+		return
+	}
+	groupIndex := -1
+	for index := range model.groups {
+		if model.groups[index].GroupID == snapshot.groupID {
+			groupIndex = index
+			break
+		}
+	}
+	if groupIndex < 0 {
+		model.screen = screenResults
+		model.detailOffset = 0
+		model.previewWindow.home()
+		clear(model.selectedFiles)
+		return
+	}
+
+	model.resultsWindow.cursor = groupIndex
+	model.selectedFiles = make(map[int]bool, len(snapshot.selectedFiles))
+	for index, result := range model.groups[groupIndex].Files {
+		identity := provider.ResultIdentity(result)
+		if snapshot.selectedFiles[identity] {
+			model.selectedFiles[index] = true
+		}
+		if identity == snapshot.activeFile {
+			model.previewWindow.cursor = index
+		}
+	}
+	model.previewWindow.clamp(len(model.groups[groupIndex].Files), model.bodyHeight()-2)
 }
 
 func (model Model) currentGroup() rank.ResultGroup {
@@ -748,6 +1061,35 @@ func (model *Model) selectAllCurrentGroup() {
 	for index := range model.currentGroup().Files {
 		model.selectedFiles[index] = true
 	}
+}
+
+func (model *Model) selectRecommendedCurrentGroup() {
+	model.selectedFiles = make(map[int]bool)
+	selectedStyles := make(map[string]bool)
+	for index, result := range model.currentGroup().Files {
+		style := familyStyleCategory(result)
+		if selectedStyles[style] {
+			continue
+		}
+		selectedStyles[style] = true
+		model.selectedFiles[index] = true
+	}
+}
+
+func familyStyleCategory(result provider.Result) string {
+	tags := rank.ParseFilename(result.Filename)
+	posture := "roman"
+	if tags.Italic {
+		posture = "italic"
+	}
+	if result.Variable || tags.Variable {
+		return "variable\x00" + posture
+	}
+	weight := rank.WeightOf(result)
+	if weight == "" {
+		weight = "regular"
+	}
+	return weight + "\x00" + posture
 }
 
 func (model Model) selectedCount() int {
@@ -794,9 +1136,18 @@ func (model Model) previewContext() string {
 
 func (model Model) familyPreviewBody() string {
 	group := model.currentGroup()
-	available := max(1, model.bodyHeight()-2)
-	lines := []string{truncate(fmt.Sprintf("  %s  %s", titleFamily(group.FamilyName), model.providerTag(group.Source)), model.contentWidth()), ""}
-	lines = append(lines, renderWindow(&model.previewWindow, len(group.Files), available, func(index int, active bool) []string {
+	layout := newPreviewLayout(model.contentWidth())
+	lines := []string{truncate(fmt.Sprintf("  %s  %s", titleFamily(group.FamilyName), model.providerTag(group.Provider)), model.contentWidth()), ""}
+	if !layout.stacked {
+		lines = append(lines, model.previewHeading(layout))
+	}
+	available := max(1, model.bodyHeight()-len(lines))
+	capacity := available
+	compact := layout.stacked && available < 2
+	if layout.stacked {
+		capacity = max(1, available/2)
+	}
+	lines = append(lines, renderWindow(&model.previewWindow, len(group.Files), capacity, func(index int, active bool) []string {
 		result := group.Files[index]
 		check := "[ ]"
 		if model.selectedFiles[index] {
@@ -806,12 +1157,10 @@ func (model Model) familyPreviewBody() string {
 		if active {
 			prefix = "> "
 		}
-		line := fmt.Sprintf("%s%s %s  %s  %s", prefix, check, result.Filename, model.formatBadge(displayFormat(result)), displayWeight(result.Weight))
-		line = truncate(line, model.contentWidth())
-		if active {
-			line = model.accent.Render(line)
+		if compact {
+			return model.compactPreviewFileRow(prefix, check, result, active)
 		}
-		return []string{line}
+		return model.previewFileRows(layout, prefix, check, result, active)
 	})...)
 	return strings.Join(lines, "\n")
 }
@@ -849,17 +1198,12 @@ func titleFamily(value string) string {
 }
 
 func (model Model) providerTag(source string) string {
-	name := strings.ToLower(source)
-	for _, providerName := range []string{"github", "getfonts", "registry", "websearch", "plugins"} {
-		if strings.Contains(name, providerName) {
-			label := "[" + providerName + "]"
-			if style, ok := model.providerStyles[providerName]; ok {
-				return style.Render(label)
-			}
-			return label
-		}
+	providerName := strings.ToLower(source)
+	label := displayProvider(providerName)
+	if style, ok := model.providerStyles[providerName]; ok {
+		return style.Render(label)
 	}
-	return source
+	return label
 }
 
 func (model Model) formatBadge(format string) string {
@@ -926,7 +1270,7 @@ func (model Model) healthHelp() string {
 }
 
 func (model Model) sortName() string {
-	return []string{"score", "format", "size"}[model.sortMode]
+	return []string{"score", "most files", "preferred format"}[model.sortMode]
 }
 
 func displayWeight(weight string) string {

--- a/internal/tui/results_test.go
+++ b/internal/tui/results_test.go
@@ -36,7 +36,7 @@ func TestModelNavigationFilteringPreviewAndFormatCycle(t *testing.T) {
 		{Filename: "Example-Regular.otf", Format: "otf", Source: "fixture", Score: 2},
 		{Filename: "Example-Bold.ttf", Format: "ttf", Source: "fixture", Score: 1},
 	}, nil, false)
-	if !strings.Contains(model.View(), "Found 2 files in 1 groups") {
+	if !strings.Contains(model.View(), "1 options  2 files") {
 		t.Fatal(model.View())
 	}
 	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'f'}})
@@ -112,7 +112,7 @@ func TestZeroSizedPTYUsesFallbackDimensions(t *testing.T) {
 	t.Parallel()
 	model := sizedModel(t, NewModel([]provider.Result{{Filename: "Fallback.otf", Format: "otf"}}, nil, false), 0, 0)
 	view := model.View()
-	if !strings.Contains(view, "Fallback.otf") || strings.Count(view, "\n") < 5 {
+	if !strings.Contains(view, "Fallback") || strings.Count(view, "\n") < 5 {
 		t.Fatalf("zero-sized PTY collapsed the interface:\n%s", view)
 	}
 }
@@ -130,7 +130,7 @@ func TestResultsKeepChromeVisibleAndScrollSelectionIntoView(t *testing.T) {
 	}
 	view := model.View()
 	assertViewFits(t, view, 80, 12)
-	for _, wanted := range []string{"文字  moji", "Found 20 files in 20 groups", "Font-15.otf", "j/k"} {
+	for _, wanted := range []string{"文字  moji", "20 options  20 files", "Font 15", "j/k"} {
 		if !strings.Contains(view, wanted) {
 			t.Fatalf("%q is not visible after scrolling:\n%s", wanted, view)
 		}
@@ -153,7 +153,7 @@ func TestResultsSupportPageAndBoundaryNavigation(t *testing.T) {
 
 	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyEnd})
 	model = updated.(Model)
-	if model.resultsWindow.cursor != len(results)-1 || !strings.Contains(model.View(), "Font-29.otf") {
+	if model.resultsWindow.cursor != len(results)-1 || !strings.Contains(model.View(), "Font 29") {
 		t.Fatalf("end did not select the last result: cursor=%d\n%s", model.resultsWindow.cursor, model.View())
 	}
 
@@ -161,6 +161,58 @@ func TestResultsSupportPageAndBoundaryNavigation(t *testing.T) {
 	model = updated.(Model)
 	if model.resultsWindow.cursor != 0 {
 		t.Fatalf("home selected result %d", model.resultsWindow.cursor)
+	}
+}
+
+func TestAlternateSortModesReorderFamilyCandidates(t *testing.T) {
+	model := NewModel([]provider.Result{
+		{Filename: "Alpha-Regular.otf", Format: "otf", Weight: "regular", Source: "getfonts.cc/owner/alpha", Provider: "getfonts"},
+		{Filename: "Beta-Regular.woff2", Format: "woff2", Weight: "regular", Source: "github.com/owner/beta", Provider: "github"},
+		{Filename: "Beta-Bold.woff2", Format: "woff2", Weight: "bold", Source: "github.com/owner/beta", Provider: "github"},
+		{Filename: "Beta-Italic.woff2", Format: "woff2", Weight: "regular", Source: "github.com/owner/beta", Provider: "github"},
+	}, nil, false)
+
+	model.sortMode = 1
+	model.refresh()
+	if model.groups[0].FileCount != 3 {
+		t.Fatalf("most-files order starts with %d files", model.groups[0].FileCount)
+	}
+
+	model.sortMode = 2
+	model.refresh()
+	if model.groups[0].BestFormat != "otf" {
+		t.Fatalf("preferred-format order starts with %q", model.groups[0].BestFormat)
+	}
+}
+
+func TestPreferredFormatOrderCoversEveryAcceptedFormat(t *testing.T) {
+	formats := []string{"otf", "ttf", "dfont", "pfb", "woff2", "woff", "pfm"}
+	results := make([]provider.Result, 0, len(formats))
+	for index := len(formats) - 1; index >= 0; index-- {
+		format := formats[index]
+		results = append(results, provider.Result{
+			Filename: fmt.Sprintf("Family%d.%s", index, format), Format: format,
+			Source: fmt.Sprintf("fixture/%d", index), Provider: "fixture",
+		})
+	}
+	model := NewModel(results, nil, false)
+	model.sortMode = 2
+	model.refresh()
+	for index, format := range formats {
+		if model.groups[index].BestFormat != format {
+			t.Fatalf("preferred format %d = %q, want %q", index, model.groups[index].BestFormat, format)
+		}
+	}
+}
+
+func TestFilterMatchesDisplayedProvider(t *testing.T) {
+	model := NewModel([]provider.Result{{
+		Filename: "Example-Regular.otf", Format: "otf", Source: "fontsource.org", Provider: "registry",
+	}}, nil, false)
+	model.filter = "registry"
+	model.refresh()
+	if len(model.visible) != 1 || !strings.Contains(model.View(), "[registry]") {
+		t.Fatalf("provider filter hid the visibly matching candidate:\n%s", model.View())
 	}
 }
 
@@ -301,6 +353,27 @@ func TestRefreshClosesDetailsWhenSelectedResultDisappears(t *testing.T) {
 	}
 }
 
+func TestRefreshClosesPreviewWhenItsGroupDisappearsButOthersRemain(t *testing.T) {
+	model := NewModel([]provider.Result{
+		{Filename: "Alpha-Regular.otf", Format: "otf", Source: "fixture/alpha"},
+		{Filename: "Alpha-Bold.otf", Format: "otf", Source: "fixture/alpha"},
+		{Filename: "Beta-Regular.ttf", Format: "ttf", Source: "fixture/beta"},
+		{Filename: "Beta-Bold.ttf", Format: "ttf", Source: "fixture/beta"},
+	}, nil, false)
+	model.resultsWindow.cursor = 1
+	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	if model.currentGroup().FamilyName != "beta" {
+		t.Fatalf("opened %q, want beta", model.currentGroup().FamilyName)
+	}
+
+	model.format = "otf"
+	model.refresh()
+	if model.screen != screenResults || len(model.groups) != 1 || model.groups[0].FamilyName != "alpha" {
+		t.Fatalf("disappeared preview remained open: screen=%v groups=%#v", model.screen, model.groups)
+	}
+}
+
 func TestHomeModelStartsLiveSearchFromTypedQuery(t *testing.T) {
 	t.Parallel()
 
@@ -330,7 +403,7 @@ func TestHomeModelStartsLiveSearchFromTypedQuery(t *testing.T) {
 		updated, command = model.Update(command())
 		model = updated.(Model)
 	}
-	if !strings.Contains(model.View(), "Quicksand-Regular.otf") {
+	if !strings.Contains(model.View(), "Quicksand") {
 		t.Fatalf("search result missing:\n%s", model.View())
 	}
 }
@@ -403,15 +476,372 @@ func TestGroupedResultsOpenSelectableFamilyPreview(t *testing.T) {
 	}
 }
 
-func TestGroupedResultUsesTwoRowsAtNarrowWidths(t *testing.T) {
+func TestFamilyPreviewSelectsOneRankedFilePerStyle(t *testing.T) {
+	results := []provider.Result{
+		{Filename: "Example-Regular.ttf", Format: "ttf", Weight: "regular", Source: "fixture"},
+		{Filename: "Example-Regular.otf", Format: "otf", Weight: "regular", Source: "fixture"},
+		{Filename: "Example-Italic.ttf", Format: "ttf", Weight: "regular", Source: "fixture"},
+		{Filename: "Example-Italic.otf", Format: "otf", Weight: "regular", Source: "fixture"},
+		{Filename: "Example-Bold.ttf", Format: "ttf", Weight: "bold", Source: "fixture"},
+		{Filename: "Example-Bold.otf", Format: "otf", Weight: "bold", Source: "fixture"},
+		{Filename: "Example-BoldItalic.ttf", Format: "ttf", Weight: "bold", Source: "fixture"},
+		{Filename: "Example-BoldItalic.otf", Format: "otf", Weight: "bold", Source: "fixture"},
+		{Filename: "Example[wdth,wght].ttf", Format: "ttf", Variable: true, Source: "fixture"},
+		{Filename: "Example[wdth,wght].otf", Format: "otf", Variable: true, Source: "fixture"},
+		{Filename: "Example-Italic[wdth,wght].ttf", Format: "ttf", Variable: true, Source: "fixture"},
+		{Filename: "Example-Italic[wdth,wght].otf", Format: "otf", Variable: true, Source: "fixture"},
+	}
+	model := NewModel(results, nil, false)
+	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	if model.selectedCount() != 6 || !strings.Contains(model.View(), "6/12 selected") {
+		t.Fatalf("default family selection chose %d files, want one per style:\n%s", model.selectedCount(), model.View())
+	}
+	for index, result := range model.currentGroup().Files {
+		if model.selectedFiles[index] && result.Format != "otf" {
+			t.Fatalf("selected lower-ranked duplicate %q", result.Filename)
+		}
+	}
+
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'a'}})
+	model = updated.(Model)
+	if model.selectedCount() != len(results) {
+		t.Fatalf("select all chose %d/%d files", model.selectedCount(), len(results))
+	}
+}
+
+func TestLiveResultsKeepTheOpenedFamilyAndSelectionsStable(t *testing.T) {
+	var downloaded []string
+	model := NewModel([]provider.Result{
+		{Filename: "Beta-Regular.ttf", Format: "ttf", Weight: "regular", Source: "fixture/beta", URL: "https://example.test/beta-regular.ttf"},
+		{Filename: "Beta-Bold.ttf", Format: "ttf", Weight: "bold", Source: "fixture/beta", URL: "https://example.test/beta-bold.ttf"},
+	}, func(result provider.Result) (string, error) {
+		downloaded = append(downloaded, result.Filename)
+		return "/tmp/" + result.Filename, nil
+	}, false)
+	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+
+	for _, result := range []provider.Result{
+		{Filename: "Alpha-Regular.otf", Format: "otf", Weight: "regular", Source: "fixture/alpha", URL: "https://example.test/alpha-regular.otf"},
+		{Filename: "Alpha-Bold.otf", Format: "otf", Weight: "bold", Source: "fixture/alpha", URL: "https://example.test/alpha-bold.otf"},
+	} {
+		updated, _ = model.Update(eventMessage{event: provider.Event{Provider: "fixture", Type: provider.EventResult, Result: result}, open: true})
+		model = updated.(Model)
+	}
+	if model.currentGroup().FamilyName != "beta" || model.selectedCount() != 2 {
+		t.Fatalf("live ranking retargeted preview to %q with %d selected", model.currentGroup().FamilyName, model.selectedCount())
+	}
+	updated, command := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}})
+	model = updated.(Model)
+	if command == nil {
+		t.Fatal("download command is nil")
+	}
+	model.Update(command())
+	if strings.Join(downloaded, ",") != "Beta-Bold.ttf,Beta-Regular.ttf" {
+		t.Fatalf("downloaded retargeted files: %v", downloaded)
+	}
+}
+
+func TestLiveReorderingPreservesManualFileToggles(t *testing.T) {
+	model := NewModel([]provider.Result{
+		{Filename: "Example-Regular.ttf", Format: "ttf", Weight: "regular", Source: "fixture", URL: "https://example.test/regular.ttf"},
+		{Filename: "Example-Bold.ttf", Format: "ttf", Weight: "bold", Source: "fixture", URL: "https://example.test/bold.ttf"},
+	}, nil, false)
+	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	deselected := provider.ResultIdentity(model.currentGroup().Files[model.previewWindow.cursor])
+	updated, _ = model.Update(tea.KeyMsg{Type: tea.KeySpace})
+	model = updated.(Model)
+	selected := make(map[string]bool)
+	for index, result := range model.currentGroup().Files {
+		if model.selectedFiles[index] {
+			selected[provider.ResultIdentity(result)] = true
+		}
+	}
+
+	updated, _ = model.Update(eventMessage{event: provider.Event{Provider: "fixture", Type: provider.EventResult, Result: provider.Result{
+		Filename: "Example-Regular.otf", Format: "otf", Weight: "regular", Source: "fixture", URL: "https://example.test/regular.otf",
+	}}, open: true})
+	model = updated.(Model)
+	for index, result := range model.currentGroup().Files {
+		identity := provider.ResultIdentity(result)
+		if identity == deselected && model.selectedFiles[index] {
+			t.Fatalf("manually deselected %q became selected", result.Filename)
+		}
+		if selected[identity] && !model.selectedFiles[index] {
+			t.Fatalf("selected %q became deselected", result.Filename)
+		}
+	}
+}
+
+func TestLiveResultsCannotRetargetAConfirmedFamilyDownload(t *testing.T) {
+	var downloaded []string
+	model := NewModel([]provider.Result{
+		{Filename: "Beta-Regular.ttf", Format: "ttf", Weight: "regular", Source: "fixture/beta", URL: "https://example.test/beta-regular.ttf"},
+		{Filename: "Beta-Medium.ttf", Format: "ttf", Weight: "medium", Source: "fixture/beta", URL: "https://example.test/beta-medium.ttf"},
+		{Filename: "Beta-Bold.ttf", Format: "ttf", Weight: "bold", Source: "fixture/beta", URL: "https://example.test/beta-bold.ttf"},
+		{Filename: "Beta-Black.ttf", Format: "ttf", Weight: "black", Source: "fixture/beta", URL: "https://example.test/beta-black.ttf"},
+	}, func(result provider.Result) (string, error) {
+		downloaded = append(downloaded, result.Filename)
+		return "/tmp/" + result.Filename, nil
+	}, false)
+	updated, _ := model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	updated, command := model.Update(tea.KeyMsg{Type: tea.KeyRunes, Runes: []rune{'D'}})
+	model = updated.(Model)
+	if model.screen != screenConfirm || command != nil {
+		t.Fatalf("large family did not open confirmation: screen=%v", model.screen)
+	}
+
+	for _, result := range []provider.Result{
+		{Filename: "Alpha-Regular.otf", Format: "otf", Weight: "regular", Source: "fixture/alpha", URL: "https://example.test/alpha-regular.otf"},
+		{Filename: "Alpha-Bold.otf", Format: "otf", Weight: "bold", Source: "fixture/alpha", URL: "https://example.test/alpha-bold.otf"},
+	} {
+		updated, _ = model.Update(eventMessage{event: provider.Event{Provider: "fixture", Type: provider.EventResult, Result: result}, open: true})
+		model = updated.(Model)
+	}
+	updated, command = model.Update(tea.KeyMsg{Type: tea.KeyEnter})
+	model = updated.(Model)
+	if command == nil {
+		t.Fatal("confirmed download command is nil")
+	}
+	model.Update(command())
+	if len(downloaded) != 4 {
+		t.Fatalf("downloaded %d files, want 4 Beta styles: %v", len(downloaded), downloaded)
+	}
+	for _, filename := range downloaded {
+		if !strings.HasPrefix(filename, "Beta-") {
+			t.Fatalf("confirmation downloaded unreviewed file %q", filename)
+		}
+	}
+}
+
+func TestGroupedResultUsesTheResponsiveRowShape(t *testing.T) {
 	model := NewModel([]provider.Result{
 		{Filename: "Example-Regular.otf", Format: "otf", Source: "github"},
 		{Filename: "Example-Bold.otf", Format: "otf", Source: "github"},
 	}, nil, false)
-	model = sizedModel(t, model, 60, 20)
-	rows := model.groupRow(model.groups[0], true)
-	if len(rows) != 2 || !strings.Contains(rows[0], "Example") || !strings.Contains(rows[1], "2 files") {
-		t.Fatalf("narrow group rows = %#v", rows)
+	for _, test := range []struct {
+		width, wantRows int
+	}{{24, 2}, {40, 2}, {60, 1}, {80, 1}, {120, 1}} {
+		model := sizedModel(t, model, test.width, 20)
+		rows := model.groupRow(model.groups[0], true)
+		if len(rows) != test.wantRows || !strings.Contains(rows[0], "Example") {
+			t.Fatalf("%d-column group rows = %#v, want %d", test.width, rows, test.wantRows)
+		}
+	}
+}
+
+func TestStackedCandidateMetadataUsesFixedColumns(t *testing.T) {
+	model := NewModel([]provider.Result{
+		{Filename: "Alpha-Regular.otf", Format: "otf", Source: "github.com/owner/alpha", Provider: "github"},
+		{Filename: "Beta-Regular.woff2", Format: "woff2", Source: "github.com/owner/beta", Provider: "github"},
+	}, nil, false)
+	model = sizedModel(t, model, 40, 16)
+	view := model.View()
+	var providerColumns []int
+	for _, line := range strings.Split(view, "\n") {
+		if column := strings.Index(line, "[github]"); column >= 0 && !strings.Contains(line, "Best") {
+			providerColumns = append(providerColumns, column)
+		}
+	}
+	if len(providerColumns) != 2 || providerColumns[0] != providerColumns[1] {
+		t.Fatalf("stacked provider columns = %v, want two aligned columns:\n%s", providerColumns, view)
+	}
+}
+
+func TestResultGridShowsOnlyAlignedFamilyCandidates(t *testing.T) {
+	model := NewModel([]provider.Result{
+		{Filename: "GaramondPremierPro-Regular.ttf", Format: "ttf", Source: "github.com/owner/family", Provider: "github", Score: 12.3},
+		{Filename: "GaramondPremierPro-Bold.ttf", Format: "ttf", Source: "github.com/owner/family", Provider: "github", Score: 12.3},
+		{Filename: "GaramondPremierProCaption.otf", Format: "otf", Source: "getfonts.cc/archive/fonts", Provider: "getfonts", Score: 9.2},
+	}, nil, false)
+	model.query = "Garamond Premier Pro"
+	model = sizedModel(t, model, 120, 20)
+	view := model.View()
+	assertViewFits(t, view, 120, 20)
+
+	for _, wanted := range []string{"Query", "Garamond Premier Pro", "Recommended", "Family", "Files", "Format", "Provider", "[github]", "[getfonts]"} {
+		if !strings.Contains(view, wanted) {
+			t.Fatalf("results grid is missing %q:\n%s", wanted, view)
+		}
+	}
+	for _, unwanted := range []string{"Family / file", "> +", "  -", "GaramondPremierProCaption.otf", "owner/family", "archive/fonts", "Score"} {
+		if strings.Contains(view, unwanted) {
+			t.Fatalf("results grid still exposes %q:\n%s", unwanted, view)
+		}
+	}
+
+	lines := strings.Split(view, "\n")
+	var heading string
+	var candidates []string
+	for _, line := range lines {
+		switch {
+		case strings.Contains(line, "Family") && strings.Contains(line, "Provider"):
+			heading = line
+		case strings.Contains(line, "[github]"), strings.Contains(line, "[getfonts]"):
+			if !strings.Contains(line, "Recommended") {
+				candidates = append(candidates, line)
+			}
+		}
+	}
+	if len(candidates) != 2 {
+		t.Fatalf("candidate rows = %d, want 2:\n%s", len(candidates), view)
+	}
+	for _, column := range []string{"Format", "Provider"} {
+		position := strings.Index(heading, column)
+		for _, candidate := range candidates {
+			if position < 0 || position >= len(candidate) || candidate[position] == ' ' {
+				t.Fatalf("column %q was not rendered consistently:\n%s", column, view)
+			}
+		}
+	}
+}
+
+func TestFamilyPreviewUsesAlignedFileColumns(t *testing.T) {
+	model := NewModel([]provider.Result{
+		{Filename: "Example-Regular.otf", Format: "otf", Weight: "regular", Source: "github.com/owner/fonts", Provider: "github"},
+		{Filename: "Example-ExtraBoldItalic.woff2", Format: "woff2", Weight: "bold", Source: "github.com/owner/fonts", Provider: "github"},
+	}, nil, false)
+	model.screen = screenPreview
+	model.selectAllCurrentGroup()
+	model = sizedModel(t, model, 80, 18)
+	view := model.View()
+	assertViewFits(t, view, 80, 18)
+
+	lines := strings.Split(view, "\n")
+	var heading string
+	var files []string
+	for _, line := range lines {
+		switch {
+		case strings.Contains(line, "File") && strings.Contains(line, "Weight"):
+			heading = line
+		case strings.Contains(line, "Example-"):
+			files = append(files, line)
+		}
+	}
+	if len(files) != 2 {
+		t.Fatalf("preview rows = %d, want 2:\n%s", len(files), view)
+	}
+	for _, column := range []string{"Format", "Weight"} {
+		position := strings.Index(heading, column)
+		for _, file := range files {
+			if position < 0 || position >= len(file) || file[position] == ' ' {
+				t.Fatalf("preview column %q is misaligned:\n%s", column, view)
+			}
+		}
+	}
+}
+
+func TestVeryShortFamilyPreviewKeepsFileMetadata(t *testing.T) {
+	model := NewModel([]provider.Result{
+		{Filename: "GaramondPremierPro-Regular.otf", Format: "otf", Weight: "regular", Source: "fixture", Provider: "fixture"},
+		{Filename: "GaramondPremierPro-Roman.otf", Format: "otf", Weight: "regular", Source: "fixture", Provider: "fixture"},
+	}, nil, false)
+	model.screen = screenPreview
+	model.selectAllCurrentGroup()
+	model = sizedModel(t, model, 24, 7)
+	view := model.View()
+	assertViewFits(t, view, 24, 7)
+	for _, wanted := range []string{"Gar...", "OTF", "regular"} {
+		if !strings.Contains(view, wanted) {
+			t.Fatalf("short preview lost %q:\n%s", wanted, view)
+		}
+	}
+}
+
+func TestResultsHierarchyHidesSettledProviderNoise(t *testing.T) {
+	model := NewModel([]provider.Result{{Filename: "GaramondPremierPro.otf", Format: "otf", Source: "github.com/owner/fonts"}}, nil, false)
+	model.query = "Garamond Premier Pro"
+	model.providerStatus["github"] = "done (214 results)"
+	model.providerStatus["registry"] = "done (0 results)"
+	model = sizedModel(t, model, 80, 16)
+
+	view := model.View()
+	for _, unwanted := range []string{"done (214 results)", "done (0 results)", "format:all", "sort:score"} {
+		if strings.Contains(view, unwanted) {
+			t.Fatalf("settled results contain %q:\n%s", unwanted, view)
+		}
+	}
+	for _, wanted := range []string{"Query", "Garamond Premier Pro", "Format All", "Order Best match", "Recommended", "1/1"} {
+		if !strings.Contains(view, wanted) {
+			t.Fatalf("results hierarchy is missing %q:\n%s", wanted, view)
+		}
+	}
+
+	model.screen = screenHealth
+	if health := model.View(); !strings.Contains(health, "done (214 results)") || !strings.Contains(health, "done (0 results)") {
+		t.Fatalf("provider details disappeared from Health:\n%s", health)
+	}
+}
+
+func TestResultsLoadingAndProviderAttentionStayConcise(t *testing.T) {
+	model := NewModel([]provider.Result{{Filename: "Example.otf", Format: "otf"}}, nil, false)
+	model.loading = true
+	model.providerStatus["github"] = "searching"
+	model.providerStatus["getfonts"] = "done (2 results)"
+	model.providerStates["github"] = provider.StateSearching
+	model.providerStates["getfonts"] = provider.StateDone
+	model = sizedModel(t, model, 80, 16)
+	if view := model.View(); !strings.Contains(view, "Searching providers") || strings.Contains(view, "getfonts: done") {
+		t.Fatalf("loading progress is not concise:\n%s", view)
+	}
+	if view := model.View(); strings.Contains(view, "Recommended") || !strings.Contains(view, "Best so far") {
+		t.Fatalf("loading results were presented as a settled recommendation:\n%s", view)
+	}
+	model.providerStates["github"] = provider.StateFailed
+	model.providerStates["getfonts"] = provider.StateSearching
+	if view := model.View(); !strings.Contains(view, "1/2 finished") {
+		t.Fatalf("terminal provider failures were not counted as finished:\n%s", view)
+	}
+	compact := sizedModel(t, model, 24, 8)
+	if view := compact.View(); !strings.Contains(view, "Example") || !strings.Contains(view, "OTF") {
+		t.Fatalf("compact loading chrome displaced the two-line result:\n%s", view)
+	}
+
+	model.loading = false
+	model.providerStatus["github"] = "rate limited"
+	model.providerStates["github"] = provider.StateThrottled
+	if view := model.View(); !strings.Contains(view, "provider needs attention") || strings.Contains(view, "github: rate limited") {
+		t.Fatalf("provider attention is not summarized:\n%s", view)
+	}
+}
+
+func TestProviderDisplayNeverIncludesOrigin(t *testing.T) {
+	model := NewModel([]provider.Result{
+		{Filename: "Example-Regular.otf", Format: "otf", Source: "github.com/owner/private-fonts", Provider: "github"},
+		{Filename: "Example-Bold.otf", Format: "otf", Source: "github.com/owner/private-fonts", Provider: "github"},
+	}, nil, false)
+	model = sizedModel(t, model, 80, 16)
+	view := model.View()
+	if !strings.Contains(view, "[github]") || strings.Contains(view, "owner/private-fonts") || strings.Contains(view, "github.com") {
+		t.Fatalf("provider display leaked source provenance:\n%s", view)
+	}
+}
+
+func TestResultRowsAndFooterFillTheCenteredColumn(t *testing.T) {
+	model := NewModel([]provider.Result{
+		{Filename: "Example-Regular.otf", Format: "otf", Source: "github.com/owner/fonts"},
+		{Filename: "Example-Bold.otf", Format: "otf", Source: "github.com/owner/fonts"},
+	}, nil, false)
+	for _, size := range []struct{ width, height, content int }{
+		{24, 8, 24}, {40, 12, 36}, {60, 16, 56}, {80, 20, 72}, {120, 24, 112}, {154, 30, 118},
+	} {
+		model := sizedModel(t, model, size.width, size.height)
+		if model.contentWidth() != size.content {
+			t.Fatalf("%d columns produced content width %d, want %d", size.width, model.contentWidth(), size.content)
+		}
+		rows := model.groupRow(model.groups[0], true)
+		for _, row := range rows {
+			if got := lipgloss.Width(row); got != model.contentWidth() {
+				t.Fatalf("selected row is %d cells, want %d at terminal width %d: %q", got, model.contentWidth(), size.width, row)
+			}
+		}
+		footer := strings.Split(model.resultsHelp(), "\n")[0]
+		if got := lipgloss.Width(footer); got != model.contentWidth() || !strings.Contains(footer, "1/1") {
+			t.Fatalf("footer at %d columns = %q (%d cells)", size.width, footer, got)
+		}
 	}
 }
 
@@ -419,7 +849,7 @@ func TestVeryNarrowChromePrioritizesContext(t *testing.T) {
 	model := sizedModel(t, NewModel([]provider.Result{{Filename: "Example.otf", Format: "otf"}}, nil, false), 24, 8)
 	view := model.View()
 	assertViewFits(t, view, 24, 8)
-	if !strings.Contains(view, "moji  1 groups") || strings.Contains(view, "文字") {
+	if !strings.Contains(view, "moji  results") || strings.Contains(view, "文字") {
 		t.Fatalf("narrow header did not prioritize context:\n%s", view)
 	}
 }
@@ -466,11 +896,35 @@ func TestResultsReserveAVisibleRowForStatus(t *testing.T) {
 	model.status = "Downloaded: /tmp/Font-15.otf"
 
 	view := model.View()
-	if !strings.Contains(view, "> Font-15.otf") {
+	if !strings.Contains(view, "> Font 15") {
 		t.Fatalf("selected result disappeared behind status:\n%s", view)
 	}
 	if !strings.Contains(view, model.status) {
 		t.Fatalf("status missing from view:\n%s", view)
+	}
+}
+
+func TestCompactResultsKeepCompleteMetadataBesideStatus(t *testing.T) {
+	model := NewModel([]provider.Result{
+		{Filename: "Example-Regular.otf", Format: "otf", Source: "fixture"},
+		{Filename: "Example-Bold.otf", Format: "otf", Source: "fixture"},
+	}, nil, false)
+	model.status = "Downloaded: /tmp/Example-Regular.otf"
+	model = sizedModel(t, model, 24, 8)
+
+	view := model.View()
+	assertViewFits(t, view, 24, 8)
+	for _, wanted := range []string{"Example", "OTF", "Downloaded"} {
+		if !strings.Contains(view, wanted) {
+			t.Fatalf("compact status view lost %q:\n%s", wanted, view)
+		}
+	}
+
+	minimal := sizedModel(t, model, 24, 7)
+	minimalView := minimal.View()
+	assertViewFits(t, minimalView, 24, 7)
+	if !strings.Contains(minimalView, "Example") || !strings.Contains(minimalView, "Downloaded") {
+		t.Fatalf("one-line compact fallback lost the result or status:\n%s", minimalView)
 	}
 }
 
@@ -487,8 +941,12 @@ func TestLiveModelStreamsProviderEvents(t *testing.T) {
 		model = updated.(Model)
 		command = next
 	}
-	if model.loading || len(model.visible) != 1 || !strings.Contains(model.View(), "fixture: done (1 results)") {
+	if model.loading || len(model.visible) != 1 || !strings.Contains(model.View(), "Live") {
 		t.Fatalf("live model did not settle: %s", model.View())
+	}
+	model.screen = screenHealth
+	if !strings.Contains(model.View(), "done (1 results)") {
+		t.Fatalf("settled provider state is missing from Health: %s", model.View())
 	}
 }
 


### PR DESCRIPTION
**What changed**

- Reuse an authenticated GitHub CLI session when no explicit token is configured, without starting login or persisting the token.
- Replace mixed family and file rows with a responsive family-candidate grid.
- Separate provider identity from repository provenance.
- Add best-match, most-files, and preferred-format ordering.
- Select one ranked file per weight and posture category when opening a family.
- Preserve the reviewed family and manual selections while live results reorder.
- Improve narrow-terminal layouts, family previews, status hierarchy, and keyboard guidance.

**Why**

GitHub authentication ignored existing `gh` sessions, while the results interface mixed singleton files and family groups using incompatible layouts. Family previews also selected every duplicate format and relied on numeric indexes that could become unsafe when streamed results reordered.

**Impact**

Interactive searches now provide clearer download choices and cleaner full-family selections. Explicit GitHub tokens retain precedence, and non-interactive output remains compatible.

**Verification**

- 201 Go tests passed.
- 157 race-enabled tests passed.
- End-to-end TUI test rerun without cache.
- `go vet` passed.
- Documentation checks and production build passed.
- Garamond Premier Pro inspected at multiple terminal sizes.
- Independent review completed with all findings resolved.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves GitHub authentication and reshapes the interactive results experience. The main changes are:

- Reuses an existing authenticated GitHub CLI session when no explicit token is configured.
- Separates provider identity from repository/source provenance in result handling.
- Presents TUI results as ranked family candidates with responsive grid layouts.
- Adds best-match, most-files, and preferred-format ordering.
- Preserves opened families and manual file selections while live results reorder.
- Updates documentation and tests for the new auth, ranking, preview, and keyboard behavior.

<h3>Confidence Score: 5/5</h3>

Safe to merge with minimal risk.

The changed paths are well-scoped around authentication resolution, result grouping, and TUI state/layout behavior, with targeted tests for the new flows.

No files require special attention.

<details><summary><h3><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="20" align="absmiddle"></a> T-Rex Logs</h3></summary>

**What T-Rex did**
- A no-cache focused test run completed successfully, as shown in the before-log artifact.
- The TUI was captured in wide layout to verify rendering of the full family results grid and preview columns.
- The TUI was captured in narrow layout to verify responsive metadata stacking and shortened keyboard guidance.

<a href="https://app.greptile.com/trex/runs/14153369/artifacts"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifactsDark.svg?v=4"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"><img alt="View all artifacts" src="https://greptile-static-assets.s3.amazonaws.com/badges/ViewAllArtifacts.svg?v=4"></picture></a>

<sub><a href="https://www.greptile.com/trex"><img alt="T-Rex" src="https://greptile-static-assets.s3.amazonaws.com/trex/trex_green.svg" height="14" align="absmiddle"></a> Ran code and verified through T-Rex</sub>
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| internal/app/search.go | Implements guarded `gh auth token --hostname github.com` fallback and updates the home hint. |
| internal/app/app.go | Resolves GitHub CLI fallback tokens before home and search flows. |
| internal/aggregator/aggregator.go | Stamps streamed result payloads with the provider name before forwarding events. |
| internal/provider/provider.go | Adds internal provider identity to results and exposes stable result identity for TUI state restoration. |
| internal/rank/rank.go | Extends result groups with IDs/provider metadata and preferred-format ordering. |
| internal/tui/results.go | Reworks results into a responsive family-candidate grid with stable preview selections and provider health summaries. |
| internal/tui/results_test.go | Adds broad coverage for responsive layouts, ordering, provider display, and live preview preservation. |
| docs/content/docs/how-to/github-authentication.mdx | Adds guidance for reusing an existing `gh auth token` session without persisting it. |
| docs/content/docs/reference/cli.mdx | Updates CLI/TUI reference for candidate grid, preview selection, ordering, and key bindings. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
participant User
participant App as internal/app
participant GH as GitHub CLI
participant Agg as Aggregator
participant Provider
participant TUI as Results TUI

User->>App: Run search/home with config
App->>App: Check explicit token/provider selection
alt no explicit token and default GitHub.com selected
    App->>GH: gh auth token --hostname github.com
    GH-->>App: existing session token
end
App->>Agg: searchEvents(query, formats)
Agg->>Provider: Search
Provider-->>Agg: result/status events
Agg->>Agg: stamp Result.Provider
Agg-->>TUI: streamed provider events
TUI->>TUI: rank, group by family/source, preserve preview IDs
TUI-->>User: family-candidate grid and preview selection
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
participant User
participant App as internal/app
participant GH as GitHub CLI
participant Agg as Aggregator
participant Provider
participant TUI as Results TUI

User->>App: Run search/home with config
App->>App: Check explicit token/provider selection
alt no explicit token and default GitHub.com selected
    App->>GH: gh auth token --hostname github.com
    GH-->>App: existing session token
end
App->>Agg: searchEvents(query, formats)
Agg->>Provider: Search
Provider-->>Agg: result/status events
Agg->>Agg: stamp Result.Provider
Agg-->>TUI: streamed provider events
TUI->>TUI: rank, group by family/source, preserve preview IDs
TUI-->>User: family-candidate grid and preview selection
```

</a>

<sub>Reviews (2): Last reviewed commit: ["feat(tui): redesign results around ranke..."](https://github.com/microck/moji/commit/062e0471d7a85a26f66e4d213a47e9d056400cdd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43641269)</sub>

<!-- /greptile_comment -->